### PR TITLE
Allow address lookup cert to be a Base64 string

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,7 @@ SERVICE_API_ENABLED=false
 #SERVICE_API_PORT=
 
 # The configuration for the address lookup api
+# The variable ADDRESS_LOOKUP_PFX_CERT can be a file location or a Base64 string. See Readme for more info
 ADDRESS_LOOKUP_ENABLED=false
 #ADDRESS_LOOKUP_URL=
 #ADDRESS_LOOKUP_PASSPHRASE=

--- a/README.md
+++ b/README.md
@@ -6,17 +6,21 @@ Digital service to support the Ivory Act.
 
 The default values will be used if the environment variables are missing or commented out.
 
-| name                       | description              | required | default   |            valid            | notes |
-| -------------------------- | ------------------------ | :------: | --------- | :-------------------------: | ----- |
-| NODE_ENV                   | Node environment         |    no    |           | development,test,production |       |
-| PORT                       | Port number              |    no    | 3000      |                             |       |
-| SERVICE_NAME               | Name of the service      |    no    |           |       Any text string       |       |
-| COOKIE_VALIDATION_PASSWORD | Cookie encoding password |   yes    |           |       Any text string       |       |
-| REDIS_HOST                 | Redis server IP address  |    no    | 127.0.0.1 |                             |       |
-| REDIS_PORT                 | Redis port number        |    no    | 6379      |                             |       |
-| SERVICE_API_ENABLED        | Enable/disable ivory API |   yes    | false     |         true,false          |       |
-| SERVICE_API_HOST           | Ivory API IP address     |    no    | 127.0.0.1 |                             |       |
-| SERVICE_API_PORT           | Ivory API port number    |    no    | 3010      |                             |       |
+| name                       | description                | required | default         |            valid                   | notes |
+| -------------------------- | -------------------------- | :------: | --------------- | :--------------------------------: | ----- |
+| NODE_ENV                   | Node environment           |    no    |                 |    development,test,production     |       |
+| PORT                       | Port number                |    no    | 3000            |                                    |       |
+| SERVICE_NAME               | Name of the service        |    no    |                 |          Any text string           |       |
+| COOKIE_VALIDATION_PASSWORD | Cookie encoding password   |   yes    |                 |          Any text string           |       |
+| REDIS_HOST                 | Redis server IP address    |    no    | 127.0.0.1       |                                    |       |
+| REDIS_PORT                 | Redis port number          |    no    | 6379            |                                    |       |
+| SERVICE_API_ENABLED        | Enable/disable ivory API   |    no    | false           |            true,false              |       |
+| SERVICE_API_HOST           | Ivory API IP address       |    no    | 127.0.0.1       |                                    |       |
+| SERVICE_API_PORT           | Ivory API port number      |    no    | 3010            |                                    |       |
+| ADDRESS_LOOKUP_ENABLED     | Enable/disable address API |    no    | false           |             true,false             |       |
+| ADDRESS_LOOKUP_URL         | Address lookup URL         |    no    | http://some-url |                                    |       |
+| ADDRESS_LOOKUP_PASSPHRASE  | Address lookup passphrase  |    no    |                 |                                    |       |
+| ADDRESS_LOOKUP_PFX_CERT    | Address lookup certificate |    no    |                 | PFX file location or Base64 string |       |
 
 # Prerequisites
 
