### PR TITLE
Session-specific Redis storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ SERVICE_NAME='Tell us you want to sell or hire out ivory'
 REDIS_HOST='127.0.0.1'
 REDIS_PORT=6379
 
+# The configuration for Session tracking
+COOKIE_VALIDATION_PASSWORD=password
+
 # The configuration for the ivory api
 SERVICE_API_ENABLED=false
 #SERVICE_API_HOST=

--- a/README.md
+++ b/README.md
@@ -1,27 +1,28 @@
 # Ivory Project
+
 Digital service to support the Ivory Act.
 
 # Environment variables
+
 The default values will be used if the environment variables are missing or commented out.
 
-| name                | description              | required | default   |            valid            | notes |
-|---------------------|--------------------------|:--------:|-----------|:---------------------------:|-------|
-| NODE_ENV            | Node environment         |    no    |           | development,test,production |       |
-| PORT                | Port number              |    no    | 3000      |                             |       |
-| SERVICE_NAME        | Name of the service      |    no    |           | Any text string             |       |
-| REDIS_HOST          | Redis server IP address  |    no    | 127.0.0.1 |                             |       |
-| REDIS_PORT          | Redis port number        |    no    | 6379      |                             |       |
-| SERVICE_API_ENABLED | Enable/disable ivory API |    yes   | false     | true,false                  |       |
-| SERVICE_API_HOST    | Ivory API IP address     |    no    | 127.0.0.1 |                             |       |
-| SERVICE_API_PORT    | Ivory API port number    |    no    | 3010      |                             |       |
-
+| name                       | description              | required | default   |            valid            | notes |
+| -------------------------- | ------------------------ | :------: | --------- | :-------------------------: | ----- |
+| NODE_ENV                   | Node environment         |    no    |           | development,test,production |       |
+| PORT                       | Port number              |    no    | 3000      |                             |       |
+| SERVICE_NAME               | Name of the service      |    no    |           |       Any text string       |       |
+| COOKIE_VALIDATION_PASSWORD | Cookie encoding password |   yes    |           |       Any text string       |       |
+| REDIS_HOST                 | Redis server IP address  |    no    | 127.0.0.1 |                             |       |
+| REDIS_PORT                 | Redis port number        |    no    | 6379      |                             |       |
+| SERVICE_API_ENABLED        | Enable/disable ivory API |   yes    | false     |         true,false          |       |
+| SERVICE_API_HOST           | Ivory API IP address     |    no    | 127.0.0.1 |                             |       |
+| SERVICE_API_PORT           | Ivory API port number    |    no    | 3010      |                             |       |
 
 # Prerequisites
 
 Node v14.x
 
 Redis
-
 
 # Running the application
 
@@ -38,26 +39,28 @@ Now the application is ready to run:
 `$ npm start` or `$ node index.js`
 
 ### To run the application in Docker
+
 `$ npm run docker` or `$ npm run docker:build` followed by `$ npm run docker:run`
 
 ## Project structure
 
 Here's the default structure for your project files.
 
-* **bin** (build tasks)
-* **client** (client js/sass code)
-* **server**
-  * **plugins**
-  * **public**  (This folder is publicly served)
-    * **static** (Put all static assets in here)
-    * **build** (This contains the build output files (js/css etc.) and is not checked-in)
-  * **routes**
-  * **views**
-  * config.js
-  * index.js (Exports a function that creates a server)
-* **test**
-* README.md
-* index.js (startup server)
+- **bin** (build tasks)
+- **client** (client js/sass code)
+- **server**
+  - **plugins**
+  - **public** (This folder is publicly served)
+    - **static** (Put all static assets in here)
+    - **build** (This contains the build output files (js/css etc.) and is not checked-in)
+  - **routes**
+  - **services**
+  - **views**
+  - config.js
+  - index.js (Exports a function that creates a server)
+- **test**
+- README.md
+- index.js (startup server)
 
 ## Config
 
