### PR TITLE
Hide back link for non-JS users

### DIFF
--- a/server/views/layout.html
+++ b/server/views/layout.html
@@ -40,6 +40,11 @@
     html: 'This is a new service – your <a class="govuk-link" href="/feedback">feedback</a> will help us to improve it.'
   }) }}
 
+  <!-- Hide the back link if Javascript is not available -->
+  <noscript>
+    <style>#back-link {display: none} </style>
+  </noscript>
+
   {{ govukBackLink({
       text: "Back",
       href: "#",


### PR DESCRIPTION
Some users might not have JavaScript enabled, hence for these users the back link must be hidden.