### PR TITLE
Ivory 320 make 'ivory has been repaired' question easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ server/public/build
 lcov.info
 .env
 test-output
+*.pfx

--- a/server/routes/ivory-added.route.js
+++ b/server/routes/ivory-added.route.js
@@ -42,8 +42,7 @@ const handlers = {
 const _getContext = () => {
   return {
     title:
-      'Has any replacement ivory been added to the item since it was made?',
-    hintText: 'This could have been to repair or restore damaged ivory.'
+      'Has any ivory been added to the item since 1 January 1975 to repair or restore it?'
   }
 }
 
@@ -53,7 +52,7 @@ const _validateForm = payload => {
     errors.push({
       name: 'yesNoIdk',
       text:
-        'You must tell us if any ivory has been added to the item since it was made'
+        'You must tell us if any ivory has been added to the item since 1 January 1975'
     })
   }
   return errors

--- a/test/routes/ivory-added.route.test.js
+++ b/test/routes/ivory-added.route.test.js
@@ -64,15 +64,7 @@ describe('/ivory-added route', () => {
       const element = document.querySelector('.govuk-fieldset__legend')
       expect(element).toBeTruthy()
       expect(TestHelper.getTextContent(element)).toEqual(
-        'Has any replacement ivory been added to the item since it was made?'
-      )
-    })
-
-    it('should have the correct hint text', () => {
-      const element = document.querySelector(`#${elementIds.yesNoIdkHint}`)
-      expect(element).toBeTruthy()
-      expect(TestHelper.getTextContent(element)).toEqual(
-        'This could have been to repair or restore damaged ivory.'
+        'Has any ivory been added to the item since 1 January 1975 to repair or restore it?'
       )
     })
 
@@ -125,7 +117,7 @@ describe('/ivory-added route', () => {
           response,
           'yesNoIdk',
           'yesNoIdk-error',
-          'You must tell us if any ivory has been added to the item since it was made'
+          'You must tell us if any ivory has been added to the item since 1 January 1975'
         )
       })
     })


### PR DESCRIPTION
Amended page title and error message. Removed the hint text.

Updated unit tests accordingly