@@ -96,7 +99,7 @@ Any build output should write to `server/public/build`. This path is in the `.gi
 
 ## Routes
 
-Incoming requests are handled by the server via routes. 
+Incoming requests are handled by the server via routes.
 Each route describes an HTTP endpoint with a path, method, and other properties.
 
 Routes are found in the `server/routes` directory and loaded using the `server/plugins/router.js` plugin.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3621,6 +3621,13 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "require-directory": {
@@ -4536,9 +4543,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "hapi-sanitize-payload": "^2.0.0",
     "joi": "^17.4.0",
     "node-sass": "^5.0.0",
-    "nunjucks": "3.2.3"
+    "nunjucks": "3.2.3",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@hapi/code": "^8.0.3",

--- a/server/index.js
+++ b/server/index.js
@@ -5,7 +5,7 @@ const config = require('./utils/config')
 const cookieConfig = require('./utils/cookieConfig')
 const { DEFRA_IVORY_SESSION_KEY } = require('./utils/constants')
 
-async function createServer () {
+const createServer = async () => {
   const server = hapi.server({
     port: config.port,
     routes: {
@@ -17,9 +17,9 @@ async function createServer () {
     }
   })
 
-  _registerPlugins()
+  _registerPlugins(server)
 
-  _createSessionCookie()
+  _createSessionCookie(server)
 
   return server
 }

--- a/server/index.js
+++ b/server/index.js
@@ -2,6 +2,8 @@
 
 const hapi = require('@hapi/hapi')
 const config = require('./utils/config')
+const cookieConfig = require('./utils/cookieConfig')
+const { DEFRA_IVORY_SESSION_KEY } = require('./utils/constants')
 
 async function createServer () {
   // Create the hapi server
@@ -27,6 +29,9 @@ async function createServer () {
   await server.register(require('./plugins/robots.plugin'))
   await server.register(require('./plugins/router.plugin'))
   await server.register(require('./plugins/views.plugin'))
+
+  // Create a session cookie in which to store a waste permit application token
+  server.state(DEFRA_IVORY_SESSION_KEY, cookieConfig.options)
 
   return server
 }

--- a/server/index.js
+++ b/server/index.js
@@ -6,7 +6,6 @@ const cookieConfig = require('./utils/cookieConfig')
 const { DEFRA_IVORY_SESSION_KEY } = require('./utils/constants')
 
 async function createServer () {
-  // Create the hapi server
   const server = hapi.server({
     port: config.port,
     routes: {
@@ -18,7 +17,14 @@ async function createServer () {
     }
   })
 
-  // Register the plugins
+  _registerPlugins()
+
+  _createSessionCookie()
+
+  return server
+}
+
+const _registerPlugins = async server => {
   await server.register(require('./plugins/blipp.plugin'))
   await server.register(require('./plugins/disinfect.plugin'))
   await server.register(require('./plugins/error-pages.plugin'))
@@ -29,11 +35,10 @@ async function createServer () {
   await server.register(require('./plugins/robots.plugin'))
   await server.register(require('./plugins/router.plugin'))
   await server.register(require('./plugins/views.plugin'))
+}
 
-  // Create a session cookie in which to store a waste permit application token
+const _createSessionCookie = server => {
   server.state(DEFRA_IVORY_SESSION_KEY, cookieConfig.options)
-
-  return server
 }
 
 module.exports = createServer

--- a/server/plugins/logging.plugin.js
+++ b/server/plugins/logging.plugin.js
@@ -7,6 +7,9 @@ module.exports = {
   options: {
     logPayload: true,
     prettyPrint: config.isDev,
-    level: config.isDev ? 'debug' : 'warn'
+    level: 'warn'
+
+    // TODO reinstate this
+    // level: config.isDev ? 'debug' : 'warn'
   }
 }

--- a/server/plugins/logging.plugin.js
+++ b/server/plugins/logging.plugin.js
@@ -7,9 +7,6 @@ module.exports = {
   options: {
     logPayload: true,
     prettyPrint: config.isDev,
-    level: 'warn'
-
-    // TODO reinstate this
-    // level: config.isDev ? 'debug' : 'warn'
+    level: config.isDev ? 'debug' : 'warn'
   }
 }

--- a/server/routes/check-your-answers.route.js
+++ b/server/routes/check-your-answers.route.js
@@ -6,7 +6,7 @@ const { Paths, RedisKeys, Views } = require('../utils/constants')
 const handlers = {
   get: async (request, h) => {
     return h.view(Views.CHECK_YOUR_ANSWERS, {
-      ivoryIntegral: await RedisService.get(request, RedisKeys.IVORY_INTEGRTAL),
+      ivoryIntegral: await RedisService.get(request, RedisKeys.IVORY_INTEGRAL),
       ivoryAdded: await RedisService.get(request, RedisKeys.IVORY_ADDED),
       errorSummaryText: '',
       errorText: false
@@ -19,7 +19,7 @@ const handlers = {
       return h.view(Views.CHECK_YOUR_ANSWERS, {
         ivoryIntegral: await RedisService.get(
           request,
-          RedisKeys.IVORY_INTEGRTAL
+          RedisKeys.IVORY_INTEGRAL
         ),
         ivoryAdded: await RedisService.get(request, RedisKeys.IVORY_ADDED),
         errorSummaryText: 'You must agree to the declaration',

--- a/server/routes/check-your-answers.route.js
+++ b/server/routes/check-your-answers.route.js
@@ -1,13 +1,13 @@
 'use strict'
 
-const { Paths, Views } = require('../utils/constants')
+const RedisService = require('../services/redis.service')
+const { Paths, RedisKeys, Views } = require('../utils/constants')
 
 const handlers = {
   get: async (request, h) => {
-    const client = request.redis.client
     return h.view(Views.CHECK_YOUR_ANSWERS, {
-      ivoryIntegral: await client.get('ivory-integral'),
-      ivoryAdded: await client.get('ivory-added'),
+      ivoryIntegral: await RedisService.get(request, RedisKeys.IVORY_INTEGRTAL),
+      ivoryAdded: await RedisService.get(request, RedisKeys.IVORY_ADDED),
       errorSummaryText: '',
       errorText: false
     })
@@ -16,10 +16,12 @@ const handlers = {
   post: async (request, h) => {
     const payload = request.payload
     if (!payload.agree) {
-      const client = request.redis.client
       return h.view(Views.CHECK_YOUR_ANSWERS, {
-        ivoryIntegral: await client.get('ivory-integral'),
-        ivoryAdded: await client.get('ivory-added'),
+        ivoryIntegral: await RedisService.get(
+          request,
+          RedisKeys.IVORY_INTEGRTAL
+        ),
+        ivoryAdded: await RedisService.get(request, RedisKeys.IVORY_ADDED),
         errorSummaryText: 'You must agree to the declaration',
         errorText: {
           text: 'You must agree to the declaration'

--- a/server/routes/home.route.js
+++ b/server/routes/home.route.js
@@ -1,9 +1,13 @@
 'use strict'
 
-const { Views } = require('../utils/constants')
+const { v4: uuidv4 } = require('uuid')
+const { SESSION_ID, Views } = require('../utils/constants')
 
 const handlers = {
   get: (request, h) => {
+    const sessionId = uuidv4()
+    h.state(SESSION_ID, sessionId)
+
     return h.view(Views.HOME, {
       title: 'Hello',
       message: 'Elephants'

--- a/server/routes/home.route.js
+++ b/server/routes/home.route.js
@@ -5,8 +5,7 @@ const { SESSION_ID, Views } = require('../utils/constants')
 
 const handlers = {
   get: (request, h) => {
-    const sessionId = uuidv4()
-    h.state(SESSION_ID, sessionId)
+    _setCookieSessionId(h)
 
     return h.view(Views.HOME, {
       title: 'Hello',
@@ -20,6 +19,10 @@ const handlers = {
       message: 'Elephants'
     })
   }
+}
+
+const _setCookieSessionId = h => {
+  h.state(SESSION_ID, uuidv4())
 }
 
 module.exports = [

--- a/server/routes/ivory-added.route.js
+++ b/server/routes/ivory-added.route.js
@@ -1,13 +1,18 @@
 'use strict'
 
-const { Paths, Views } = require('../utils/constants')
+const RedisService = require('../services/redis.service')
+const { Paths, RedisKeys, Views } = require('../utils/constants')
+
+const title =
+  'Has any replacement ivory been added to the item since it was made?'
+
+const hintText = 'This could have been to repair or restore damaged ivory.'
 
 const handlers = {
   get: (request, h) => {
     return h.view(Views.YES_NO_IDK, {
-      title:
-        'Has any replacement ivory been added to the item since it was made?',
-      hintText: 'This could have been to repair or restore damaged ivory.',
+      title,
+      hintText,
       errorSummaryText: '',
       errorText: false
     })
@@ -16,20 +21,18 @@ const handlers = {
   post: (request, h) => {
     const payload = request.payload
     if (!payload.yesNoIdk) {
+      const errorText =
+        'You must tell us if any ivory has been added to the item since it was made'
       return h.view(Views.YES_NO_IDK, {
-        title:
-          'Has any replacement ivory been added to the item since it was made?',
-        hintText: 'This could have been to repair or restore damaged ivory.',
-        errorSummaryText:
-          'You must tell us if any ivory has been added to the item since it was made',
+        title,
+        hintText,
+        errorSummaryText: errorText,
         errorText: {
-          text:
-            'You must tell us if any ivory has been added to the item since it was made'
+          text: errorText
         }
       })
     } else if (payload.yesNoIdk === 'No') {
-      const client = request.redis.client
-      client.set('ivory-added', 'no')
+      RedisService.set(request, RedisKeys.IVORY_ADDED, 'no')
       return h.redirect(Paths.CHECK_YOUR_ANSWERS)
     } else if (payload.yesNoIdk === 'I dont know') {
       return 'Game over man...game over!'

--- a/server/routes/ivory-integral.route.js
+++ b/server/routes/ivory-integral.route.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { Paths, Views } = require('../utils/constants')
+const RedisService = require('../services/redis.service')
+const { Paths, RedisKeys, Views } = require('../utils/constants')
 
 const handlers = {
   get: (request, h) => {
@@ -13,8 +14,11 @@ const handlers = {
   post: (request, h) => {
     const payload = request.payload
     if (payload.ivoryIsIntegral) {
-      const client = request.redis.client
-      client.set('ivory-integral', payload.ivoryIsIntegral)
+      RedisService.set(
+        request,
+        RedisKeys.IVORY_INTEGRAL,
+        payload.ivoryIsIntegral
+      )
       return h.redirect(Paths.CHECK_YOUR_ANSWERS)
     } else {
       return h.view(Views.IVORY_INTEGRAL, {

--- a/server/routes/taken-from-elephant.route.js
+++ b/server/routes/taken-from-elephant.route.js
@@ -1,12 +1,15 @@
 'use strict'
 
-const { Paths, Views } = require('../utils/constants')
+const RedisService = require('../services/redis.service')
+const { Paths, RedisKeys, Views } = require('../utils/constants')
+
+const title =
+  'Was the replacement ivory taken from the elephant on or after 1 January 1975?'
 
 const handlers = {
   get: (request, h) => {
     return h.view(Views.YES_NO_IDK, {
-      title:
-        'Was the replacement ivory taken from the elephant on or after 1 January 1975?',
+      title,
       hintText: '',
       errorSummaryText: '',
       errorText: false
@@ -17,20 +20,18 @@ const handlers = {
     const payload = request.payload
 
     if (!payload.yesNoIdk) {
+      const errorText =
+        'You must tell us if the replacement ivory was taken from an elephant on or after 1 January 1975'
       return h.view(Views.YES_NO_IDK, {
-        title:
-          'Was the replacement ivory taken from the elephant on or after 1 January 1975?',
+        title,
         hintText: '',
-        errorSummaryText:
-          'You must tell us if the replacement ivory was taken from an elephant on or after 1 January 1975',
+        errorSummaryText: errorText,
         errorText: {
-          text:
-            'You must tell us if the replacement ivory was taken from an elephant on or after 1 January 1975'
+          text: errorText
         }
       })
     } else if (payload.yesNoIdk === 'No') {
-      const client = request.redis.client
-      client.set('ivory-added', 'yes-pre-1975')
+      RedisService.set(request, RedisKeys.IVORY_ADDED, 'yes-pre-1975')
       return h.redirect(Paths.CHECK_YOUR_ANSWERS)
     } else if (payload.yesNoIdk === 'I dont know') {
       return 'Best find out then!'

--- a/server/services/redis.service.js
+++ b/server/services/redis.service.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const { SESSION_ID } = require('../utils/constants')
+const REDIS_TTL_IN_SECONDS = 86400
+
+module.exports = class RedisService {
+  static async get (request, key) {
+    const client = request.redis.client
+    return client.get(`${request.state[SESSION_ID]}.${key}`)
+  }
+
+  static async set (request, key, value) {
+    const client = request.redis.client
+    const keyWithSessionId = `${request.state[SESSION_ID]}.${key}`
+    client.set(keyWithSessionId, value)
+    client.expire(keyWithSessionId, REDIS_TTL_IN_SECONDS)
+  }
+}

--- a/server/utils/config.js
+++ b/server/utils/config.js
@@ -18,7 +18,8 @@ const schema = joi.object().keys({
     .valid(true, false)
     .default(false),
   serviceApiHost: joi.string().default('127.0.0.1'),
-  serviceApiPort: joi.number().default(3010)
+  serviceApiPort: joi.number().default(3010),
+  cookieValidationPassword: joi.string().required()
 })
 
 // Build config
@@ -30,7 +31,8 @@ const config = {
   redisPort: process.env.REDIS_PORT,
   serviceApiEnabled: process.env.SERVICE_API_ENABLED,
   serviceApiHost: process.env.SERVICE_API_HOST,
-  serviceApiPort: process.env.SERVICE_API_PORT
+  serviceApiPort: process.env.SERVICE_API_PORT,
+  cookieValidationPassword: process.env.COOKIE_VALIDATION_PASSWORD
 }
 
 // Validate config

--- a/server/utils/config.js
+++ b/server/utils/config.js
@@ -19,7 +19,7 @@ const schema = joi.object().keys({
     .default(false),
   serviceApiHost: joi.string().default('127.0.0.1'),
   serviceApiPort: joi.number().default(3010),
-  cookieValidationPassword: joi.string().required()
+  cookieValidationPassword: joi.string()
 })
 
 // Build config

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -15,3 +15,11 @@ Constants.Views = {
   TAKEN_FROM_ELEPHANT: 'taken-from-elephant',
   YES_NO_IDK: 'yes-no-idk'
 }
+
+Constants.RedisKeys = {
+  IVORY_ADDED: 'ivory-added',
+  IVORY_INTEGRAL: 'ivory-integral'
+}
+
+Constants.DEFRA_IVORY_SESSION_KEY = 'DefraIvorySession'
+Constants.SESSION_ID = 'sessionId'

--- a/server/utils/cookieConfig.js
+++ b/server/utils/cookieConfig.js
@@ -1,0 +1,19 @@
+/* eslint-disable no-multi-spaces */
+const config = require('./config')
+
+const cookieOptions = {
+  ttl: undefined, // Session lifespan (deleted when browser closed)
+  isSecure: true, // Secure
+  isHttpOnly: true, // and non-secure
+  isSameSite: 'Strict', // Don't attach cookies on cross-site requests, preventing CSRF attacks
+  encoding: 'base64json', // Base 64 JSON encoded
+  sign: {
+    // Sign values assigned to the cookie to ensure they came from the server
+    password: config.cookieValidationPassword
+  },
+  clearInvalid: false, // Remove invalid cookies
+  strictHeader: true, // Don't allow violations of RFC 6265,
+  ignoreErrors: true // Errors are ignored and treated as missing cookies
+}
+
+module.exports = { options: cookieOptions }

--- a/server/views/check-your-answers.html
+++ b/server/views/check-your-answers.html
@@ -73,7 +73,7 @@
         <li>the information you’ve provided is complete and correct</li>
       </ul>
 
-      <form method="post">
+      <form method="post" novalidate="novalidate">
         {{ govukCheckboxes({
           idPrefix: "agree",
           name: "agree",

--- a/server/views/ivory-integral.html
+++ b/server/views/ivory-integral.html
@@ -21,7 +21,7 @@
     {% endif %}
 
     <div class="govuk-grid-column-two-thirds">
-      <form method="post">
+      <form method="post" novalidate="novalidate">
 
         {{ govukRadios({
           idPrefix: "ivoryIsIntegral",

--- a/server/views/yes-no-idk.html
+++ b/server/views/yes-no-idk.html
@@ -21,7 +21,7 @@
     {% endif %}
 
     <div class="govuk-grid-column-two-thirds">
-      <form method="post">
+      <form method="post" novalidate="novalidate">
         {{ govukRadios({
           idPrefix: "yesNoIdk",
           name: "yesNoIdk",


### PR DESCRIPTION
IVORY-306: Make data stored in Redis session-specific

Added creation of a session cookie to the home page.

Generated a unique session ID and added to the session cookie.

Appended session ID to Redis keys using the following format:

sessionId.redisKey

e.g. 91bde99f-c98e-4ff7-8d87-b786b8fb6eb4.ivory-added

Created a RedisService responsible for getting and setting Redis valus and setting expiry (Time To Live / TTL) on values stored Redis. Currently hard-coded to 86400 (i.e. one day in seconds). This could be made a configurable parameter if required.

Also, added novalidate to forms to turn off HTML5 validation as per GDS guidelines.

Submitting draft PR for now, unit tests to follow if the implementation method in this PR is accepted.