@@ -37,6 +41,10 @@ If installing on a Windows machine you may encounter an error when running `$ np
 Now the application is ready to run:
 
 `$ npm start` or `$ node index.js`
+
+### Converting the Address Lookup PFX certificate to a Base64 string
+
+In some instances you may not be able to use a PFX certificate file with your environment. In these cases it is possible to use the script at `/bin/scripts/convertCert.js` to convert your PFX certificate into a Base64 string that can be added to the Environment Variable `ADDRESS_LOOKUP_PFX_CERT` instead of the location of the certificate itself.
 
 ### To run the application in Docker
 

--- a/bin/scripts/convertCert.js
+++ b/bin/scripts/convertCert.js
@@ -1,0 +1,13 @@
+'use strict'
+
+/**
+ * This script will convert a PFX certificate into a Base64 string that can be used
+ * as the environment variable ADDRESS_LOOKUP_PFX_CERT instead of the certificate path/file.
+ * */
+const fs = require('fs')
+
+// Enter the path/name of your certificate
+const buff = fs.readFileSync('./the-name-of-your-cert.pfx')
+const base64data = buff.toString('base64')
+
+console.log('Certificate converted to base 64 is:\n\n' + base64data)

--- a/server/services/address.service.js
+++ b/server/services/address.service.js
@@ -97,12 +97,12 @@ const _convertPostcodeToUpperCase = address => {
   address.AddressLine += postcode
 }
 
+/**
+ * Check if the address lookup certificate is a file or a base64 string.
+ * If it's a string convert it back to binary
+ * @returns address lookup certificate as binary
+*/
 const _getCertificate = () => {
-  /**
-   * Check if the address lookup certificate is a file or a base64 string.
-   * If it's a string convert it back to binary
-   * @returns address lookup certificate as binary
-  */
   if (config.addressLookupPfxCert) {
     return config.addressLookupPfxCert.toUpperCase().endsWith('.PFX')
       ? readFileSync(config.addressLookupPfxCert)

--- a/server/services/address.service.js
+++ b/server/services/address.service.js
@@ -11,6 +11,17 @@ const config = require('../utils/config')
 const PAGE_SIZE = 100
 const POSTCODE_SEARCH_ENDPOINT = '/ws/rest/DEFRA/v1/address/postcodes'
 
+/**
+ * Check if the address lookup certificate is a file or a base64 string.
+ * If it's a string convert it back to binary
+*/
+let addressLookupCert = ''
+if (config.addressLookupPfxCert.toUpperCase().endsWith('.PFX')) {
+  addressLookupCert = readFileSync(config.addressLookupPfxCert)
+} else if (config.addressLookupPfxCert) {
+  addressLookupCert = Buffer.from(config.addressLookupPfxCert, 'base64')
+}
+
 module.exports = class AddressService {
   static async addressSearch (nameOrNumber, postcode, pageSize = PAGE_SIZE) {
     let pageNumber = 0
@@ -58,7 +69,7 @@ module.exports = class AddressService {
   static async _queryAddressEndpoint (postcode, pageNumber, pageSize) {
     const authOptions = {
       passphrase: config.addressLookupPassphrase,
-      pfx: readFileSync(config.addressLookupPfxCert),
+      pfx: addressLookupCert,
       keepAlive: false
     }
     const tlsConfiguredAgent = new https.Agent(authOptions)

--- a/server/services/address.service.js
+++ b/server/services/address.service.js
@@ -56,22 +56,9 @@ module.exports = class AddressService {
   }
 
   static async _queryAddressEndpoint (postcode, pageNumber, pageSize) {
-    /**
-     * Check if the address lookup certificate is a file or a base64 string.
-     * If it's a string convert it back to binary
-    */
-    let addressLookupCert = ''
-    if (config.addressLookupPfxCert) {
-      if (config.addressLookupPfxCert.toUpperCase().endsWith('.PFX')) {
-        addressLookupCert = readFileSync(config.addressLookupPfxCert)
-      } else if (config.addressLookupPfxCert) {
-        addressLookupCert = Buffer.from(config.addressLookupPfxCert, 'base64')
-      }
-    }
-
     const authOptions = {
       passphrase: config.addressLookupPassphrase,
-      pfx: addressLookupCert,
+      pfx: _getCertificate(),
       keepAlive: false
     }
     const tlsConfiguredAgent = new https.Agent(authOptions)
@@ -108,4 +95,13 @@ const _convertPostcodeToUpperCase = address => {
   )
 
   address.AddressLine += postcode
+}
+
+const _getCertificate = () => {
+  // Check if the address lookup certificate is a file or a base64 string. If a string convert it back to binary
+  if (config.addressLookupPfxCert) {
+    return config.addressLookupPfxCert.toUpperCase().endsWith('.PFX')
+      ? readFileSync(config.addressLookupPfxCert)
+      : Buffer.from(config.addressLookupPfxCert, 'base64')
+  }
 }

--- a/server/services/address.service.js
+++ b/server/services/address.service.js
@@ -11,17 +11,6 @@ const config = require('../utils/config')
 const PAGE_SIZE = 100
 const POSTCODE_SEARCH_ENDPOINT = '/ws/rest/DEFRA/v1/address/postcodes'
 
-/**
- * Check if the address lookup certificate is a file or a base64 string.
- * If it's a string convert it back to binary
-*/
-let addressLookupCert = ''
-if (config.addressLookupPfxCert.toUpperCase().endsWith('.PFX')) {
-  addressLookupCert = readFileSync(config.addressLookupPfxCert)
-} else if (config.addressLookupPfxCert) {
-  addressLookupCert = Buffer.from(config.addressLookupPfxCert, 'base64')
-}
-
 module.exports = class AddressService {
   static async addressSearch (nameOrNumber, postcode, pageSize = PAGE_SIZE) {
     let pageNumber = 0
@@ -67,6 +56,19 @@ module.exports = class AddressService {
   }
 
   static async _queryAddressEndpoint (postcode, pageNumber, pageSize) {
+    /**
+     * Check if the address lookup certificate is a file or a base64 string.
+     * If it's a string convert it back to binary
+    */
+    let addressLookupCert = ''
+    if (config.addressLookupPfxCert) {
+      if (config.addressLookupPfxCert.toUpperCase().endsWith('.PFX')) {
+        addressLookupCert = readFileSync(config.addressLookupPfxCert)
+      } else if (config.addressLookupPfxCert) {
+        addressLookupCert = Buffer.from(config.addressLookupPfxCert, 'base64')
+      }
+    }
+
     const authOptions = {
       passphrase: config.addressLookupPassphrase,
       pfx: addressLookupCert,

--- a/server/services/address.service.js
+++ b/server/services/address.service.js
@@ -98,7 +98,11 @@ const _convertPostcodeToUpperCase = address => {
 }
 
 const _getCertificate = () => {
-  // Check if the address lookup certificate is a file or a base64 string. If a string convert it back to binary
+  /**
+   * Check if the address lookup certificate is a file or a base64 string.
+   * If it's a string convert it back to binary
+   * @returns address lookup certificate as binary
+  */
   if (config.addressLookupPfxCert) {
     return config.addressLookupPfxCert.toUpperCase().endsWith('.PFX')
       ? readFileSync(config.addressLookupPfxCert)


### PR DESCRIPTION
Given that our environments cannot easily use a certificate file to authenticate the address lookup I have created this workaround.