### PR TITLE
IVORY-314 bug fix plus added unit tests for Redis service and contact-details route, log level change

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ PORT=3000
 
 SERVICE_NAME='Tell us you want to sell or hire out ivory'
 
+# The log level - set to defaults to "warn", can be set to "debug"
+LOG_LEVEL=warn
+
 # The configuration for Redis
 REDIS_HOST='127.0.0.1'
 REDIS_PORT=6379

--- a/server/plugins/logging.plugin.js
+++ b/server/plugins/logging.plugin.js
@@ -7,6 +7,6 @@ module.exports = {
   options: {
     logPayload: true,
     prettyPrint: config.isDev,
-    level: config.isDev ? 'debug' : 'warn'
+    level: config.logLevel
   }
 }

--- a/server/utils/config.js
+++ b/server/utils/config.js
@@ -11,6 +11,7 @@ const schema = joi.object().keys({
     .default(envs[0]),
   port: joi.number().default(3000),
   serviceName: joi.string().default('No service name in .env'),
+  logLevel: joi.string(),
   redisHost: joi.string().default('127.0.0.1'),
   redisPort: joi.number().default(6379),
   serviceApiEnabled: joi
@@ -27,6 +28,7 @@ const config = {
   env: process.env.NODE_ENV,
   port: process.env.PORT,
   serviceName: process.env.SERVICE_NAME,
+  logLevel: process.env.LOG_LEVEL || 'warn',
   redisHost: process.env.REDIS_HOST,
   redisPort: process.env.REDIS_PORT,
   serviceApiEnabled: process.env.SERVICE_API_ENABLED,

--- a/server/views/user-details/contact-details.html
+++ b/server/views/user-details/contact-details.html
@@ -25,8 +25,10 @@
 
         {{ govukInput({
           label: {
-            text: "Business name (optional)",
-            hintText: "We only need this if your business owns the item"
+            text: "Business name (optional)"
+          },
+          hint: {
+            text: "We only need this if your business owns the item"
           },
           id: "businessName",
           name: "businessName",

--- a/test/routes/owner/contact-details.route.test.js
+++ b/test/routes/owner/contact-details.route.test.js
@@ -1,0 +1,385 @@
+'use strict'
+
+const createServer = require('../../../server')
+
+const TestHelper = require('../../utils/test-helper')
+const { ServerEvents } = require('../../../server/utils/constants')
+
+jest.mock('../../../server/services/redis.service')
+const RedisService = require('../../../server/services/redis.service')
+
+describe('/contact-details route', () => {
+  let server
+  const url = '/user-details/owner/contact-details'
+  const nextUrl = '/check-your-answers'
+  const nextUrlNonOwnerApplicant = '/user-details/applicant/contact-details'
+
+  const elementIds = {
+    pageHeading: 'page-heading',
+    name: 'name',
+    ownerApplicant: {
+      businessName: 'businessName'
+    },
+    emailAddress: 'emailAddress',
+    confirmEmailAddress: 'confirmEmailAddress',
+    continue: 'continue'
+  }
+
+  let document
+
+  beforeAll(async done => {
+    server = await createServer()
+    server.events.on(ServerEvents.PLUGINS_LOADED, () => {
+      done()
+    })
+  })
+
+  afterAll(() => {
+    server.stop()
+  })
+
+  beforeEach(() => {
+    _createMocks()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GET: Owner applicant', () => {
+    const getOptions = {
+      method: 'GET',
+      url
+    }
+
+    beforeEach(async () => {
+      RedisService.get = jest.fn().mockReturnValue('yes')
+
+      document = await TestHelper.submitGetRequest(server, getOptions)
+    })
+
+    it('should have the Beta banner', () => {
+      TestHelper.checkBetaBanner(document)
+    })
+
+    it('should have the Back link', () => {
+      TestHelper.checkBackLink(document)
+    })
+
+    it('should have the correct page title', () => {
+      const element = document.querySelector(`#${elementIds.pageHeading}`)
+      expect(element).toBeTruthy()
+      expect(TestHelper.getTextContent(element)).toEqual('Your contact details')
+    })
+
+    it('should have the "Full name" form field', () => {
+      TestHelper.checkFormField(document, elementIds.name, 'Full name')
+    })
+
+    it('should have the optional "Business name" form field', () => {
+      TestHelper.checkFormField(
+        document,
+        elementIds.ownerApplicant.businessName,
+        'Business name (optional)',
+        'We only need this if your business owns the item'
+      )
+    })
+
+    it('should have the "Email address" form field', () => {
+      TestHelper.checkFormField(
+        document,
+        elementIds.emailAddress,
+        'Email address'
+      )
+    })
+
+    it('should have the "Confirm email address" form field', () => {
+      TestHelper.checkFormField(
+        document,
+        elementIds.confirmEmailAddress,
+        'Confirm email address'
+      )
+    })
+
+    it('should have the correct Call to Action button', () => {
+      const element = document.querySelector(`#${elementIds.continue}`)
+      expect(element).toBeTruthy()
+      expect(TestHelper.getTextContent(element)).toEqual('Continue')
+    })
+  })
+
+  describe('GET: Non-owner applicant', () => {
+    const getOptions = {
+      method: 'GET',
+      url
+    }
+
+    beforeEach(async () => {
+      RedisService.get = jest.fn().mockReturnValue('no')
+
+      document = await TestHelper.submitGetRequest(server, getOptions)
+    })
+
+    it('should have the Beta banner', () => {
+      TestHelper.checkBetaBanner(document)
+    })
+
+    it('should have the Back link', () => {
+      TestHelper.checkBackLink(document)
+    })
+
+    it('should have the correct page title', () => {
+      const element = document.querySelector(`#${elementIds.pageHeading}`)
+      expect(element).toBeTruthy()
+      expect(TestHelper.getTextContent(element)).toEqual(
+        "Owner's contact details"
+      )
+    })
+
+    it('should have the "Full name or business name" form field', () => {
+      TestHelper.checkFormField(
+        document,
+        elementIds.name,
+        'Full name or business name'
+      )
+    })
+
+    it('should have the "Email address" form field', () => {
+      TestHelper.checkFormField(
+        document,
+        elementIds.emailAddress,
+        'Email address'
+      )
+    })
+
+    it('should have the "Confirm email address" form field', () => {
+      TestHelper.checkFormField(
+        document,
+        elementIds.confirmEmailAddress,
+        'Confirm email address'
+      )
+    })
+
+    it('should have the correct Call to Action button', () => {
+      const element = document.querySelector(`#${elementIds.continue}`)
+      expect(element).toBeTruthy()
+      expect(TestHelper.getTextContent(element)).toEqual('Continue')
+    })
+  })
+
+  describe('POST: Owner applicant', () => {
+    let postOptions
+
+    beforeEach(() => {
+      postOptions = {
+        method: 'POST',
+        url,
+        payload: {}
+      }
+    })
+
+    describe('Success: Owner-applicant', () => {
+      beforeEach(() => {
+        RedisService.get = jest.fn().mockReturnValue('yes')
+      })
+
+      it('should store the value in Redis and progress to the next route when all fields have been entered correctly', async () => {
+        postOptions.payload = {
+          name: 'some-value',
+          emailAddress: 'some-email@somewhere.com',
+          confirmEmailAddress: 'some-email@somewhere.com'
+        }
+
+        const response = await TestHelper.submitPostRequest(
+          server,
+          postOptions,
+          302
+        )
+
+        expect(RedisService.set).toBeCalledTimes(4)
+
+        expect(response.headers.location).toEqual(nextUrl)
+      })
+    })
+
+    describe('Success: Non-owner-applicant', () => {
+      beforeEach(() => {
+        RedisService.get = jest.fn().mockReturnValue('no')
+      })
+
+      it('should store the value in Redis and progress to the next route when all fields have been entered correctly', async () => {
+        postOptions.payload = {
+          name: 'some-value',
+          emailAddress: 'some-email@somewhere.com',
+          confirmEmailAddress: 'some-email@somewhere.com'
+        }
+
+        const response = await TestHelper.submitPostRequest(
+          server,
+          postOptions,
+          302
+        )
+
+        expect(RedisService.set).toBeCalledTimes(2)
+
+        expect(response.headers.location).toEqual(nextUrlNonOwnerApplicant)
+      })
+    })
+
+    describe('Failure: Owner-applicant', () => {
+      beforeEach(() => {
+        RedisService.get = jest.fn().mockReturnValue('yes')
+      })
+
+      it('should display a validation error message if the user does not enter the full name', async () => {
+        postOptions.payload = {
+          name: '',
+          emailAddress: 'some-email@somewhere.com',
+          confirmEmailAddress: 'some-email@somewhere.com'
+        }
+        await TestHelper.checkFormFieldValidation(
+          postOptions,
+          server,
+          elementIds.name,
+          'Enter your full name'
+        )
+      })
+
+      it('should display a validation error message if the user does not enter the email address', async () => {
+        postOptions.payload = {
+          name: 'some-value',
+          emailAddress: '',
+          confirmEmailAddress: 'some-email@somewhere.com'
+        }
+        await TestHelper.checkFormFieldValidation(
+          postOptions,
+          server,
+          elementIds.emailAddress,
+          'Enter your email address'
+        )
+      })
+
+      it('should display a validation error message if the user does not enter an email address in a valid format', async () => {
+        postOptions.payload = {
+          name: 'some-value',
+          emailAddress: 'invalid-email@',
+          confirmEmailAddress: 'some-email@somewhere.com'
+        }
+        await TestHelper.checkFormFieldValidation(
+          postOptions,
+          server,
+          elementIds.emailAddress,
+          'Enter an email address in the correct format, like name@example.com'
+        )
+      })
+
+      it('should display a validation error message if the user does not confirm their email address', async () => {
+        postOptions.payload = {
+          name: 'some-value',
+          emailAddress: 'some-email@somewhere.com',
+          confirmEmailAddress: ''
+        }
+        await TestHelper.checkFormFieldValidation(
+          postOptions,
+          server,
+          elementIds.confirmEmailAddress,
+          'You must confirm your email address'
+        )
+      })
+
+      it('should display a validation error message if the email addresses do not match', async () => {
+        postOptions.payload = {
+          name: 'some-value',
+          emailAddress: 'some-email@somewhere.com',
+          confirmEmailAddress: 'some-other-email@somewhere.com'
+        }
+        await TestHelper.checkFormFieldValidation(
+          postOptions,
+          server,
+          elementIds.confirmEmailAddress,
+          'This confirmation does not match your email address'
+        )
+      })
+    })
+
+    describe('Failure: Non-owner-applicant', () => {
+      beforeEach(() => {
+        RedisService.get = jest.fn().mockReturnValue('no')
+      })
+
+      it('should display a validation error message if the user does not enter the full name', async () => {
+        postOptions.payload = {
+          name: '',
+          emailAddress: 'some-email@somewhere.com',
+          confirmEmailAddress: 'some-email@somewhere.com'
+        }
+        await TestHelper.checkFormFieldValidation(
+          postOptions,
+          server,
+          elementIds.name,
+          "Enter the owner's full name or business name"
+        )
+      })
+
+      it('should display a validation error message if the user does not enter the email address', async () => {
+        postOptions.payload = {
+          name: 'some-value',
+          emailAddress: '',
+          confirmEmailAddress: 'some-email@somewhere.com'
+        }
+        await TestHelper.checkFormFieldValidation(
+          postOptions,
+          server,
+          elementIds.emailAddress,
+          "Enter the owner's email address"
+        )
+      })
+
+      it('should display a validation error message if the user does not enter an email address in a valid format', async () => {
+        postOptions.payload = {
+          name: 'some-value',
+          emailAddress: 'invalid-email@',
+          confirmEmailAddress: 'some-email@somewhere.com'
+        }
+        await TestHelper.checkFormFieldValidation(
+          postOptions,
+          server,
+          elementIds.emailAddress,
+          'Enter an email address in the correct format, like name@example.com'
+        )
+      })
+
+      it('should display a validation error message if the user does not confirm their email address', async () => {
+        postOptions.payload = {
+          name: 'some-value',
+          emailAddress: 'some-email@somewhere.com',
+          confirmEmailAddress: ''
+        }
+        await TestHelper.checkFormFieldValidation(
+          postOptions,
+          server,
+          elementIds.confirmEmailAddress,
+          "You must confirm the owner's email address"
+        )
+      })
+
+      it('should display a validation error message if the email addresses do not match', async () => {
+        postOptions.payload = {
+          name: 'some-value',
+          emailAddress: 'some-email@somewhere.com',
+          confirmEmailAddress: 'some-other-email@somewhere.com'
+        }
+        await TestHelper.checkFormFieldValidation(
+          postOptions,
+          server,
+          elementIds.confirmEmailAddress,
+          "This confirmation does not match the owner's email address"
+        )
+      })
+    })
+  })
+})
+
+const _createMocks = () => {
+  RedisService.set = jest.fn()
+}

--- a/test/services/redis.service.test.js
+++ b/test/services/redis.service.test.js
@@ -1,0 +1,68 @@
+'use strict'
+
+const RedisService = require('../../server/services/redis.service')
+
+let mockRequest
+const sessionId = 'the-session-id'
+const redisKey = 'some_key'
+
+describe('Redis service', () => {
+  beforeEach(() => {
+    _createMocks()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('get method', () => {
+    it('should get a value from Redis', async () => {
+      expect(mockRequest.redis.client.get).toBeCalledTimes(0)
+
+      await RedisService.get(mockRequest, redisKey)
+
+      expect(mockRequest.redis.client.get).toBeCalledTimes(1)
+      expect(mockRequest.redis.client.get).toBeCalledWith(
+        `${sessionId}.${redisKey}`
+      )
+    })
+  })
+
+  describe('set method', () => {
+    it('should set a value in Redis with correct expiry (TTL)', async () => {
+      const redisValue = 'some_value'
+      const redisTtlSeconds = 86400
+
+      expect(mockRequest.redis.client.set).toBeCalledTimes(0)
+      expect(mockRequest.redis.client.expire).toBeCalledTimes(0)
+
+      await RedisService.set(mockRequest, redisKey, redisValue)
+
+      expect(mockRequest.redis.client.set).toBeCalledTimes(1)
+      expect(mockRequest.redis.client.set).toBeCalledWith(
+        `${sessionId}.${redisKey}`,
+        redisValue
+      )
+
+      expect(mockRequest.redis.client.expire).toBeCalledTimes(1)
+      expect(mockRequest.redis.client.expire).toBeCalledWith(
+        `${sessionId}.${redisKey}`,
+        redisTtlSeconds
+      )
+    })
+  })
+})
+
+const _createMocks = () => {
+  mockRequest = jest.fn()
+  mockRequest.state = {
+    sessionId
+  }
+  mockRequest.redis = {
+    client: {
+      get: jest.fn(),
+      set: jest.fn(),
+      expire: jest.fn()
+    }
+  }
+}

--- a/test/utils/test-helper.js
+++ b/test/utils/test-helper.js
@@ -135,6 +135,40 @@ module.exports = class TestHelper {
     expect(TestHelper.getTextContent(elementLabel)).toEqual(expectedLabel)
   }
 
+  static checkFormField (document, fieldName, expectedLabel, expectedHint) {
+    let element = document.querySelector(`#${fieldName}`)
+    expect(element).toBeTruthy()
+
+    element = document.querySelector(`[for="${fieldName}"]`)
+    expect(element).toBeTruthy()
+    expect(TestHelper.getTextContent(element)).toEqual(expectedLabel)
+
+    if (expectedHint) {
+      element = document.querySelector(`#${fieldName}-hint`)
+      expect(element).toBeTruthy()
+      expect(TestHelper.getTextContent(element)).toEqual(expectedHint)
+    }
+  }
+
+  static async checkFormFieldValidation (
+    postOptions,
+    server,
+    fieldName,
+    expectedValidationMessage
+  ) {
+    const response = await TestHelper.submitPostRequest(
+      server,
+      postOptions,
+      400
+    )
+    return TestHelper.checkValidationError(
+      response,
+      fieldName,
+      `${fieldName}-error`,
+      expectedValidationMessage
+    )
+  }
+
   /**
    * Submits a HTTP POST request to the test server, checks the response code and returns the HTTP response.
    * @param response - The HTTP response object containing the document


### PR DESCRIPTION
Fixed bug IVORY-314 (hint text not appearing on 'Your contact details' page).

Added unit tests for the Redis service and contact-details route. 

Also, made the log level a separate config item (defaults to 'warn') because with debug mode turned on in development, like it was by default, the amount of debug info being produced was a bit overwhelming during normal development. If needed a Developer can turn the debug mode back on by setting the log level to 'debug' in their local .env file.