### PR TITLE
IVORY 305 - Applicant address screens

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,7 @@ module.exports = {
   ],
   coverageDirectory: 'test-output',
   coveragePathIgnorePatterns: [
+    '<rootDir>/bin/',
     '<rootDir>/node_modules/',
     '<rootDir>/test-output/',
     '<rootDir>/test/',

--- a/server/routes/check-your-answers.route.js
+++ b/server/routes/check-your-answers.route.js
@@ -32,15 +32,21 @@ const _getContext = async request => {
   return {
     ivoryIntegral: await RedisService.get(request, RedisKeys.IVORY_INTEGRAL),
     ivoryAdded: await RedisService.get(request, RedisKeys.IVORY_ADDED),
+
     ownerDetails: `${await RedisService.get(
       request,
       RedisKeys.OWNER_NAME
     )} ${await RedisService.get(request, RedisKeys.OWNER_EMAIL_ADDRESS)}`,
     ownerAddress: `${await RedisService.get(request, RedisKeys.OWNER_ADDRESS)}`,
+
     applicantDetails: `${await RedisService.get(
       request,
       RedisKeys.APPLICANT_NAME
-    )} ${await RedisService.get(request, RedisKeys.APPLICANT_EMAIL_ADDRESS)}`
+    )} ${await RedisService.get(request, RedisKeys.APPLICANT_EMAIL_ADDRESS)}`,
+    applicantAddress: `${await RedisService.get(
+      request,
+      RedisKeys.APPLICANT_ADDRESS
+    )}`
   }
 }
 

--- a/server/routes/check-your-answers.route.js
+++ b/server/routes/check-your-answers.route.js
@@ -30,7 +30,11 @@ const handlers = {
 
 const _getContext = async request => {
   return {
-    whatTypeOfItemIsIt: await RedisService.get(request, RedisKeys.WHAT_TYPE_OF_ITEM_IS_IT),
+    pageTitle: 'Check your answers (incomplete)',
+    whatTypeOfItemIsIt: await RedisService.get(
+      request,
+      RedisKeys.WHAT_TYPE_OF_ITEM_IS_IT
+    ),
     ivoryIntegral: await RedisService.get(request, RedisKeys.IVORY_INTEGRAL),
     ivoryAdded: await RedisService.get(request, RedisKeys.IVORY_ADDED),
 

--- a/server/routes/common/address-choose.route.js
+++ b/server/routes/common/address-choose.route.js
@@ -1,0 +1,108 @@
+'use strict'
+
+const {
+  AddressType,
+  Options,
+  Paths,
+  RedisKeys,
+  Views
+} = require('../../utils/constants')
+const RedisService = require('../../services/redis.service')
+const { buildErrorSummary, Validators } = require('../../utils/validation')
+
+const getAddressType = request =>
+  request.route.path === Paths.OWNER_ADDRESS_CHOOSE
+    ? AddressType.OWNER
+    : AddressType.APPLICANT
+
+const handlers = {
+  get: async (request, h) => {
+    const addressType = getAddressType(request)
+    return h.view(Views.ADDRESS_CHOOSE, {
+      ...(await _getContext(request, addressType))
+    })
+  },
+
+  post: async (request, h) => {
+    const addressType = getAddressType(request)
+    const payload = request.payload
+    const errors = _validateForm(payload)
+
+    if (errors.length) {
+      return h
+        .view(Views.ADDRESS_CHOOSE, {
+          ...(await _getContext(request, addressType)),
+          ...buildErrorSummary(errors)
+        })
+        .code(400)
+    }
+
+    const ownedByApplicant = await RedisService.get(
+      request,
+      RedisKeys.OWNED_BY_APPLICANT
+    )
+
+    RedisService.set(
+      request,
+      addressType === AddressType.OWNER
+        ? RedisKeys.OWNER_ADDRESS
+        : RedisKeys.APPLICANT_ADDRESS,
+      payload.address
+    )
+
+    if (ownedByApplicant === Options.YES) {
+      RedisService.set(request, RedisKeys.APPLICANT_ADDRESS, payload.address)
+    }
+
+    let route
+    if (addressType === AddressType.OWNER) {
+      route =
+        ownedByApplicant === Options.YES
+          ? Paths.CHECK_YOUR_ANSWERS
+          : Paths.APPLICANT_CONTACT_DETAILS
+    } else {
+      route = Paths.CHECK_YOUR_ANSWERS
+    }
+
+    return h.redirect(route)
+  }
+}
+
+const _getContext = async (request, completedBy) => {
+  const addresses = JSON.parse(
+    await RedisService.get(request, RedisKeys.ADDRESS_FIND)
+  )
+
+  const items = addresses.map(item => {
+    return {
+      value: item.Address.AddressLine,
+      text: item.Address.AddressLine
+    }
+  })
+
+  return {
+    pageHeading:
+      completedBy === AddressType.OWNER
+        ? 'Choose your address'
+        : "Choose the owner's address",
+    addresses: items
+  }
+}
+
+const _validateForm = payload => {
+  const errors = []
+
+  if (Validators.empty(payload.address)) {
+    errors.push({
+      name: 'address',
+      text: 'You must choose an address'
+    })
+  }
+
+  return errors
+}
+
+module.exports = {
+  get: handlers.get,
+  post: handlers.post
+}

--- a/server/routes/common/address-choose.route.js
+++ b/server/routes/common/address-choose.route.js
@@ -69,6 +69,13 @@ const handlers = {
 }
 
 const _getContext = async (request, addressType) => {
+  let context
+
+  const ownedByApplicant = await RedisService.get(
+    request,
+    RedisKeys.OWNED_BY_APPLICANT
+  )
+
   const addresses = JSON.parse(
     await RedisService.get(request, RedisKeys.ADDRESS_FIND)
   )
@@ -80,12 +87,29 @@ const _getContext = async (request, addressType) => {
     }
   })
 
+  if (addressType === AddressType.OWNER) {
+    context = _getContextForOwnerAddressType(ownedByApplicant)
+  } else {
+    context = _getContextForApplicantAddressType()
+  }
+
+  context.addresses = items
+
+  return context
+}
+
+const _getContextForOwnerAddressType = ownedByApplicant => {
   return {
     pageHeading:
-      addressType === AddressType.OWNER
+      ownedByApplicant === Options.YES
         ? 'Choose your address'
-        : "Choose the owner's address",
-    addresses: items
+        : "Choose the owner's address"
+  }
+}
+
+const _getContextForApplicantAddressType = () => {
+  return {
+    pageHeading: 'Choose your address'
   }
 }
 

--- a/server/routes/common/address-choose.route.js
+++ b/server/routes/common/address-choose.route.js
@@ -100,7 +100,7 @@ const _getContext = async (request, addressType) => {
 
 const _getContextForOwnerAddressType = ownedByApplicant => {
   return {
-    pageHeading:
+    pageTitle:
       ownedByApplicant === Options.YES
         ? 'Choose your address'
         : "Choose the owner's address"
@@ -109,7 +109,7 @@ const _getContextForOwnerAddressType = ownedByApplicant => {
 
 const _getContextForApplicantAddressType = () => {
   return {
-    pageHeading: 'Choose your address'
+    pageTitle: 'Choose your address'
   }
 }
 

--- a/server/routes/common/address-choose.route.js
+++ b/server/routes/common/address-choose.route.js
@@ -68,7 +68,7 @@ const handlers = {
   }
 }
 
-const _getContext = async (request, completedBy) => {
+const _getContext = async (request, addressType) => {
   const addresses = JSON.parse(
     await RedisService.get(request, RedisKeys.ADDRESS_FIND)
   )
@@ -82,7 +82,7 @@ const _getContext = async (request, completedBy) => {
 
   return {
     pageHeading:
-      completedBy === AddressType.OWNER
+      addressType === AddressType.OWNER
         ? 'Choose your address'
         : "Choose the owner's address",
     addresses: items

--- a/server/routes/common/address-confirm.route.js
+++ b/server/routes/common/address-confirm.route.js
@@ -87,7 +87,7 @@ const _getContext = async (request, addressType) => {
 
 const _getContextForOwnerAddressType = ownedByApplicant => {
   return {
-    pageHeading:
+    pageTitle:
       ownedByApplicant === Options.YES
         ? 'Confirm your address'
         : "Confirm the owner's address"
@@ -96,7 +96,7 @@ const _getContextForOwnerAddressType = ownedByApplicant => {
 
 const _getContextForApplicantAddressType = () => {
   return {
-    pageHeading: 'Confirm your address'
+    pageTitle: 'Confirm your address'
   }
 }
 

--- a/server/routes/common/address-confirm.route.js
+++ b/server/routes/common/address-confirm.route.js
@@ -1,0 +1,106 @@
+'use strict'
+
+const {
+  AddressType,
+  Options,
+  Paths,
+  RedisKeys,
+  Views
+} = require('../../utils/constants')
+const RedisService = require('../../services/redis.service')
+
+const getAddressType = request =>
+  request.route.path === Paths.OWNER_ADDRESS_CONFIRM
+    ? AddressType.OWNER
+    : AddressType.APPLICANT
+
+const handlers = {
+  get: async (request, h) => {
+    const addressType = getAddressType(request)
+
+    return h.view(Views.ADDRESS_CONFIRM, {
+      ...(await _getContext(request, addressType))
+    })
+  },
+
+  post: async (request, h) => {
+    const addressType = getAddressType(request)
+    const context = await _getContext(request, addressType)
+
+    const ownedByApplicant = await RedisService.get(
+      request,
+      RedisKeys.OWNED_BY_APPLICANT
+    )
+
+    RedisService.set(
+      request,
+      addressType === AddressType.OWNER
+        ? RedisKeys.OWNER_ADDRESS
+        : RedisKeys.APPLICANT_ADDRESS,
+      context.address.AddressLine
+    )
+
+    if (ownedByApplicant === Options.YES) {
+      RedisService.set(
+        request,
+        RedisKeys.APPLICANT_ADDRESS,
+        context.address.AddressLine
+      )
+    }
+
+    let route
+    if (addressType === AddressType.OWNER) {
+      route =
+        ownedByApplicant === Options.YES
+          ? Paths.CHECK_YOUR_ANSWERS
+          : Paths.APPLICANT_CONTACT_DETAILS
+    } else {
+      route = Paths.CHECK_YOUR_ANSWERS
+    }
+
+    return h.redirect(route)
+  }
+}
+
+const _getContext = async (request, addressType) => {
+  let context
+
+  const ownedByApplicant = await RedisService.get(
+    request,
+    RedisKeys.OWNED_BY_APPLICANT
+  )
+
+  if (addressType === AddressType.OWNER) {
+    context = _getContextForOwnerAddressType(ownedByApplicant)
+  } else {
+    context = _getContextForApplicantAddressType()
+  }
+
+  const addresses = JSON.parse(
+    await RedisService.get(request, RedisKeys.ADDRESS_FIND)
+  )
+
+  context.address = addresses[0].Address
+
+  return context
+}
+
+const _getContextForOwnerAddressType = ownedByApplicant => {
+  return {
+    pageHeading:
+      ownedByApplicant === Options.YES
+        ? 'Confirm your address'
+        : "Confirm the owner's address"
+  }
+}
+
+const _getContextForApplicantAddressType = () => {
+  return {
+    pageHeading: 'Confirm your address'
+  }
+}
+
+module.exports = {
+  get: handlers.get,
+  post: handlers.post
+}

--- a/server/routes/common/address-enter.route.js
+++ b/server/routes/common/address-enter.route.js
@@ -91,30 +91,30 @@ const _getContext = async (request, addressType, isGet) => {
   const resultSize = addresses.length
 
   if (resultSize === 0) {
-    context.pageHeading = 'No results, you will need to enter the address'
+    context.pageTitle = 'No results, you will need to enter the address'
   } else if (resultSize === 1) {
     if (addressType === AddressType.OWNER) {
-      context.pageHeading =
+      context.pageTitle =
         ownedByApplicant === Options.YES
           ? 'Edit your address'
           : "Edit the owner's address"
     } else {
-      context.pageHeading = 'Edit your address'
+      context.pageTitle = 'Edit your address'
     }
     if (isGet) {
       Object.assign(context, _getAddressFieldsFromAddress(addresses[0].Address))
     }
   } else if (resultSize > 1 && resultSize <= 50) {
     if (addressType === AddressType.OWNER) {
-      context.pageHeading =
+      context.pageTitle =
         ownedByApplicant === Options.YES
           ? 'Enter your address'
           : "Enter the owner's address"
     } else {
-      context.pageHeading = 'Enter your address'
+      context.pageTitle = 'Enter your address'
     }
   } else if (resultSize > 50) {
-    context.pageHeading = 'Too many results, you will need to enter the address'
+    context.pageTitle = 'Too many results, you will need to enter the address'
   }
 
   if (addressType === AddressType.OWNER) {

--- a/server/routes/common/address-enter.route.js
+++ b/server/routes/common/address-enter.route.js
@@ -86,16 +86,16 @@ const _getContext = async (request, addressType, isGet) => {
   const resultSize = addresses.length
 
   if (resultSize === 0) {
-    context.title = 'No results, you will need to enter the address'
+    context.pageHeading = 'No results, you will need to enter the address'
   } else if (resultSize === 1) {
-    context.title = 'Edit your address'
+    context.pageHeading = 'Edit your address'
     if (isGet) {
       Object.assign(context, _getAddressFieldsFromAddress(addresses[0].Address))
     }
   } else if (resultSize > 1 && resultSize <= 50) {
-    context.title = 'Enter your address'
+    context.pageHeading = 'Enter your address'
   } else if (resultSize > 50) {
-    context.title = 'Too many results, you will need to enter the address'
+    context.pageHeading = 'Too many results, you will need to enter the address'
   }
 
   context.helpText =

--- a/server/routes/common/address-enter.route.js
+++ b/server/routes/common/address-enter.route.js
@@ -1,0 +1,173 @@
+'use strict'
+
+const {
+  AddressType,
+  Options,
+  Paths,
+  RedisKeys,
+  Views
+} = require('../../utils/constants')
+const RedisService = require('../../services/redis.service')
+const { buildErrorSummary, Validators } = require('../../utils/validation')
+const {
+  addPayloadToContext,
+  convertToCommaSeparatedTitleCase
+} = require('../../utils/general')
+
+const getAddressType = request =>
+  request.route.path === Paths.OWNER_ADDRESS_ENTER
+    ? AddressType.OWNER
+    : AddressType.APPLICANT
+
+const handlers = {
+  get: async (request, h) => {
+    const addressType = getAddressType(request)
+
+    return h.view(Views.ADDRESS_ENTER, {
+      ...(await _getContext(request, addressType, true))
+    })
+  },
+
+  post: async (request, h) => {
+    const addressType = getAddressType(request)
+    const payload = request.payload
+    const errors = _validateForm(payload)
+
+    if (errors.length) {
+      return h
+        .view(Views.ADDRESS_ENTER, {
+          ...(await _getContext(request, addressType, false)),
+          ...buildErrorSummary(errors)
+        })
+        .code(400)
+    }
+
+    const ownedByApplicant = await RedisService.get(
+      request,
+      RedisKeys.OWNED_BY_APPLICANT
+    )
+
+    _updateAddressFieldCasing(payload)
+    const address = _concatenateAddressFields(payload)
+
+    RedisService.set(
+      request,
+      addressType === AddressType.OWNER
+        ? RedisKeys.OWNER_ADDRESS
+        : RedisKeys.APPLICANT_ADDRESS,
+      address
+    )
+
+    if (ownedByApplicant === Options.YES) {
+      RedisService.set(request, RedisKeys.APPLICANT_ADDRESS, address)
+    }
+
+    let route
+    if (addressType === AddressType.OWNER) {
+      route =
+        ownedByApplicant === Options.YES
+          ? Paths.CHECK_YOUR_ANSWERS
+          : Paths.APPLICANT_CONTACT_DETAILS
+    } else {
+      route = Paths.CHECK_YOUR_ANSWERS
+    }
+
+    return h.redirect(route)
+  }
+}
+
+const _getContext = async (request, addressType, isGet) => {
+  const context = {}
+
+  const addresses = JSON.parse(
+    await RedisService.get(request, RedisKeys.ADDRESS_FIND)
+  )
+
+  const resultSize = addresses.length
+
+  if (resultSize === 0) {
+    context.title = 'No results, you will need to enter the address'
+  } else if (resultSize === 1) {
+    context.title = 'Edit your address'
+    if (isGet) {
+      Object.assign(context, _getAddressFieldsFromAddress(addresses[0].Address))
+    }
+  } else if (resultSize > 1 && resultSize <= 50) {
+    context.title = 'Enter your address'
+  } else if (resultSize > 50) {
+    context.title = 'Too many results, you will need to enter the address'
+  }
+
+  context.helpText =
+    'If your business owns the item, give your business address.'
+
+  addPayloadToContext(request, context)
+
+  return context
+}
+
+const _validateForm = payload => {
+  const errors = []
+
+  if (Validators.empty(payload.addressLine1)) {
+    errors.push({
+      name: 'addressLine1',
+      text: 'Enter the building and street information'
+    })
+  }
+
+  if (Validators.empty(payload.townOrCity)) {
+    errors.push({
+      name: 'townOrCity',
+      text: 'Enter a town or city'
+    })
+  }
+
+  if (Validators.empty(payload.postcode)) {
+    errors.push({
+      name: 'postcode',
+      text: 'Enter the postcode'
+    })
+  }
+
+  if (!Validators.postcode(payload.postcode)) {
+    errors.push({
+      name: 'postcode',
+      text: 'Enter a UK postcode in the correct format'
+    })
+  }
+
+  return errors
+}
+
+const _getAddressFieldsFromAddress = address => {
+  return {
+    addressLine1: address.SubBuildingName
+      ? convertToCommaSeparatedTitleCase(address.SubBuildingName)
+      : `${convertToCommaSeparatedTitleCase(
+          address.BuildingNumber
+        )} ${convertToCommaSeparatedTitleCase(address.Street)}`,
+    addressLine2: convertToCommaSeparatedTitleCase(address.Locality),
+    townOrCity: convertToCommaSeparatedTitleCase(address.Town),
+    postcode: address.Postcode
+  }
+}
+const _updateAddressFieldCasing = payload => {
+  for (const key in payload) {
+    payload[key] =
+      key === 'postcode'
+        ? payload[key].toUpperCase()
+        : convertToCommaSeparatedTitleCase(payload[key])
+  }
+}
+
+const _concatenateAddressFields = payload => {
+  return Object.keys(payload)
+    .map(key => payload[key])
+    .join(', ')
+}
+
+module.exports = {
+  get: handlers.get,
+  post: handlers.post
+}

--- a/server/routes/common/address-find.route.js
+++ b/server/routes/common/address-find.route.js
@@ -99,13 +99,13 @@ const _getContextForOwnerAddressType = ownedByApplicant => {
   let context
   if (ownedByApplicant === Options.YES) {
     context = {
-      title: 'What is your address?',
+      pageHeading: 'What is your address?',
       helpText:
         'If your business is the legal owner of the item, give your business address.'
     }
   } else {
     context = {
-      title: 'What is the owner’s address?',
+      pageHeading: 'What is the owner’s address?',
       helpText:
         'If the legal owner of the item is a business, give the business address.'
     }
@@ -115,20 +115,20 @@ const _getContextForOwnerAddressType = ownedByApplicant => {
 
 const _getContextForApplicantAddressType = () => {
   return {
-    title: 'What is your address?',
+    pageHeading: 'What is your address?',
     helpText:
       'If your business is helping someone else sell their item, give your business address.'
   }
 }
 
-const _validateForm = (payload, completedBy) => {
+const _validateForm = (payload, addressType) => {
   const errors = []
 
   if (Validators.empty(payload.postcode)) {
     errors.push({
       name: 'postcode',
       text:
-        completedBy === AddressType.OWNER
+        addressType === AddressType.OWNER
           ? 'Enter your postcode'
           : 'Enter the owner’s postcode'
     })

--- a/server/routes/common/address-find.route.js
+++ b/server/routes/common/address-find.route.js
@@ -130,7 +130,7 @@ const _validateForm = (payload, addressType) => {
       text:
         addressType === AddressType.OWNER
           ? 'Enter your postcode'
-          : 'Enter the owner’s postcode'
+          : "Enter the owner's postcode"
     })
   }
 

--- a/server/routes/common/address-find.route.js
+++ b/server/routes/common/address-find.route.js
@@ -1,0 +1,150 @@
+'use strict'
+
+const {
+  AddressType,
+  Paths,
+  RedisKeys,
+  Views,
+  Options
+} = require('../../utils/constants')
+const AddressService = require('../../services/address.service')
+const RedisService = require('../../services/redis.service')
+const { buildErrorSummary, Validators } = require('../../utils/validation')
+const { addPayloadToContext } = require('../../utils/general')
+
+const getAddressType = request =>
+  request.route.path === Paths.OWNER_ADDRESS_FIND
+    ? AddressType.OWNER
+    : AddressType.APPLICANT
+
+const handlers = {
+  get: async (request, h) => {
+    return h.view(Views.ADDRESS_FIND, {
+      ...(await _getContext(request, getAddressType(request)))
+    })
+  },
+
+  post: async (request, h) => {
+    const addressType = getAddressType(request)
+    const payload = request.payload
+    const errors = _validateForm(payload, addressType)
+
+    if (errors.length) {
+      return h
+        .view(Views.ADDRESS_FIND, {
+          ...(await _getContext(request, addressType)),
+          ...buildErrorSummary(errors)
+        })
+        .code(400)
+    }
+
+    const searchResults = await AddressService.addressSearch(
+      payload.nameOrNumber,
+      payload.postcode
+    )
+    await RedisService.set(
+      request,
+      RedisKeys.ADDRESS_FIND,
+      JSON.stringify(searchResults)
+    )
+
+    const resultSize = searchResults.length
+
+    if (resultSize === 0 || resultSize > 50) {
+      return h.redirect(
+        addressType === AddressType.OWNER
+          ? Paths.OWNER_ADDRESS_ENTER
+          : Paths.APPLICANT_ADDRESS_ENTER
+      )
+    }
+
+    if (resultSize === 1) {
+      return h.redirect(
+        addressType === AddressType.OWNER
+          ? Paths.OWNER_ADDRESS_CONFIRM
+          : Paths.APPLICANT_ADDRESS_CONFIRM
+      )
+    }
+
+    if (resultSize > 1) {
+      return h.redirect(
+        addressType === AddressType.OWNER
+          ? Paths.OWNER_ADDRESS_CHOOSE
+          : Paths.APPLICANT_ADDRESS_CHOOSE
+      )
+    }
+  }
+}
+
+const _getContext = async (request, addressType) => {
+  let context
+
+  const ownedByApplicant = await RedisService.get(
+    request,
+    RedisKeys.OWNED_BY_APPLICANT
+  )
+
+  if (addressType === AddressType.OWNER) {
+    context = _getContextForOwnerAddressType(ownedByApplicant)
+  } else {
+    context = _getContextForApplicantAddressType()
+  }
+
+  addPayloadToContext(request, context)
+
+  return context
+}
+
+const _getContextForOwnerAddressType = ownedByApplicant => {
+  let context
+  if (ownedByApplicant === Options.YES) {
+    context = {
+      title: 'What is your address?',
+      helpText:
+        'If your business is the legal owner of the item, give your business address.'
+    }
+  } else {
+    context = {
+      title: 'What is the owner’s address?',
+      helpText:
+        'If the legal owner of the item is a business, give the business address.'
+    }
+  }
+  return context
+}
+
+const _getContextForApplicantAddressType = () => {
+  return {
+    title: 'What is your address?',
+    helpText:
+      'If your business is helping someone else sell their item, give your business address.'
+  }
+}
+
+const _validateForm = (payload, completedBy) => {
+  const errors = []
+
+  if (Validators.empty(payload.postcode)) {
+    errors.push({
+      name: 'postcode',
+      text:
+        completedBy === AddressType.OWNER
+          ? 'Enter your postcode'
+          : 'Enter the owner’s postcode'
+    })
+  }
+
+  if (!Validators.postcode(payload.postcode)) {
+    errors.push({
+      name: 'postcode',
+      text: 'Enter a UK postcode in the correct format'
+    })
+  }
+
+  return errors
+}
+
+module.exports = {
+  get: handlers.get,
+  post: handlers.post
+}

--- a/server/routes/common/address-find.route.js
+++ b/server/routes/common/address-find.route.js
@@ -99,13 +99,13 @@ const _getContextForOwnerAddressType = ownedByApplicant => {
   let context
   if (ownedByApplicant === Options.YES) {
     context = {
-      pageHeading: 'What is your address?',
+      pageTitle: 'What is your address?',
       helpText:
         'If your business is the legal owner of the item, give your business address.'
     }
   } else {
     context = {
-      pageHeading: 'What is the owner’s address?',
+      pageTitle: 'What is the owner’s address?',
       helpText:
         'If the legal owner of the item is a business, give the business address.'
     }
@@ -115,7 +115,7 @@ const _getContextForOwnerAddressType = ownedByApplicant => {
 
 const _getContextForApplicantAddressType = () => {
   return {
-    pageHeading: 'What is your address?',
+    pageTitle: 'What is your address?',
     helpText:
       'If your business is helping someone else sell their item, give your business address.'
   }

--- a/server/routes/common/address-international.route.js
+++ b/server/routes/common/address-international.route.js
@@ -104,12 +104,12 @@ const _getContextForOwnerAddressType = ownedByApplicant => {
   let context
   if (ownedByApplicant === Options.YES) {
     context = {
-      pageHeading: 'Enter your address',
+      pageTitle: 'Enter your address',
       hintText: 'If your business owns the item, give your business address.'
     }
   } else {
     context = {
-      pageHeading: "Enter the owner's address",
+      pageTitle: "Enter the owner's address",
       hintText: 'If the owner is a business, give the business address.'
     }
   }
@@ -118,7 +118,7 @@ const _getContextForOwnerAddressType = ownedByApplicant => {
 
 const _getContextForApplicantAddressType = () => {
   return {
-    pageHeading: 'Enter your address',
+    pageTitle: 'Enter your address',
     hintText:
       'If your business is helping someone else sell their item, give your business address.'
   }

--- a/server/routes/common/address-international.route.js
+++ b/server/routes/common/address-international.route.js
@@ -1,0 +1,128 @@
+'use strict'
+
+const RedisService = require('../../services/redis.service')
+const {
+  AddressType,
+  Options,
+  Paths,
+  RedisKeys,
+  Views
+} = require('../../utils/constants')
+const { buildErrorSummary, Validators } = require('../../utils/validation')
+
+const {
+  addPayloadToContext,
+  convertToCommaSeparatedTitleCase
+} = require('../../utils/general')
+
+const getAddressType = request =>
+  request.route.path === Paths.OWNER_ADDRESS_INTERNATIONAL
+    ? AddressType.OWNER
+    : AddressType.APPLICANT
+
+const handlers = {
+  get: (request, h) => {
+    const addressType = getAddressType(request)
+
+    return h.view(Views.ADDRESS_INTERNATIONAL, {
+      ..._getContext(request, addressType)
+    })
+  },
+
+  post: async (request, h) => {
+    const addressType = getAddressType(request)
+    const payload = request.payload
+    const errors = _validateForm(payload)
+
+    if (errors.length) {
+      return h
+        .view(Views.ADDRESS_INTERNATIONAL, {
+          ..._getContext(request, addressType),
+          ...buildErrorSummary(errors)
+        })
+        .code(400)
+    }
+    const ownedByApplicant = await RedisService.get(
+      request,
+      RedisKeys.OWNED_BY_APPLICANT
+    )
+
+    payload.internationalAddress = convertToCommaSeparatedTitleCase(
+      payload.internationalAddress
+    )
+
+    RedisService.set(
+      request,
+      addressType === AddressType.OWNER
+        ? RedisKeys.OWNER_ADDRESS
+        : RedisKeys.APPLICANT_ADDRESS,
+      payload.internationalAddress
+    )
+
+    if (ownedByApplicant === Options.YES) {
+      RedisService.set(
+        request,
+        RedisKeys.APPLICANT_ADDRESS,
+        payload.internationalAddress
+      )
+    }
+
+    let route
+    if (addressType === AddressType.OWNER) {
+      route =
+        ownedByApplicant === Options.YES
+          ? Paths.CHECK_YOUR_ANSWERS
+          : Paths.APPLICANT_CONTACT_DETAILS
+    } else {
+      route = Paths.CHECK_YOUR_ANSWERS
+    }
+
+    return h.redirect(route)
+  }
+}
+
+const _getContext = (request, completedBy) => {
+  let context
+
+  if (completedBy === AddressType.OWNER) {
+    context = {
+      title: 'Enter your address',
+      hintText: 'If your business owns the item, give your business address.'
+    }
+  } else {
+    context = {
+      title: 'Enter the owner’s address',
+      hintText: 'If the owner is a business, give the business address.'
+    }
+  }
+
+  addPayloadToContext(request, context)
+
+  return context
+}
+
+const _validateForm = payload => {
+  const errors = []
+
+  if (Validators.empty(payload.internationalAddress)) {
+    errors.push({
+      name: 'internationalAddress',
+      text: 'Enter the address'
+    })
+  }
+
+  const characterLimit = 4000
+  if (Validators.maxLength(payload.internationalAddress, characterLimit)) {
+    errors.push({
+      name: 'internationalAddress',
+      text: `Enter a shorter address with no more than ${characterLimit} characters`
+    })
+  }
+
+  return errors
+}
+
+module.exports = {
+  get: handlers.get,
+  post: handlers.post
+}

--- a/server/routes/home.route.js
+++ b/server/routes/home.route.js
@@ -8,14 +8,14 @@ const handlers = {
     _setCookieSessionId(h)
 
     return h.view(Views.HOME, {
-      title: 'Hello',
+      pageTitle: 'Hello',
       message: 'Elephants'
     })
   },
 
   post: (request, h) => {
     return h.view(Views.HOME, {
-      title: 'Hello',
+      pageTitle: 'Hello',
       message: 'Elephants'
     })
   }

--- a/server/routes/ivory-added.route.js
+++ b/server/routes/ivory-added.route.js
@@ -41,7 +41,7 @@ const handlers = {
 
 const _getContext = () => {
   return {
-    pageHeading:
+    pageTitle:
       'Has any ivory been added to the item since 1 January 1975 to repair or restore it?'
   }
 }

--- a/server/routes/ivory-added.route.js
+++ b/server/routes/ivory-added.route.js
@@ -41,7 +41,7 @@ const handlers = {
 
 const _getContext = () => {
   return {
-    title:
+    pageHeading:
       'Has any ivory been added to the item since 1 January 1975 to repair or restore it?'
   }
 }

--- a/server/routes/taken-from-elephant.route.js
+++ b/server/routes/taken-from-elephant.route.js
@@ -41,7 +41,7 @@ const handlers = {
 
 const _getContext = () => {
   return {
-    pageHeading:
+    pageTitle:
       'Was the replacement ivory taken from the elephant on or after 1 January 1975?'
   }
 }

--- a/server/routes/taken-from-elephant.route.js
+++ b/server/routes/taken-from-elephant.route.js
@@ -41,7 +41,7 @@ const handlers = {
 
 const _getContext = () => {
   return {
-    title:
+    pageHeading:
       'Was the replacement ivory taken from the elephant on or after 1 January 1975?'
   }
 }

--- a/server/routes/user-details/applicant/address-choose.route.js
+++ b/server/routes/user-details/applicant/address-choose.route.js
@@ -1,17 +1,17 @@
 'use strict'
 
 const { Paths } = require('../../../utils/constants')
-const { get, post } = require('../../common/address-find.route')
+const { get, post } = require('../../common/address-choose.route')
 
 module.exports = [
   {
     method: 'GET',
-    path: `${Paths.OWNER_ADDRESS_FIND}`,
+    path: `${Paths.APPLICANT_ADDRESS_CHOOSE}`,
     handler: get
   },
   {
     method: 'POST',
-    path: `${Paths.OWNER_ADDRESS_FIND}`,
+    path: `${Paths.APPLICANT_ADDRESS_CHOOSE}`,
     handler: post
   }
 ]

--- a/server/routes/user-details/applicant/address-confirm.route.js
+++ b/server/routes/user-details/applicant/address-confirm.route.js
@@ -1,17 +1,17 @@
 'use strict'
 
 const { Paths } = require('../../../utils/constants')
-const { get, post } = require('../../common/address-find.route')
+const { get, post } = require('../../common/address-confirm.route')
 
 module.exports = [
   {
     method: 'GET',
-    path: `${Paths.OWNER_ADDRESS_FIND}`,
+    path: `${Paths.APPLICANT_ADDRESS_CONFIRM}`,
     handler: get
   },
   {
     method: 'POST',
-    path: `${Paths.OWNER_ADDRESS_FIND}`,
+    path: `${Paths.APPLICANT_ADDRESS_CONFIRM}`,
     handler: post
   }
 ]

--- a/server/routes/user-details/applicant/address-enter.route.js
+++ b/server/routes/user-details/applicant/address-enter.route.js
@@ -1,17 +1,17 @@
 'use strict'
 
 const { Paths } = require('../../../utils/constants')
-const { get, post } = require('../../common/address-find.route')
+const { get, post } = require('../../common/address-enter.route')
 
 module.exports = [
   {
     method: 'GET',
-    path: `${Paths.OWNER_ADDRESS_FIND}`,
+    path: `${Paths.APPLICANT_ADDRESS_ENTER}`,
     handler: get
   },
   {
     method: 'POST',
-    path: `${Paths.OWNER_ADDRESS_FIND}`,
+    path: `${Paths.APPLICANT_ADDRESS_ENTER}`,
     handler: post
   }
 ]

--- a/server/routes/user-details/applicant/address-find.route.js
+++ b/server/routes/user-details/applicant/address-find.route.js
@@ -6,12 +6,12 @@ const { get, post } = require('../../common/address-find.route')
 module.exports = [
   {
     method: 'GET',
-    path: `${Paths.OWNER_ADDRESS_FIND}`,
+    path: `${Paths.APPLICANT_ADDRESS_FIND}`,
     handler: get
   },
   {
     method: 'POST',
-    path: `${Paths.OWNER_ADDRESS_FIND}`,
+    path: `${Paths.APPLICANT_ADDRESS_FIND}`,
     handler: post
   }
 ]

--- a/server/routes/user-details/applicant/address-international.route.js
+++ b/server/routes/user-details/applicant/address-international.route.js
@@ -6,12 +6,12 @@ const { get, post } = require('../../common/address-international.route')
 module.exports = [
   {
     method: 'GET',
-    path: `${Paths.OWNER_ADDRESS_INTERNATIONAL}`,
+    path: `${Paths.APPLICANT_ADDRESS_INTERNATIONAL}`,
     handler: get
   },
   {
     method: 'POST',
-    path: `${Paths.OWNER_ADDRESS_INTERNATIONAL}`,
+    path: `${Paths.APPLICANT_ADDRESS_INTERNATIONAL}`,
     handler: post
   }
 ]

--- a/server/routes/user-details/applicant/contact-details.route.js
+++ b/server/routes/user-details/applicant/contact-details.route.js
@@ -5,7 +5,7 @@ const { Paths, RedisKeys, Views } = require('../../../utils/constants')
 const { buildErrorSummary, Validators } = require('../../../utils/validation')
 const { addPayloadToContext } = require('../../../utils/general')
 
-const pageHeading = 'Your contact details'
+const pageTitle = 'Your contact details'
 
 const handlers = {
   get: (request, h) => {
@@ -37,7 +37,7 @@ const handlers = {
 }
 
 const _getContext = request => {
-  const context = { pageHeading, applicant: true }
+  const context = { pageTitle, applicant: true }
 
   addPayloadToContext(request, context)
 

--- a/server/routes/user-details/applicant/contact-details.route.js
+++ b/server/routes/user-details/applicant/contact-details.route.js
@@ -5,7 +5,7 @@ const { Paths, RedisKeys, Views } = require('../../../utils/constants')
 const { buildErrorSummary, Validators } = require('../../../utils/validation')
 const { addPayloadToContext } = require('../../../utils/general')
 
-const title = 'Your contact details'
+const pageHeading = 'Your contact details'
 
 const handlers = {
   get: (request, h) => {
@@ -32,12 +32,12 @@ const handlers = {
       payload.emailAddress
     )
 
-    return h.redirect(Paths.CHECK_YOUR_ANSWERS)
+    return h.redirect(Paths.APPLICANT_ADDRESS_FIND)
   }
 }
 
 const _getContext = request => {
-  const context = { title, applicant: true }
+  const context = { pageHeading, applicant: true }
 
   addPayloadToContext(request, context)
 
@@ -85,12 +85,12 @@ const _validateForm = payload => {
 module.exports = [
   {
     method: 'GET',
-    path: `${Paths.APPLICANT_DETAILS}`,
+    path: `${Paths.APPLICANT_CONTACT_DETAILS}`,
     handler: handlers.get
   },
   {
     method: 'POST',
-    path: `${Paths.APPLICANT_DETAILS}`,
+    path: `${Paths.APPLICANT_CONTACT_DETAILS}`,
     handler: handlers.post
   }
 ]

--- a/server/routes/user-details/owner/address-choose.route.js
+++ b/server/routes/user-details/owner/address-choose.route.js
@@ -1,76 +1,17 @@
 'use strict'
 
-const { Paths, RedisKeys, Views } = require('../../../utils/constants')
-const RedisService = require('../../../services/redis.service')
-const { buildErrorSummary, Validators } = require('../../../utils/validation')
-
-// const completedBy = 'owner' // Temporary until previous page built then will use value saved in Redis. Use 'owner' or '3rdParty'
-
-const handlers = {
-  get: async (request, h) => {
-    return h.view(Views.ADDRESS_CHOOSE, {
-      ...(await _getContext(request))
-    })
-  },
-  post: async (request, h) => {
-    const payload = request.payload
-    const errors = _validateForm(payload)
-
-    if (errors.length) {
-      return h
-        .view(Views.ADDRESS_CHOOSE, {
-          ...(await _getContext(request)),
-          ...buildErrorSummary(errors)
-        })
-        .code(400)
-    }
-
-    RedisService.set(request, RedisKeys.OWNER_ADDRESS, payload.address)
-
-    return h.redirect(Paths.CHECK_YOUR_ANSWERS)
-  }
-}
-
-const _getContext = async request => {
-  const addresses = JSON.parse(
-    await RedisService.get(request, RedisKeys.ADDRESS_FIND)
-  )
-
-  const items = addresses.map(item => {
-    return {
-      value: item.Address.AddressLine,
-      text: item.Address.AddressLine
-    }
-  })
-
-  return {
-    title: 'Choose your address',
-    addresses: items
-  }
-}
-
-const _validateForm = payload => {
-  const errors = []
-
-  if (Validators.empty(payload.address)) {
-    errors.push({
-      name: 'address',
-      text: 'You must choose an address'
-    })
-  }
-
-  return errors
-}
+const { Paths } = require('../../../utils/constants')
+const { get, post } = require('../../common/address-choose.route')
 
 module.exports = [
   {
     method: 'GET',
     path: `${Paths.OWNER_ADDRESS_CHOOSE}`,
-    handler: handlers.get
+    handler: get
   },
   {
     method: 'POST',
     path: `${Paths.OWNER_ADDRESS_CHOOSE}`,
-    handler: handlers.post
+    handler: post
   }
 ]

--- a/server/routes/user-details/owner/address-confirm.route.js
+++ b/server/routes/user-details/owner/address-confirm.route.js
@@ -1,48 +1,17 @@
 'use strict'
 
-const { Paths, RedisKeys, Views } = require('../../../utils/constants')
-const RedisService = require('../../../services/redis.service')
-
-const handlers = {
-  get: async (request, h) => {
-    return h.view(Views.ADDRESS_CONFIRM, {
-      ...(await _getContext(request))
-    })
-  },
-
-  post: async (request, h) => {
-    const context = await _getContext(request)
-
-    RedisService.set(
-      request,
-      RedisKeys.OWNER_ADDRESS,
-      context.address.AddressLine
-    )
-
-    return h.redirect(Paths.CHECK_YOUR_ANSWERS)
-  }
-}
-
-const _getContext = async request => {
-  const addresses = JSON.parse(
-    await RedisService.get(request, RedisKeys.ADDRESS_FIND)
-  )
-
-  return {
-    pageHeading: 'Confirm your address',
-    address: addresses[0].Address
-  }
-}
+const { Paths } = require('../../../utils/constants')
+const { get, post } = require('../../common/address-confirm.route')
 
 module.exports = [
   {
     method: 'GET',
     path: `${Paths.OWNER_ADDRESS_CONFIRM}`,
-    handler: handlers.get
+    handler: get
   },
   {
     method: 'POST',
     path: `${Paths.OWNER_ADDRESS_CONFIRM}`,
-    handler: handlers.post
+    handler: post
   }
 ]

--- a/server/routes/user-details/owner/address-enter.route.js
+++ b/server/routes/user-details/owner/address-enter.route.js
@@ -1,142 +1,17 @@
 'use strict'
 
-const { Paths, RedisKeys, Views } = require('../../../utils/constants')
-const RedisService = require('../../../services/redis.service')
-const { buildErrorSummary, Validators } = require('../../../utils/validation')
-const {
-  addPayloadToContext,
-  convertToTitleCase
-} = require('../../../utils/general')
-
-const handlers = {
-  get: async (request, h) => {
-    return h.view(Views.ADDRESS_ENTER, {
-      ...(await _getContext(request, true))
-    })
-  },
-
-  post: async (request, h) => {
-    const payload = request.payload
-    const errors = _validateForm(payload)
-
-    if (errors.length) {
-      return h
-        .view(Views.ADDRESS_ENTER, {
-          ...(await _getContext(request, false)),
-          ...buildErrorSummary(errors)
-        })
-        .code(400)
-    }
-
-    _updateAddressFieldCasing(payload)
-    const address = _concatenateAddressFields(payload)
-
-    RedisService.set(request, RedisKeys.OWNER_ADDRESS, address)
-
-    return h.redirect(Paths.CHECK_YOUR_ANSWERS)
-  }
-}
-
-const _getContext = async (request, isGet) => {
-  const context = {}
-
-  const addresses = JSON.parse(
-    await RedisService.get(request, RedisKeys.ADDRESS_FIND)
-  )
-
-  const resultSize = addresses.length
-
-  if (resultSize === 0) {
-    context.title = 'No results, you will need to enter the address'
-  } else if (resultSize === 1) {
-    context.title = 'Edit your address'
-    if (isGet) {
-      Object.assign(context, _getAddressFieldsFromAddress(addresses[0].Address))
-    }
-  } else if (resultSize > 1 && resultSize <= 50) {
-    context.title = 'Enter your address'
-  } else if (resultSize > 50) {
-    context.title = 'Too many results, you will need to enter the address'
-  }
-
-  context.helpText =
-    'If your business owns the item, give your business address.'
-
-  addPayloadToContext(request, context)
-
-  return context
-}
-
-const _validateForm = payload => {
-  const errors = []
-
-  if (Validators.empty(payload.addressLine1)) {
-    errors.push({
-      name: 'addressLine1',
-      text: 'Enter the building and street information'
-    })
-  }
-
-  if (Validators.empty(payload.townOrCity)) {
-    errors.push({
-      name: 'townOrCity',
-      text: 'Enter a town or city'
-    })
-  }
-
-  if (Validators.empty(payload.postcode)) {
-    errors.push({
-      name: 'postcode',
-      text: 'Enter the postcode'
-    })
-  }
-
-  if (!Validators.postcode(payload.postcode)) {
-    errors.push({
-      name: 'postcode',
-      text: 'Enter a UK postcode in the correct format'
-    })
-  }
-
-  return errors
-}
-
-const _getAddressFieldsFromAddress = address => {
-  return {
-    addressLine1: address.SubBuildingName
-      ? convertToTitleCase(address.SubBuildingName)
-      : `${convertToTitleCase(address.BuildingNumber)} ${convertToTitleCase(
-          address.Street
-        )}`,
-    addressLine2: convertToTitleCase(address.Locality),
-    townOrCity: convertToTitleCase(address.Town),
-    postcode: address.Postcode
-  }
-}
-const _updateAddressFieldCasing = payload => {
-  for (const key in payload) {
-    payload[key] =
-      key === 'postcode'
-        ? payload[key].toUpperCase()
-        : convertToTitleCase(payload[key])
-  }
-}
-
-const _concatenateAddressFields = payload => {
-  return Object.keys(payload)
-    .map(key => payload[key])
-    .join(', ')
-}
+const { Paths } = require('../../../utils/constants')
+const { get, post } = require('../../common/address-enter.route')
 
 module.exports = [
   {
     method: 'GET',
     path: `${Paths.OWNER_ADDRESS_ENTER}`,
-    handler: handlers.get
+    handler: get
   },
   {
     method: 'POST',
     path: `${Paths.OWNER_ADDRESS_ENTER}`,
-    handler: handlers.post
+    handler: post
   }
 ]

--- a/server/routes/user-details/owner/contact-details.route.js
+++ b/server/routes/user-details/owner/contact-details.route.js
@@ -7,38 +7,38 @@ const { addPayloadToContext } = require('../../../utils/general')
 
 const handlers = {
   get: async (request, h) => {
-    const ownerApplicant = await RedisService.get(
+    const ownedByApplicant = await RedisService.get(
       request,
-      RedisKeys.OWNER_APPLICANT
+      RedisKeys.OWNED_BY_APPLICANT
     )
 
     return h.view(Views.CONTACT_DETAILS, {
-      title: _getTitle(ownerApplicant),
-      ownerApplicant: ownerApplicant === Options.YES
+      pageHeading: _getPageHeading(ownedByApplicant),
+      ownerApplicant: ownedByApplicant === Options.YES
     })
   },
 
   post: async (request, h) => {
-    const ownerApplicant = await RedisService.get(
+    const ownedByApplicant = await RedisService.get(
       request,
-      RedisKeys.OWNER_APPLICANT
+      RedisKeys.OWNED_BY_APPLICANT
     )
 
     const payload = request.payload
-    const errors = _validateForm(payload, ownerApplicant)
+    const errors = _validateForm(payload, ownedByApplicant)
 
     if (errors.length) {
       return h
         .view(Views.CONTACT_DETAILS, {
-          title: _getTitle(ownerApplicant),
-          ownerApplicant: ownerApplicant === Options.YES,
+          pageHeading: _getPageHeading(ownedByApplicant),
+          ownerApplicant: ownedByApplicant === Options.YES,
           ..._getContext(request),
           ...buildErrorSummary(errors)
         })
         .code(400)
     }
 
-    if (ownerApplicant === Options.YES) {
+    if (ownedByApplicant === Options.YES) {
       RedisService.set(
         request,
         RedisKeys.OWNER_NAME,
@@ -64,16 +64,12 @@ const handlers = {
       )
     }
 
-    return h.redirect(
-      ownerApplicant === Options.YES
-        ? Paths.OWNER_ADDRESS_FIND
-        : Paths.APPLICANT_DETAILS
-    )
+    return h.redirect(Paths.OWNER_ADDRESS_FIND)
   }
 }
 
-const _getTitle = ownerApplicant => {
-  return ownerApplicant === Options.YES
+const _getPageHeading = ownedByApplicant => {
+  return ownedByApplicant === Options.YES
     ? 'Your contact details'
     : "Owner's contact details"
 }
@@ -82,8 +78,8 @@ const _getContext = request => {
   return addPayloadToContext(request)
 }
 
-const _validateForm = (payload, ownerApplicant) => {
-  return ownerApplicant === Options.YES
+const _validateForm = (payload, ownedByApplicant) => {
+  return ownedByApplicant === Options.YES
     ? _validateOwnerApplicant(payload)
     : _validateApplicant(payload)
 }
@@ -167,12 +163,12 @@ const _validateApplicant = payload => {
 module.exports = [
   {
     method: 'GET',
-    path: `${Paths.OWNER_DETAILS}`,
+    path: `${Paths.OWNER_CONTACT_DETAILS}`,
     handler: handlers.get
   },
   {
     method: 'POST',
-    path: `${Paths.OWNER_DETAILS}`,
+    path: `${Paths.OWNER_CONTACT_DETAILS}`,
     handler: handlers.post
   }
 ]

--- a/server/routes/user-details/owner/contact-details.route.js
+++ b/server/routes/user-details/owner/contact-details.route.js
@@ -13,7 +13,7 @@ const handlers = {
     )
 
     return h.view(Views.CONTACT_DETAILS, {
-      pageHeading: _getPageHeading(ownedByApplicant),
+      pageTitle: _getPageHeading(ownedByApplicant),
       ownerApplicant: ownedByApplicant === Options.YES
     })
   },
@@ -30,7 +30,7 @@ const handlers = {
     if (errors.length) {
       return h
         .view(Views.CONTACT_DETAILS, {
-          pageHeading: _getPageHeading(ownedByApplicant),
+          pageTitle: _getPageHeading(ownedByApplicant),
           ownerApplicant: ownedByApplicant === Options.YES,
           ..._getContext(request),
           ...buildErrorSummary(errors)

--- a/server/routes/what-type-of-item-is-it.route.js
+++ b/server/routes/what-type-of-item-is-it.route.js
@@ -6,8 +6,11 @@ const { buildErrorSummary, Validators } = require('../utils/validation')
 
 const handlers = {
   get: async (request, h) => {
-    return h.view(Views.WHAT_TYPE_OF_ITEM_IS_IT)
+    return h.view(Views.WHAT_TYPE_OF_ITEM_IS_IT, {
+      ..._getContext()
+    })
   },
+
   post: (request, h) => {
     const payload = request.payload
     const errors = _validateForm(payload)
@@ -15,14 +18,24 @@ const handlers = {
     if (errors.length) {
       return h
         .view(Views.WHAT_TYPE_OF_ITEM_IS_IT, {
+          ..._getContext(),
           ...buildErrorSummary(errors)
         })
         .code(400)
     }
 
-    RedisService.set(request, RedisKeys.WHAT_TYPE_OF_ITEM_IS_IT, payload.whatTypeOfItemIsIt)
+    RedisService.set(
+      request,
+      RedisKeys.WHAT_TYPE_OF_ITEM_IS_IT,
+      payload.whatTypeOfItemIsIt
+    )
 
     return h.redirect(Paths.CHECK_YOUR_ANSWERS)
+  }
+}
+const _getContext = () => {
+  return {
+    pageTitle: 'What is your ivory item?'
   }
 }
 

--- a/server/routes/who-owns-the-item.route.js
+++ b/server/routes/who-owns-the-item.route.js
@@ -23,11 +23,11 @@ const handlers = {
 
     RedisService.set(
       request,
-      RedisKeys.OWNER_APPLICANT,
+      RedisKeys.OWNED_BY_APPLICANT,
       payload.whoOwnsItem === 'I own it' ? Options.YES : Options.NO
     )
 
-    return h.redirect(Paths.OWNER_DETAILS)
+    return h.redirect(Paths.OWNER_CONTACT_DETAILS)
   }
 }
 

--- a/server/routes/who-owns-the-item.route.js
+++ b/server/routes/who-owns-the-item.route.js
@@ -6,7 +6,7 @@ const { buildErrorSummary, Validators } = require('../utils/validation')
 
 const handlers = {
   get: (request, h) => {
-    return h.view(Views.WHO_OWNS_ITEM)
+    return h.view(Views.WHO_OWNS_ITEM, { pageTitle: 'Who owns the item?' })
   },
 
   post: (request, h) => {

--- a/server/services/address.service.js
+++ b/server/services/address.service.js
@@ -4,7 +4,7 @@ const https = require('https')
 const fetch = require('node-fetch')
 const { readFileSync } = require('fs')
 
-const { convertToTitleCase } = require('../utils/general')
+const { convertToCommaSeparatedTitleCase } = require('../utils/general')
 
 const config = require('../utils/config')
 
@@ -81,7 +81,9 @@ module.exports = class AddressService {
 
 const _convertResultsToTitleCase = searchResults => {
   for (const result of searchResults) {
-    result.Address.AddressLine = convertToTitleCase(result.Address.AddressLine)
+    result.Address.AddressLine = convertToCommaSeparatedTitleCase(
+      result.Address.AddressLine
+    )
 
     _convertPostcodeToUpperCase(result.Address)
   }

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -1,10 +1,23 @@
+'use strict'
+
+const AddressType = {
+  OWNER: 'owner',
+  APPLICANT: 'applicant'
+}
+
 const Options = {
   YES: 'yes',
   NO: 'no'
 }
 
 const Paths = {
-  APPLICANT_DETAILS: '/user-details/applicant/contact-details',
+  APPLICANT_ADDRESS_CHOOSE: '/user-details/applicant/address-choose',
+  APPLICANT_ADDRESS_CONFIRM: '/user-details/applicant/address-confirm',
+  APPLICANT_CONTACT_DETAILS: '/user-details/applicant/contact-details',
+  APPLICANT_ADDRESS_ENTER: '/user-details/applicant/address-enter',
+  APPLICANT_ADDRESS_FIND: '/user-details/applicant/address-find',
+  APPLICANT_ADDRESS_INTERNATIONAL:
+    '/user-details/applicant/address-international',
   CHECK_YOUR_ANSWERS: '/check-your-answers',
   IVORY_ADDED: '/ivory-added',
   IVORY_INTEGRAL: '/ivory-integral',
@@ -13,7 +26,7 @@ const Paths = {
   OWNER_ADDRESS_ENTER: '/user-details/owner/address-enter',
   OWNER_ADDRESS_FIND: '/user-details/owner/address-find',
   OWNER_ADDRESS_INTERNATIONAL: '/user-details/owner/address-international',
-  OWNER_DETAILS: '/user-details/owner/contact-details',
+  OWNER_CONTACT_DETAILS: '/user-details/owner/contact-details',
   TAKEN_FROM_ELEPHANT: '/taken-from-elephant',
   WHO_OWNS_ITEM: '/who-owns-the-item'
 }
@@ -36,18 +49,19 @@ const Views = {
 
 const RedisKeys = {
   ADDRESS_FIND: 'address-find',
+  APPLICANT_ADDRESS: 'applicant.address',
   APPLICANT_EMAIL_ADDRESS: 'applicant.emailAddress',
   APPLICANT_NAME: 'applicant.name',
   IVORY_ADDED: 'ivory-added',
   IVORY_INTEGRAL: 'ivory-integral',
-  OWNER_ADDRESS: 'owner-address',
-  OWNER_APPLICANT: 'owner-applicant',
+  OWNED_BY_APPLICANT: 'owned-by-applicant',
+  OWNER_ADDRESS: 'owner.address',
   OWNER_EMAIL_ADDRESS: 'owner.emailAddress',
-  OWNER_NAME: 'owner.name',
-  OWNER_INTERNATIONAL_ADDRESS: 'owner.internationalAddress'
+  OWNER_NAME: 'owner.name'
 }
 
 module.exports = Object.freeze({
+  AddressType,
   Options,
   Paths,
   Views,

--- a/server/utils/general.js
+++ b/server/utils/general.js
@@ -10,8 +10,9 @@ const addPayloadToContext = (request, context = {}) => {
   return context
 }
 
-const convertToTitleCase = value => {
+const convertToCommaSeparatedTitleCase = value => {
   if (value) {
+    value = value.replace(/(\r\n|\r|\n)/g, ', ')
     let words = value.split(' ')
     words = words.map(word => {
       word = word.toLowerCase()
@@ -25,5 +26,5 @@ const convertToTitleCase = value => {
 
 module.exports = {
   addPayloadToContext,
-  convertToTitleCase
+  convertToCommaSeparatedTitleCase
 }

--- a/server/views/404.html
+++ b/server/views/404.html
@@ -5,7 +5,7 @@
     <div class="govuk-main-wrapper">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <h1 id="pageHeading" class="govuk-heading-xl">Page not found</h1>
+          <h1 id="pageTitle" class="govuk-heading-xl">Page not found</h1>
           <p id="para1" class="govuk-body">We have reported this to the team that manages the service and they will fix it as soon as possible.</p>
           <p id="para2" class="govuk-body">Contact us if you need to speak to someone.</p>
           <p id="para3" class="govuk-body">Telephone:

--- a/server/views/500.html
+++ b/server/views/500.html
@@ -5,7 +5,7 @@
     <div class="govuk-main-wrapper">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <h1 id="pageHeading" class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+          <h1 id="pageTitle" class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
           <p id="try-again-later" class="govuk-body">Try again later.</p>
         </div>
       </div>

--- a/server/views/check-your-answers.html
+++ b/server/views/check-your-answers.html
@@ -66,7 +66,8 @@
                 }
               ]
             }
-          },{
+          },
+          {
             key: {
               text: "Owner address"
             },
@@ -96,6 +97,23 @@
                   href: "who-owns-the-item",
                   text: "Change",
                   visuallyHiddenText: "who is applying"
+                }
+              ]
+            }
+          },
+          {
+            key: {
+              text: "Applicant address"
+            },
+            value: {
+              text: applicantAddress
+            },
+            actions: {
+              items: [
+                {
+                  href: "who-owns-the-item",
+                  text: "Change",
+                  visuallyHiddenText: "applicant address"
                 }
               ]
             }

--- a/server/views/check-your-answers.html
+++ b/server/views/check-your-answers.html
@@ -11,14 +11,14 @@
 
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 id="pageHeading" class="govuk-heading-l">Check your answers (incomplete)</h1>
+      <h1 id="pageTitle" class="govuk-heading-l">{{ pageTitle }}</h1>
 
       {{ govukSummaryList({
         classes: 'govuk-!-margin-bottom-9',
         rows: [
           {
             key: {
-              text: "What is your ivory item?"
+              text: pageTitle
             },
             value: {
               text: whatTypeOfItemIsIt

--- a/server/views/layout.html
+++ b/server/views/layout.html
@@ -57,7 +57,7 @@
 {% endblock %}
 
 {% block content %}
-  <h1 id="pageHeading" class="govuk-heading-xl">Default page template</h1>
+  <h1 id="pageTitle" class="govuk-heading-xl">Default page template</h1>
 {% endblock %}
 
 {% block bodyEnd %}

--- a/server/views/user-details/address-choose.html
+++ b/server/views/user-details/address-choose.html
@@ -14,7 +14,7 @@
         name: "address",
         fieldset: {
           legend: {
-            text: pageHeading,
+            text: pageTitle,
             isPageHeading: true,
             classes: "govuk-fieldset__legend--l"
           }

--- a/server/views/user-details/address-choose.html
+++ b/server/views/user-details/address-choose.html
@@ -14,7 +14,7 @@
         name: "address",
         fieldset: {
           legend: {
-            text: title,
+            text: pageHeading,
             isPageHeading: true,
             classes: "govuk-fieldset__legend--l"
           }

--- a/server/views/user-details/address-confirm.html
+++ b/server/views/user-details/address-confirm.html
@@ -6,7 +6,7 @@
   <div class="govuk-grid-row">
 
     <div class="govuk-grid-column-two-thirds">
-      <h1 id="pageHeading" class="govuk-heading-l">{{ pageHeading }}</h1>
+      <h1 id="pageTitle" class="govuk-heading-l">{{ pageTitle }}</h1>
 
       <p id="address" class="govuk-body">{{ address.AddressLine }}</p>
 

--- a/server/views/user-details/address-enter.html
+++ b/server/views/user-details/address-enter.html
@@ -12,10 +12,10 @@
 
         {% call govukFieldset({
             attributes: {
-              id: "pageHeading"
+              id: "pageTitle"
             },
             legend: {
-              text: pageHeading,
+              text: pageTitle,
               classes: "govuk-fieldset__legend--l",
               isPageHeading: true
             }

--- a/server/views/user-details/address-enter.html
+++ b/server/views/user-details/address-enter.html
@@ -15,7 +15,7 @@
               id: "pageHeading"
             },
             legend: {
-              text: title,
+              text: pageHeading,
               classes: "govuk-fieldset__legend--l",
               isPageHeading: true
             }

--- a/server/views/user-details/address-find.html
+++ b/server/views/user-details/address-find.html
@@ -15,7 +15,7 @@
                 id: "pageHeading"
               },
               legend: {
-                text: title,
+                text: pageHeading,
                 classes: "govuk-fieldset__legend--l",
                 isPageHeading: true
               }

--- a/server/views/user-details/address-find.html
+++ b/server/views/user-details/address-find.html
@@ -12,10 +12,10 @@
 
           {% call govukFieldset({
               attributes: {
-                id: "pageHeading"
+                id: "pageTitle"
               },
               legend: {
-                text: pageHeading,
+                text: pageTitle,
                 classes: "govuk-fieldset__legend--l",
                 isPageHeading: true
               }

--- a/server/views/user-details/address-international.html
+++ b/server/views/user-details/address-international.html
@@ -12,7 +12,7 @@
           name: "internationalAddress",
           id: "internationalAddress",
           label: {
-            text: title,
+            text: pageHeading,
             classes: "govuk-label--l",
             isPageHeading: true,
             attributes: {

--- a/server/views/user-details/address-international.html
+++ b/server/views/user-details/address-international.html
@@ -12,11 +12,11 @@
           name: "internationalAddress",
           id: "internationalAddress",
           label: {
-            text: pageHeading,
+            text: pageTitle,
             classes: "govuk-label--l",
             isPageHeading: true,
             attributes: {
-              id: "pageHeading"
+              id: "pageTitle"
             }
           },
           value: internationalAddress,

--- a/server/views/user-details/contact-details.html
+++ b/server/views/user-details/contact-details.html
@@ -8,7 +8,7 @@
   <div class="govuk-grid-row">
 
     <div class="govuk-grid-column-two-thirds">
-      <h1 id="pageHeading" class="govuk-heading-l">{{ title }}</h1>
+      <h1 id="pageHeading" class="govuk-heading-l">{{ pageHeading }}</h1>
 
       {% if ownerApplicant %}
 

--- a/server/views/user-details/contact-details.html
+++ b/server/views/user-details/contact-details.html
@@ -8,7 +8,7 @@
   <div class="govuk-grid-row">
 
     <div class="govuk-grid-column-two-thirds">
-      <h1 id="pageHeading" class="govuk-heading-l">{{ pageHeading }}</h1>
+      <h1 id="pageTitle" class="govuk-heading-l">{{ pageTitle }}</h1>
 
       {% if ownerApplicant %}
 

--- a/server/views/who-owns-the-item.html
+++ b/server/views/who-owns-the-item.html
@@ -15,7 +15,7 @@
           name: "whoOwnsItem",
           fieldset: {
             legend: {
-              text: "Who owns the item?",
+              text: pageTitle,
               isPageHeading: true,
               classes: "govuk-fieldset__legend--l"
             }

--- a/server/views/yes-no-idk.html
+++ b/server/views/yes-no-idk.html
@@ -14,7 +14,7 @@
         name: "yesNoIdk",
         fieldset: {
           legend: {
-            text: title,
+            text: pageHeading,
             isPageHeading: true,
             classes: "govuk-fieldset__legend--l"
           }

--- a/server/views/yes-no-idk.html
+++ b/server/views/yes-no-idk.html
@@ -14,7 +14,7 @@
         name: "yesNoIdk",
         fieldset: {
           legend: {
-            text: pageHeading,
+            text: pageTitle,
             isPageHeading: true,
             classes: "govuk-fieldset__legend--l"
           }

--- a/test/routes/applicant/address-choose.route.test.js
+++ b/test/routes/applicant/address-choose.route.test.js
@@ -22,7 +22,7 @@ describe('/user-details/applicant/address-choose route', () => {
   const nextUrlCheckYourAnswers = '/check-your-answers'
 
   const elementIds = {
-    pageHeading: 'pageHeading',
+    pageTitle: 'pageTitle',
     address: 'address',
     address2: 'address-2',
     address3: 'address-3',

--- a/test/routes/applicant/address-choose.route.test.js
+++ b/test/routes/applicant/address-choose.route.test.js
@@ -1,0 +1,189 @@
+'use strict'
+
+const createServer = require('../../../server')
+
+const TestHelper = require('../../utils/test-helper')
+const { ServerEvents } = require('../../../server/utils/constants')
+
+jest.mock('../../../server/services/redis.service')
+const RedisService = require('../../../server/services/redis.service')
+
+jest.mock('../../../server/services/address.service')
+const AddressService = require('../../../server/services/address.service')
+
+const {
+  singleAddress,
+  multipleAddresses
+} = require('../../mock-data/addresses')
+
+describe('/user-details/applicant/address-choose route', () => {
+  let server
+  const url = '/user-details/applicant/address-choose'
+  const nextUrlCheckYourAnswers = '/check-your-answers'
+
+  const elementIds = {
+    pageHeading: 'pageHeading',
+    address: 'address',
+    address2: 'address-2',
+    address3: 'address-3',
+    addressNotOnList: 'addressNotOnList',
+    continue: 'continue'
+  }
+
+  let document
+
+  beforeAll(async done => {
+    server = await createServer()
+    server.events.on(ServerEvents.PLUGINS_LOADED, () => {
+      done()
+    })
+  })
+
+  afterAll(() => {
+    server.stop()
+  })
+
+  beforeEach(() => {
+    _createMocks()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GET', () => {
+    const getOptions = {
+      method: 'GET',
+      url
+    }
+
+    beforeEach(async () => {
+      RedisService.get = jest
+        .fn()
+        .mockReturnValue(JSON.stringify(multipleAddresses))
+
+      document = await TestHelper.submitGetRequest(server, getOptions)
+    })
+
+    it('should have the Beta banner', () => {
+      TestHelper.checkBetaBanner(document)
+    })
+
+    it('should have the Back link', () => {
+      TestHelper.checkBackLink(document)
+    })
+
+    it('should have the correct page heading', () => {
+      const element = document.querySelector('.govuk-fieldset__heading')
+      expect(element).toBeTruthy()
+      expect(TestHelper.getTextContent(element)).toEqual('Choose your address')
+    })
+
+    it('should have the correct radio buttons', () => {
+      TestHelper.checkRadioOption(
+        document,
+        elementIds.address,
+        multipleAddresses[0].Address.AddressLine,
+        multipleAddresses[0].Address.AddressLine
+      )
+      TestHelper.checkRadioOption(
+        document,
+        elementIds.address2,
+        multipleAddresses[1].Address.AddressLine,
+        multipleAddresses[1].Address.AddressLine
+      )
+      TestHelper.checkRadioOption(
+        document,
+        elementIds.address3,
+        multipleAddresses[2].Address.AddressLine,
+        multipleAddresses[2].Address.AddressLine
+      )
+    })
+
+    it('should have the correct "Address not on the list" link', () => {
+      const element = document.querySelector(`#${elementIds.addressNotOnList}`)
+      expect(element).toBeTruthy()
+      expect(TestHelper.getTextContent(element)).toEqual(
+        'The address is not on the list'
+      )
+      expect(element.href).toEqual('address-enter')
+    })
+
+    it('should have the correct Call to Action button', () => {
+      const element = document.querySelector(`#${elementIds.continue}`)
+      expect(element).toBeTruthy()
+      expect(TestHelper.getTextContent(element)).toEqual('Continue')
+    })
+  })
+
+  describe('POST', () => {
+    const redisKey = 'applicant.address'
+    let postOptions
+
+    beforeEach(() => {
+      postOptions = {
+        method: 'POST',
+        url,
+        payload: {}
+      }
+    })
+
+    describe('Success', () => {
+      beforeEach(() => {
+        RedisService.get = jest
+          .fn()
+          .mockReturnValueOnce('no')
+          .mockReturnValueOnce(JSON.stringify(singleAddress))
+      })
+
+      it('should store the selected address in Redis and progress to the next route when the user selects an address', async () => {
+        AddressService.addressSearch = jest.fn().mockReturnValue(singleAddress)
+        postOptions.payload = {
+          address: singleAddress[0].Address.AddressLine
+        }
+
+        expect(RedisService.set).toBeCalledTimes(0)
+
+        const response = await TestHelper.submitPostRequest(
+          server,
+          postOptions,
+          302
+        )
+
+        expect(RedisService.set).toBeCalledTimes(1)
+        expect(RedisService.set).toBeCalledWith(
+          expect.any(Object),
+          redisKey,
+          singleAddress[0].Address.AddressLine
+        )
+
+        expect(response.headers.location).toEqual(nextUrlCheckYourAnswers)
+      })
+    })
+
+    describe('Failure', () => {
+      beforeEach(() => {
+        RedisService.get = jest
+          .fn()
+          .mockReturnValueOnce('yes')
+          .mockReturnValueOnce(JSON.stringify(singleAddress))
+      })
+
+      it('should display a validation error message if the user does not select an address', async () => {
+        postOptions.payload = {
+          address: ''
+        }
+        await TestHelper.checkFormFieldValidation(
+          postOptions,
+          server,
+          elementIds.address,
+          'You must choose an address'
+        )
+      })
+    })
+  })
+})
+
+const _createMocks = () => {
+  RedisService.set = jest.fn()
+}

--- a/test/routes/applicant/address-confirm.route.test.js
+++ b/test/routes/applicant/address-confirm.route.test.js
@@ -19,7 +19,7 @@ describe('/user-details/applicant/address-confirm route', () => {
   const nextUrlCheckYourAnswers = '/check-your-answers'
 
   const elementIds = {
-    pageHeading: 'pageHeading',
+    pageTitle: 'pageTitle',
     address: 'address',
     editTheAddress: 'editTheAddress',
     confirmAndContinue: 'confirmAndContinue'
@@ -71,7 +71,7 @@ describe('/user-details/applicant/address-confirm route', () => {
       })
 
       it('should have the correct page heading', () => {
-        const element = document.querySelector(`#${elementIds.pageHeading}`)
+        const element = document.querySelector(`#${elementIds.pageTitle}`)
         expect(element).toBeTruthy()
         expect(TestHelper.getTextContent(element)).toEqual(
           'Confirm your address'

--- a/test/routes/applicant/address-confirm.route.test.js
+++ b/test/routes/applicant/address-confirm.route.test.js
@@ -13,11 +13,9 @@ const AddressService = require('../../../server/services/address.service')
 
 const { singleAddress } = require('../../mock-data/addresses')
 
-describe('/user-details/owner/address-confirm route', () => {
+describe('/user-details/applicant/address-confirm route', () => {
   let server
-  const url = '/user-details/owner/address-confirm'
-  const nextUrlApplicantContactDetails =
-    '/user-details/applicant/contact-details'
+  const url = '/user-details/applicant/address-confirm'
   const nextUrlCheckYourAnswers = '/check-your-answers'
 
   const elementIds = {
@@ -54,11 +52,11 @@ describe('/user-details/owner/address-confirm route', () => {
       url
     }
 
-    describe('GET: Owned by applicant', () => {
+    describe('GET', () => {
       beforeEach(async () => {
         RedisService.get = jest
           .fn()
-          .mockReturnValueOnce('yes')
+          .mockReturnValueOnce('no')
           .mockReturnValueOnce(JSON.stringify(singleAddress))
 
         document = await TestHelper.submitGetRequest(server, getOptions)
@@ -105,63 +103,10 @@ describe('/user-details/owner/address-confirm route', () => {
         )
       })
     })
-
-    describe('GET: Not owned by applicant', () => {
-      beforeEach(async () => {
-        RedisService.get = jest
-          .fn()
-          .mockReturnValueOnce('no')
-          .mockReturnValueOnce(JSON.stringify(singleAddress))
-
-        document = await TestHelper.submitGetRequest(server, getOptions)
-      })
-
-      it('should have the Beta banner', () => {
-        TestHelper.checkBetaBanner(document)
-      })
-
-      it('should have the Back link', () => {
-        TestHelper.checkBackLink(document)
-      })
-
-      it('should have the correct page heading', () => {
-        const element = document.querySelector(`#${elementIds.pageHeading}`)
-        expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual(
-          "Confirm the owner's address"
-        )
-      })
-
-      it('should show the selected address', () => {
-        const element = document.querySelector(`#${elementIds.address}`)
-        expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual(
-          singleAddress[0].Address.AddressLine
-        )
-      })
-
-      it('should have the correct "Edit the address" link', () => {
-        const element = document.querySelector(`#${elementIds.editTheAddress}`)
-        expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual('Edit the address')
-        expect(element.href).toEqual('/user-details/owner/address-enter')
-      })
-
-      it('should have the correct Call to Action button', () => {
-        const element = document.querySelector(
-          `#${elementIds.confirmAndContinue}`
-        )
-        expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual(
-          'Confirm and continue'
-        )
-      })
-    })
   })
 
   describe('POST', () => {
     let postOptions
-    const redisKeyOwnerAddress = 'owner.address'
     const redisKeyApplicantAddress = 'applicant.address'
 
     beforeEach(() => {
@@ -172,45 +117,7 @@ describe('/user-details/owner/address-confirm route', () => {
       }
     })
 
-    describe('Success: Owned by applicant', () => {
-      beforeEach(async () => {
-        RedisService.get = jest
-          .fn()
-          .mockReturnValueOnce('yes')
-          .mockReturnValueOnce(JSON.stringify(singleAddress))
-          .mockReturnValueOnce('yes')
-      })
-
-      it('should store the selected address in Redis and progress to the next route when the user selects an address', async () => {
-        AddressService.addressSearch = jest.fn().mockReturnValue(singleAddress)
-        postOptions.payload = {
-          address: singleAddress[0].Address.AddressLine
-        }
-
-        expect(RedisService.set).toBeCalledTimes(0)
-
-        const response = await TestHelper.submitPostRequest(
-          server,
-          postOptions,
-          302
-        )
-
-        expect(RedisService.set).toBeCalledTimes(2)
-        expect(RedisService.set).toBeCalledWith(
-          expect.any(Object),
-          redisKeyOwnerAddress,
-          singleAddress[0].Address.AddressLine
-        )
-        expect(RedisService.set).toBeCalledWith(
-          expect.any(Object),
-          redisKeyApplicantAddress,
-          singleAddress[0].Address.AddressLine
-        )
-        expect(response.headers.location).toEqual(nextUrlCheckYourAnswers)
-      })
-    })
-
-    describe('Success: Not owned by applicant', () => {
+    describe('Success', () => {
       beforeEach(async () => {
         RedisService.get = jest
           .fn()
@@ -236,12 +143,10 @@ describe('/user-details/owner/address-confirm route', () => {
         expect(RedisService.set).toBeCalledTimes(1)
         expect(RedisService.set).toBeCalledWith(
           expect.any(Object),
-          redisKeyOwnerAddress,
+          redisKeyApplicantAddress,
           singleAddress[0].Address.AddressLine
         )
-        expect(response.headers.location).toEqual(
-          nextUrlApplicantContactDetails
-        )
+        expect(response.headers.location).toEqual(nextUrlCheckYourAnswers)
       })
     })
   })

--- a/test/routes/applicant/address-enter.route.test.js
+++ b/test/routes/applicant/address-enter.route.test.js
@@ -1,0 +1,389 @@
+'use strict'
+
+const createServer = require('../../../server')
+
+const TestHelper = require('../../utils/test-helper')
+const { ServerEvents } = require('../../../server/utils/constants')
+
+jest.mock('../../../server/services/redis.service')
+const RedisService = require('../../../server/services/redis.service')
+
+const {
+  singleAddress,
+  multipleAddresses
+} = require('../../mock-data/addresses')
+
+const elementIds = {
+  pageHeading: 'pageHeading',
+  helpText: 'helpText',
+  addressLine1: 'addressLine1',
+  addressLine2: 'addressLine2',
+  townOrCity: 'townOrCity',
+  postcode: 'postcode',
+  continue: 'continue'
+}
+
+describe('/user-details/applicant/address-enter route', () => {
+  let server
+  const url = '/user-details/applicant/address-enter'
+  const nextUrlCheckYourAnswers = '/check-your-answers'
+
+  let document
+
+  beforeAll(async done => {
+    server = await createServer()
+    server.events.on(ServerEvents.PLUGINS_LOADED, () => {
+      done()
+    })
+  })
+
+  afterAll(() => {
+    server.stop()
+  })
+
+  beforeEach(() => {
+    _createMocks()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GET: Enter or Edit address', () => {
+    const getOptions = {
+      method: 'GET',
+      url
+    }
+
+    describe('GET: All page modes', () => {
+      beforeEach(async () => {
+        RedisService.get = jest
+          .fn()
+          .mockReturnValue(JSON.stringify(singleAddress))
+
+        document = await TestHelper.submitGetRequest(server, getOptions)
+      })
+
+      it('should have the Beta banner', () => {
+        TestHelper.checkBetaBanner(document)
+      })
+
+      it('should have the Back link', () => {
+        TestHelper.checkBackLink(document)
+      })
+
+      it('should have the correct Call to Action button', () => {
+        const element = document.querySelector(`#${elementIds.continue}`)
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual('Continue')
+      })
+    })
+
+    describe('GET: No address mode', () => {
+      beforeEach(async () => {
+        RedisService.get = jest
+          .fn()
+          .mockReturnValueOnce('no')
+          .mockReturnValueOnce(JSON.stringify([]))
+
+        document = await TestHelper.submitGetRequest(server, getOptions)
+      })
+
+      it('should have the correct page heading for no addresses returned', () => {
+        const element = document.querySelector(
+          `#${elementIds.pageHeading} > legend > h1`
+        )
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          'No results, you will need to enter the address'
+        )
+      })
+
+      it('should have the correct help text for no addresses returned', () => {
+        const element = document.querySelector(`#${elementIds.helpText}`)
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          'If your business is helping someone else sell their item, give your business address.'
+        )
+      })
+
+      it('should have the correct form fields that are NOT be pre-populated with test data', () => {
+        _checkFormFields(document, {
+          addressLine1: '',
+          addressLine2: '',
+          townOrCity: '',
+          postcode: ''
+        })
+      })
+    })
+
+    describe('GET: Single address mode', () => {
+      beforeEach(async () => {
+        RedisService.get = jest
+          .fn()
+          .mockReturnValueOnce('no')
+          .mockReturnValueOnce(JSON.stringify(singleAddress))
+
+        document = await TestHelper.submitGetRequest(server, getOptions)
+      })
+
+      it('should have the correct page heading for 1 address returned', () => {
+        const element = document.querySelector(
+          `#${elementIds.pageHeading} > legend > h1`
+        )
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual('Edit your address')
+      })
+
+      it('should have the correct help text for 1 address returned', () => {
+        const element = document.querySelector(`#${elementIds.helpText}`)
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          'If your business is helping someone else sell their item, give your business address.'
+        )
+      })
+
+      it('should have the correct form fields that are NOT be pre-populated with test data', () => {
+        _checkFormFields(document, {
+          addressLine1: 'Buckingham Palace',
+          addressLine2: 'Westminster',
+          townOrCity: 'London',
+          postcode: 'SW1A 1AA'
+        })
+      })
+    })
+
+    describe('GET: Multiple address mode', () => {
+      beforeEach(async () => {
+        RedisService.get = jest
+          .fn()
+          .mockReturnValueOnce('no')
+          .mockReturnValueOnce(JSON.stringify(multipleAddresses))
+
+        document = await TestHelper.submitGetRequest(server, getOptions)
+      })
+
+      it('should have the correct page heading for multiple addresses returned', () => {
+        const element = document.querySelector(
+          `#${elementIds.pageHeading} > legend > h1`
+        )
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual('Enter your address')
+      })
+
+      it('should have the correct help text for multiple addresses returned', () => {
+        const element = document.querySelector(`#${elementIds.helpText}`)
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          'If your business is helping someone else sell their item, give your business address.'
+        )
+      })
+
+      it('should have the correct form fields that are NOT be pre-populated with test data', () => {
+        _checkFormFields(document, {
+          addressLine1: '',
+          addressLine2: '',
+          townOrCity: '',
+          postcode: ''
+        })
+      })
+    })
+
+    describe('GET: Too many addresses mode', () => {
+      const maxAddressCount = 51
+      const addresses = []
+
+      beforeEach(async () => {
+        for (let i = 0; i < maxAddressCount; i++) {
+          addresses.push(singleAddress)
+        }
+
+        RedisService.get = jest
+          .fn()
+          .mockReturnValueOnce('no')
+          .mockReturnValueOnce(JSON.stringify(addresses))
+
+        document = await TestHelper.submitGetRequest(server, getOptions)
+      })
+
+      it('should have the correct page heading for too many addresses returned', () => {
+        const element = document.querySelector(
+          `#${elementIds.pageHeading} > legend > h1`
+        )
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          'Too many results, you will need to enter the address'
+        )
+      })
+
+      it('should have the correct help text for too many addresses returned', () => {
+        const element = document.querySelector(`#${elementIds.helpText}`)
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          'If your business is helping someone else sell their item, give your business address.'
+        )
+      })
+
+      it('should have the correct form fields that are NOT be pre-populated with test data', () => {
+        _checkFormFields(document, {
+          addressLine1: '',
+          addressLine2: '',
+          townOrCity: '',
+          postcode: ''
+        })
+      })
+    })
+  })
+
+  describe('POST', () => {
+    let postOptions
+    const redisKeyApplicantAddress = 'applicant.address'
+
+    beforeEach(async () => {
+      postOptions = {
+        method: 'POST',
+        url,
+        payload: {}
+      }
+    })
+
+    describe('Success', () => {
+      beforeEach(async () => {
+        RedisService.get = jest
+          .fn()
+          .mockReturnValueOnce('no')
+          .mockReturnValueOnce(JSON.stringify(singleAddress))
+          .mockReturnValueOnce('no')
+      })
+
+      it('should store the selected address in Redis and progress to the next route when the user selects an address', async () => {
+        postOptions.payload = {
+          addressLine1: 'A Big House',
+          townOrCity: 'London',
+          postcode: 'SW1A 1AA'
+        }
+
+        expect(RedisService.set).toBeCalledTimes(0)
+
+        const response = await TestHelper.submitPostRequest(
+          server,
+          postOptions,
+          302
+        )
+
+        expect(RedisService.set).toBeCalledTimes(1)
+        expect(RedisService.set).toBeCalledWith(
+          expect.any(Object),
+          redisKeyApplicantAddress,
+          'A Big House, London, SW1A 1AA'
+        )
+
+        expect(response.headers.location).toEqual(nextUrlCheckYourAnswers)
+      })
+    })
+
+    describe('Failure', () => {
+      beforeEach(async () => {
+        RedisService.get = jest
+          .fn()
+          .mockReturnValueOnce('no')
+          .mockReturnValueOnce(JSON.stringify(singleAddress))
+          .mockReturnValueOnce('no')
+      })
+
+      it('should display a validation error message if the user does not enter address line 1', async () => {
+        postOptions.payload = {
+          addressLine1: '',
+          townOrCity: 'London',
+          postcode: 'SW1A 1AA'
+        }
+        await TestHelper.checkFormFieldValidation(
+          postOptions,
+          server,
+          elementIds.addressLine1,
+          'Enter the building and street information'
+        )
+      })
+
+      it('should display a validation error message if the user does not enter a town or city', async () => {
+        postOptions.payload = {
+          addressLine1: 'The Big House',
+          townOrCity: '',
+          postcode: 'SW1A 1AA'
+        }
+        await TestHelper.checkFormFieldValidation(
+          postOptions,
+          server,
+          elementIds.townOrCity,
+          'Enter a town or city'
+        )
+      })
+
+      it('should display a validation error message if the user does not enter the postcode', async () => {
+        postOptions.payload = {
+          addressLine1: '1 The Big House',
+          townOrCity: 'London',
+          postcode: ''
+        }
+        await TestHelper.checkFormFieldValidation(
+          postOptions,
+          server,
+          elementIds.postcode,
+          'Enter the postcode'
+        )
+      })
+
+      it('should display a validation error message if the user enters a postcode in an invalid format', async () => {
+        postOptions.payload = {
+          addressLine1: '1 The Big House',
+          townOrCity: 'London',
+          postcode: 'INVALID_FORMAT'
+        }
+        await TestHelper.checkFormFieldValidation(
+          postOptions,
+          server,
+          elementIds.postcode,
+          'Enter a UK postcode in the correct format'
+        )
+      })
+    })
+  })
+})
+
+const _checkFormFields = (document, expectedValues) => {
+  TestHelper.checkFormField(
+    document,
+    elementIds.addressLine1,
+    'Building and street line 1 of 2',
+    null,
+    expectedValues.addressLine1
+  )
+
+  TestHelper.checkFormField(
+    document,
+    elementIds.addressLine2,
+    'Building and street line 2 of 2',
+    null,
+    expectedValues.addressLine2
+  )
+
+  TestHelper.checkFormField(
+    document,
+    elementIds.townOrCity,
+    'Town or city',
+    null,
+    expectedValues.townOrCity
+  )
+
+  TestHelper.checkFormField(
+    document,
+    elementIds.postcode,
+    'Postcode',
+    null,
+    expectedValues.postcode
+  )
+}
+
+const _createMocks = () => {
+  RedisService.set = jest.fn()
+}

--- a/test/routes/applicant/address-enter.route.test.js
+++ b/test/routes/applicant/address-enter.route.test.js
@@ -14,7 +14,7 @@ const {
 } = require('../../mock-data/addresses')
 
 const elementIds = {
-  pageHeading: 'pageHeading',
+  pageTitle: 'pageTitle',
   helpText: 'helpText',
   addressLine1: 'addressLine1',
   addressLine2: 'addressLine2',
@@ -91,7 +91,7 @@ describe('/user-details/applicant/address-enter route', () => {
 
       it('should have the correct page heading for no addresses returned', () => {
         const element = document.querySelector(
-          `#${elementIds.pageHeading} > legend > h1`
+          `#${elementIds.pageTitle} > legend > h1`
         )
         expect(element).toBeTruthy()
         expect(TestHelper.getTextContent(element)).toEqual(
@@ -129,7 +129,7 @@ describe('/user-details/applicant/address-enter route', () => {
 
       it('should have the correct page heading for 1 address returned', () => {
         const element = document.querySelector(
-          `#${elementIds.pageHeading} > legend > h1`
+          `#${elementIds.pageTitle} > legend > h1`
         )
         expect(element).toBeTruthy()
         expect(TestHelper.getTextContent(element)).toEqual('Edit your address')
@@ -165,7 +165,7 @@ describe('/user-details/applicant/address-enter route', () => {
 
       it('should have the correct page heading for multiple addresses returned', () => {
         const element = document.querySelector(
-          `#${elementIds.pageHeading} > legend > h1`
+          `#${elementIds.pageTitle} > legend > h1`
         )
         expect(element).toBeTruthy()
         expect(TestHelper.getTextContent(element)).toEqual('Enter your address')
@@ -208,7 +208,7 @@ describe('/user-details/applicant/address-enter route', () => {
 
       it('should have the correct page heading for too many addresses returned', () => {
         const element = document.querySelector(
-          `#${elementIds.pageHeading} > legend > h1`
+          `#${elementIds.pageTitle} > legend > h1`
         )
         expect(element).toBeTruthy()
         expect(TestHelper.getTextContent(element)).toEqual(

--- a/test/routes/applicant/address-find.route.test.js
+++ b/test/routes/applicant/address-find.route.test.js
@@ -16,12 +16,12 @@ const {
   multipleAddresses
 } = require('../../mock-data/addresses')
 
-describe('/user-details/owner/address-find route', () => {
+describe('/user-details/applicant/address-find route', () => {
   let server
-  const url = '/user-details/owner/address-find'
-  const nextUrlEnterAddress = '/user-details/owner/address-enter'
-  const nextUrlSingleAddress = '/user-details/owner/address-confirm'
-  const nextUrlMultipleAddresses = '/user-details/owner/address-choose'
+  const url = '/user-details/applicant/address-find'
+  const nextUrlEnterAddress = '/user-details/applicant/address-enter'
+  const nextUrlSingleAddress = '/user-details/applicant/address-confirm'
+  const nextUrlMultipleAddresses = '/user-details/applicant/address-choose'
 
   const elementIds = {
     pageHeading: 'pageHeading',
@@ -53,7 +53,7 @@ describe('/user-details/owner/address-find route', () => {
     jest.clearAllMocks()
   })
 
-  describe('GET: Owned by applicant', () => {
+  describe('GET', () => {
     const getOptions = {
       method: 'GET',
       url
@@ -87,74 +87,7 @@ describe('/user-details/owner/address-find route', () => {
       const element = document.querySelector(`#${elementIds.helpText}`)
       expect(element).toBeTruthy()
       expect(TestHelper.getTextContent(element)).toEqual(
-        'If your business is the legal owner of the item, give your business address.'
-      )
-    })
-
-    it('should have the "Name or Number" form field', () => {
-      TestHelper.checkFormField(
-        document,
-        elementIds.nameOrNumber,
-        'Property name or number',
-        'For example, The Mill, Flat A or 37b'
-      )
-    })
-
-    it('should have the "Postcode" form field', () => {
-      TestHelper.checkFormField(document, elementIds.postcode, 'Postcode')
-    })
-
-    it('should have the correct Call to Action button', () => {
-      const element = document.querySelector(`#${elementIds.findAddress}`)
-      expect(element).toBeTruthy()
-      expect(TestHelper.getTextContent(element)).toEqual('Find address')
-    })
-
-    it('should have the correct "Outside UK" link', () => {
-      const element = document.querySelector(`#${elementIds.outsideUkLink}`)
-      expect(element).toBeTruthy()
-      expect(TestHelper.getTextContent(element)).toEqual(
-        'The address is outside the UK'
-      )
-      expect(element.href).toEqual('address-international')
-    })
-  })
-
-  describe('GET: Not owned by applicant', () => {
-    const getOptions = {
-      method: 'GET',
-      url
-    }
-
-    beforeEach(async () => {
-      RedisService.get = jest.fn().mockReturnValue('no')
-
-      document = await TestHelper.submitGetRequest(server, getOptions)
-    })
-
-    it('should have the Beta banner', () => {
-      TestHelper.checkBetaBanner(document)
-    })
-
-    it('should have the Back link', () => {
-      TestHelper.checkBackLink(document)
-    })
-
-    it('should have the correct page heading', () => {
-      const element = document.querySelector(
-        `#${elementIds.pageHeading} > legend > h1`
-      )
-      expect(element).toBeTruthy()
-      expect(TestHelper.getTextContent(element)).toEqual(
-        'What is the owner’s address?'
-      )
-    })
-
-    it('should have the correct help text', () => {
-      const element = document.querySelector(`#${elementIds.helpText}`)
-      expect(element).toBeTruthy()
-      expect(TestHelper.getTextContent(element)).toEqual(
-        'If the legal owner of the item is a business, give the business address.'
+        'If your business is helping someone else sell their item, give your business address.'
       )
     })
 
@@ -298,7 +231,7 @@ describe('/user-details/owner/address-find route', () => {
       })
     })
 
-    describe('Success: Not owned by applicant', () => {
+    describe('Success', () => {
       const redisKey = 'address-find'
 
       beforeEach(() => {
@@ -398,7 +331,7 @@ describe('/user-details/owner/address-find route', () => {
       })
     })
 
-    describe('Failure: Owned by applicant', () => {
+    describe('Failure', () => {
       it('should display a validation error message if the user does not enter the postcode', async () => {
         postOptions.payload = {
           postcode: ''
@@ -407,7 +340,7 @@ describe('/user-details/owner/address-find route', () => {
           postOptions,
           server,
           elementIds.postcode,
-          'Enter your postcode'
+          "Enter the owner's postcode"
         )
       })
 

--- a/test/routes/applicant/address-find.route.test.js
+++ b/test/routes/applicant/address-find.route.test.js
@@ -24,7 +24,7 @@ describe('/user-details/applicant/address-find route', () => {
   const nextUrlMultipleAddresses = '/user-details/applicant/address-choose'
 
   const elementIds = {
-    pageHeading: 'pageHeading',
+    pageTitle: 'pageTitle',
     helpText: 'helpText',
     nameOrNumber: 'nameOrNumber',
     postcode: 'postcode',
@@ -75,7 +75,7 @@ describe('/user-details/applicant/address-find route', () => {
 
     it('should have the correct page heading', () => {
       const element = document.querySelector(
-        `#${elementIds.pageHeading} > legend > h1`
+        `#${elementIds.pageTitle} > legend > h1`
       )
       expect(element).toBeTruthy()
       expect(TestHelper.getTextContent(element)).toEqual(

--- a/test/routes/applicant/address-international.route.test.js
+++ b/test/routes/applicant/address-international.route.test.js
@@ -14,7 +14,7 @@ describe('/user-details/applicant/address-international route', () => {
   const nextUrl = '/check-your-answers'
 
   const elementIds = {
-    pageHeading: 'pageHeading',
+    pageTitle: 'pageTitle',
     helpText: 'helpText',
     internationalAddress: 'internationalAddress',
     continue: 'continue'

--- a/test/routes/applicant/address-international.route.test.js
+++ b/test/routes/applicant/address-international.route.test.js
@@ -8,11 +8,10 @@ const { ServerEvents } = require('../../../server/utils/constants')
 jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 
-describe('/user-details/owner/address-international route', () => {
+describe('/user-details/applicant/address-international route', () => {
   let server
-  const url = '/user-details/owner/address-international'
-  const nextUrlCheckYourAnswers = '/check-your-answers'
-  const nextUrlApplicantDetails = '/user-details/applicant/contact-details'
+  const url = '/user-details/applicant/address-international'
+  const nextUrl = '/check-your-answers'
 
   const elementIds = {
     pageHeading: 'pageHeading',
@@ -42,15 +41,13 @@ describe('/user-details/owner/address-international route', () => {
     jest.clearAllMocks()
   })
 
-  describe('GET: Owned by applicant', () => {
+  describe('GET', () => {
     const getOptions = {
       method: 'GET',
       url
     }
 
     beforeEach(async () => {
-      RedisService.get = jest.fn().mockReturnValue('yes')
-
       document = await TestHelper.submitGetRequest(server, getOptions)
     })
 
@@ -67,43 +64,7 @@ describe('/user-details/owner/address-international route', () => {
         document,
         elementIds.internationalAddress,
         'Enter your address',
-        'If your business owns the item, give your business address.'
-      )
-    })
-
-    it('should have the correct Call to Action button', () => {
-      const element = document.querySelector(`#${elementIds.continue}`)
-      expect(element).toBeTruthy()
-      expect(TestHelper.getTextContent(element)).toEqual('Continue')
-    })
-  })
-
-  describe('GET: Not owned by applicant', () => {
-    const getOptions = {
-      method: 'GET',
-      url
-    }
-
-    beforeEach(async () => {
-      RedisService.get = jest.fn().mockReturnValue('no')
-
-      document = await TestHelper.submitGetRequest(server, getOptions)
-    })
-
-    it('should have the Beta banner', () => {
-      TestHelper.checkBetaBanner(document)
-    })
-
-    it('should have the Back link', () => {
-      TestHelper.checkBackLink(document)
-    })
-
-    it('should have the "Enter your address" form field', () => {
-      TestHelper.checkFormField(
-        document,
-        elementIds.internationalAddress,
-        "Enter the owner's address",
-        'If the owner is a business, give the business address.'
+        'If your business is helping someone else sell their item, give your business address.'
       )
     })
 
@@ -116,7 +77,6 @@ describe('/user-details/owner/address-international route', () => {
 
   describe('POST', () => {
     let postOptions
-    const redisKeyOwnerAddress = 'owner.address'
     const redisKeyApplicantAddress = 'applicant.address'
     const internationalAddress = 'THE OWNER ADDRESS'
 
@@ -128,40 +88,7 @@ describe('/user-details/owner/address-international route', () => {
       }
     })
 
-    describe('Success: Owned by applicant', () => {
-      beforeEach(() => {
-        RedisService.get = jest.fn().mockReturnValue('yes')
-      })
-
-      it('should store the address in Redis and progress to the next route when the address is entered by the search', async () => {
-        postOptions.payload = {
-          internationalAddress
-        }
-
-        expect(RedisService.set).toBeCalledTimes(0)
-
-        const response = await TestHelper.submitPostRequest(
-          server,
-          postOptions,
-          302
-        )
-        expect(RedisService.set).toBeCalledTimes(2)
-        expect(RedisService.set).toBeCalledWith(
-          expect.any(Object),
-          redisKeyOwnerAddress,
-          'The Owner Address'
-        )
-        expect(RedisService.set).toBeCalledWith(
-          expect.any(Object),
-          redisKeyApplicantAddress,
-          'The Owner Address'
-        )
-
-        expect(response.headers.location).toEqual(nextUrlCheckYourAnswers)
-      })
-    })
-
-    describe('Success: Not owned by applicant', () => {
+    describe('Success', () => {
       beforeEach(() => {
         RedisService.get = jest.fn().mockReturnValue('no')
       })
@@ -181,11 +108,11 @@ describe('/user-details/owner/address-international route', () => {
         expect(RedisService.set).toBeCalledTimes(1)
         expect(RedisService.set).toBeCalledWith(
           expect.any(Object),
-          redisKeyOwnerAddress,
+          redisKeyApplicantAddress,
           'The Owner Address'
         )
 
-        expect(response.headers.location).toEqual(nextUrlApplicantDetails)
+        expect(response.headers.location).toEqual(nextUrl)
       })
     })
 

--- a/test/routes/ivory-added.route.test.js
+++ b/test/routes/ivory-added.route.test.js
@@ -60,7 +60,7 @@ describe('/ivory-added route', () => {
       TestHelper.checkBackLink(document)
     })
 
-    it('should have the correct page title', () => {
+    it('should have the correct page heading', () => {
       const element = document.querySelector('.govuk-fieldset__legend')
       expect(element).toBeTruthy()
       expect(TestHelper.getTextContent(element)).toEqual(

--- a/test/routes/ivory-integral.route.test.js
+++ b/test/routes/ivory-integral.route.test.js
@@ -59,7 +59,7 @@ describe('/ivory-integral route', () => {
       TestHelper.checkBackLink(document)
     })
 
-    it('should have the correct page title', () => {
+    it('should have the correct page heading', () => {
       const element = document.querySelector('.govuk-fieldset__legend')
       expect(element).toBeTruthy()
       expect(TestHelper.getTextContent(element)).toEqual(

--- a/test/routes/owner/address-choose.route.test.js
+++ b/test/routes/owner/address-choose.route.test.js
@@ -16,7 +16,7 @@ const {
   multipleAddresses
 } = require('../../mock-data/addresses')
 
-describe('/address-choose route', () => {
+describe('/user-details/owner/address-choose route', () => {
   let server
   const url = '/user-details/owner/address-choose'
   const nextUrl = '/check-your-answers'
@@ -73,7 +73,7 @@ describe('/address-choose route', () => {
       TestHelper.checkBackLink(document)
     })
 
-    it('should have the correct page title', () => {
+    it('should have the correct page heading', () => {
       const element = document.querySelector('.govuk-fieldset__heading')
       expect(element).toBeTruthy()
       expect(TestHelper.getTextContent(element)).toEqual('Choose your address')
@@ -127,7 +127,7 @@ describe('/address-choose route', () => {
       }
     })
 
-    describe('Success: Owner-applicant', () => {
+    describe('Success: Owned by applicant', () => {
       const redisKey = 'owner-address'
 
       it('should store the selected address in Redis and progress to the next route when the user selects an address', async () => {
@@ -154,7 +154,7 @@ describe('/address-choose route', () => {
       })
     })
 
-    describe('Failure: Owner-applicant', () => {
+    describe('Failure: Owned by applicant', () => {
       it('should display a validation error message if the user does not select an address', async () => {
         postOptions.payload = {
           address: ''

--- a/test/routes/owner/address-choose.route.test.js
+++ b/test/routes/owner/address-choose.route.test.js
@@ -19,7 +19,9 @@ const {
 describe('/user-details/owner/address-choose route', () => {
   let server
   const url = '/user-details/owner/address-choose'
-  const nextUrl = '/check-your-answers'
+  const nextUrlCheckYourAnswers = '/check-your-answers'
+  const nextUrlApplicantContactDetails =
+    '/user-details/applicant/contact-details'
 
   const elementIds = {
     pageHeading: 'pageHeading',
@@ -51,72 +53,145 @@ describe('/user-details/owner/address-choose route', () => {
     jest.clearAllMocks()
   })
 
-  describe('GET: Owner applicant', () => {
+  describe('GET', () => {
     const getOptions = {
       method: 'GET',
       url
     }
+    describe('GET: Owned by applicant', () => {
+      beforeEach(async () => {
+        RedisService.get = jest
+          .fn()
+          .mockReturnValueOnce('yes')
+          .mockReturnValueOnce(JSON.stringify(multipleAddresses))
 
-    beforeEach(async () => {
-      RedisService.get = jest
-        .fn()
-        .mockReturnValue(JSON.stringify(multipleAddresses))
+        document = await TestHelper.submitGetRequest(server, getOptions)
+      })
 
-      document = await TestHelper.submitGetRequest(server, getOptions)
+      it('should have the Beta banner', () => {
+        TestHelper.checkBetaBanner(document)
+      })
+
+      it('should have the Back link', () => {
+        TestHelper.checkBackLink(document)
+      })
+
+      it('should have the correct page heading', () => {
+        const element = document.querySelector('.govuk-fieldset__heading')
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          'Choose your address'
+        )
+      })
+
+      it('should have the correct radio buttons', () => {
+        TestHelper.checkRadioOption(
+          document,
+          elementIds.address,
+          multipleAddresses[0].Address.AddressLine,
+          multipleAddresses[0].Address.AddressLine
+        )
+        TestHelper.checkRadioOption(
+          document,
+          elementIds.address2,
+          multipleAddresses[1].Address.AddressLine,
+          multipleAddresses[1].Address.AddressLine
+        )
+        TestHelper.checkRadioOption(
+          document,
+          elementIds.address3,
+          multipleAddresses[2].Address.AddressLine,
+          multipleAddresses[2].Address.AddressLine
+        )
+      })
+
+      it('should have the correct "Address not on the list" link', () => {
+        const element = document.querySelector(
+          `#${elementIds.addressNotOnList}`
+        )
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          'The address is not on the list'
+        )
+        expect(element.href).toEqual('address-enter')
+      })
+
+      it('should have the correct Call to Action button', () => {
+        const element = document.querySelector(`#${elementIds.continue}`)
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual('Continue')
+      })
     })
 
-    it('should have the Beta banner', () => {
-      TestHelper.checkBetaBanner(document)
-    })
+    describe('GET: Not owned by applicant', () => {
+      beforeEach(async () => {
+        RedisService.get = jest
+          .fn()
+          .mockReturnValueOnce('no')
+          .mockReturnValueOnce(JSON.stringify(multipleAddresses))
 
-    it('should have the Back link', () => {
-      TestHelper.checkBackLink(document)
-    })
+        document = await TestHelper.submitGetRequest(server, getOptions)
+      })
 
-    it('should have the correct page heading', () => {
-      const element = document.querySelector('.govuk-fieldset__heading')
-      expect(element).toBeTruthy()
-      expect(TestHelper.getTextContent(element)).toEqual('Choose your address')
-    })
+      it('should have the Beta banner', () => {
+        TestHelper.checkBetaBanner(document)
+      })
 
-    it('should have the correct radio buttons', () => {
-      TestHelper.checkRadioOption(
-        document,
-        elementIds.address,
-        multipleAddresses[0].Address.AddressLine,
-        multipleAddresses[0].Address.AddressLine
-      )
-      TestHelper.checkRadioOption(
-        document,
-        elementIds.address2,
-        multipleAddresses[1].Address.AddressLine,
-        multipleAddresses[1].Address.AddressLine
-      )
-      TestHelper.checkRadioOption(
-        document,
-        elementIds.address3,
-        multipleAddresses[2].Address.AddressLine,
-        multipleAddresses[2].Address.AddressLine
-      )
-    })
+      it('should have the Back link', () => {
+        TestHelper.checkBackLink(document)
+      })
 
-    it('should have the correct "Address not on the list" link', () => {
-      const element = document.querySelector(`#${elementIds.addressNotOnList}`)
-      expect(element).toBeTruthy()
-      expect(TestHelper.getTextContent(element)).toEqual(
-        'The address is not on the list'
-      )
-      expect(element.href).toEqual('address-enter')
-    })
+      it('should have the correct page heading', () => {
+        const element = document.querySelector('.govuk-fieldset__heading')
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          "Choose the owner's address"
+        )
+      })
 
-    it('should have the correct Call to Action button', () => {
-      const element = document.querySelector(`#${elementIds.continue}`)
-      expect(element).toBeTruthy()
-      expect(TestHelper.getTextContent(element)).toEqual('Continue')
+      it('should have the correct radio buttons', () => {
+        TestHelper.checkRadioOption(
+          document,
+          elementIds.address,
+          multipleAddresses[0].Address.AddressLine,
+          multipleAddresses[0].Address.AddressLine
+        )
+        TestHelper.checkRadioOption(
+          document,
+          elementIds.address2,
+          multipleAddresses[1].Address.AddressLine,
+          multipleAddresses[1].Address.AddressLine
+        )
+        TestHelper.checkRadioOption(
+          document,
+          elementIds.address3,
+          multipleAddresses[2].Address.AddressLine,
+          multipleAddresses[2].Address.AddressLine
+        )
+      })
+
+      it('should have the correct "Address not on the list" link', () => {
+        const element = document.querySelector(
+          `#${elementIds.addressNotOnList}`
+        )
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          'The address is not on the list'
+        )
+        expect(element.href).toEqual('address-enter')
+      })
+
+      it('should have the correct Call to Action button', () => {
+        const element = document.querySelector(`#${elementIds.continue}`)
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual('Continue')
+      })
     })
   })
 
   describe('POST', () => {
+    const redisKeyOwnerAddress = 'owner.address'
+    const redisKeyApplicantAddress = 'applicant.address'
     let postOptions
 
     beforeEach(() => {
@@ -128,7 +203,47 @@ describe('/user-details/owner/address-choose route', () => {
     })
 
     describe('Success: Owned by applicant', () => {
-      const redisKey = 'owner-address'
+      beforeEach(() => {
+        RedisService.get = jest.fn().mockReturnValue('yes')
+      })
+
+      it('should store the selected address in Redis and progress to the next route when the user selects an address', async () => {
+        AddressService.addressSearch = jest.fn().mockReturnValue(singleAddress)
+        postOptions.payload = {
+          address: singleAddress[0].Address.AddressLine
+        }
+
+        expect(RedisService.set).toBeCalledTimes(0)
+
+        const response = await TestHelper.submitPostRequest(
+          server,
+          postOptions,
+          302
+        )
+
+        expect(RedisService.set).toBeCalledTimes(2)
+        expect(RedisService.set).toBeCalledWith(
+          expect.any(Object),
+          redisKeyOwnerAddress,
+          singleAddress[0].Address.AddressLine
+        )
+        expect(RedisService.set).toBeCalledWith(
+          expect.any(Object),
+          redisKeyApplicantAddress,
+          singleAddress[0].Address.AddressLine
+        )
+
+        expect(response.headers.location).toEqual(nextUrlCheckYourAnswers)
+      })
+    })
+
+    describe('Success: Not owned by applicant', () => {
+      beforeEach(() => {
+        RedisService.get = jest
+          .fn()
+          .mockReturnValueOnce('no')
+          .mockReturnValueOnce(JSON.stringify(singleAddress))
+      })
 
       it('should store the selected address in Redis and progress to the next route when the user selects an address', async () => {
         AddressService.addressSearch = jest.fn().mockReturnValue(singleAddress)
@@ -147,14 +262,24 @@ describe('/user-details/owner/address-choose route', () => {
         expect(RedisService.set).toBeCalledTimes(1)
         expect(RedisService.set).toBeCalledWith(
           expect.any(Object),
-          redisKey,
+          redisKeyOwnerAddress,
           singleAddress[0].Address.AddressLine
         )
-        expect(response.headers.location).toEqual(nextUrl)
+
+        expect(response.headers.location).toEqual(
+          nextUrlApplicantContactDetails
+        )
       })
     })
 
-    describe('Failure: Owned by applicant', () => {
+    describe('Failure', () => {
+      beforeEach(() => {
+        RedisService.get = jest
+          .fn()
+          .mockReturnValueOnce('no')
+          .mockReturnValueOnce(JSON.stringify(singleAddress))
+      })
+
       it('should display a validation error message if the user does not select an address', async () => {
         postOptions.payload = {
           address: ''

--- a/test/routes/owner/address-choose.route.test.js
+++ b/test/routes/owner/address-choose.route.test.js
@@ -24,7 +24,7 @@ describe('/user-details/owner/address-choose route', () => {
     '/user-details/applicant/contact-details'
 
   const elementIds = {
-    pageHeading: 'pageHeading',
+    pageTitle: 'pageTitle',
     address: 'address',
     address2: 'address-2',
     address3: 'address-3',

--- a/test/routes/owner/address-confirm.route.test.js
+++ b/test/routes/owner/address-confirm.route.test.js
@@ -13,7 +13,7 @@ const AddressService = require('../../../server/services/address.service')
 
 const { singleAddress } = require('../../mock-data/addresses')
 
-describe('/address-confirm route', () => {
+describe('/user-details/owner/address-confirm route', () => {
   let server
   const url = '/user-details/owner/address-confirm'
   const nextUrl = '/check-your-answers'
@@ -68,7 +68,7 @@ describe('/address-confirm route', () => {
       TestHelper.checkBackLink(document)
     })
 
-    it('should have the correct page title', () => {
+    it('should have the correct page heading', () => {
       const element = document.querySelector(`#${elementIds.pageHeading}`)
       expect(element).toBeTruthy()
       expect(TestHelper.getTextContent(element)).toEqual('Confirm your address')
@@ -109,7 +109,7 @@ describe('/address-confirm route', () => {
       }
     })
 
-    describe('Success: Owner-applicant', () => {
+    describe('Success: Owned by applicant', () => {
       const redisKey = 'owner-address'
 
       it('should store the selected address in Redis and progress to the next route when the user selects an address', async () => {

--- a/test/routes/owner/address-confirm.route.test.js
+++ b/test/routes/owner/address-confirm.route.test.js
@@ -21,7 +21,7 @@ describe('/user-details/owner/address-confirm route', () => {
   const nextUrlCheckYourAnswers = '/check-your-answers'
 
   const elementIds = {
-    pageHeading: 'pageHeading',
+    pageTitle: 'pageTitle',
     address: 'address',
     editTheAddress: 'editTheAddress',
     confirmAndContinue: 'confirmAndContinue'
@@ -73,7 +73,7 @@ describe('/user-details/owner/address-confirm route', () => {
       })
 
       it('should have the correct page heading', () => {
-        const element = document.querySelector(`#${elementIds.pageHeading}`)
+        const element = document.querySelector(`#${elementIds.pageTitle}`)
         expect(element).toBeTruthy()
         expect(TestHelper.getTextContent(element)).toEqual(
           'Confirm your address'
@@ -125,7 +125,7 @@ describe('/user-details/owner/address-confirm route', () => {
       })
 
       it('should have the correct page heading', () => {
-        const element = document.querySelector(`#${elementIds.pageHeading}`)
+        const element = document.querySelector(`#${elementIds.pageTitle}`)
         expect(element).toBeTruthy()
         expect(TestHelper.getTextContent(element)).toEqual(
           "Confirm the owner's address"

--- a/test/routes/owner/address-enter.route.test.js
+++ b/test/routes/owner/address-enter.route.test.js
@@ -26,7 +26,9 @@ const elementIds = {
 describe('/user-details/owner/address-enter route', () => {
   let server
   const url = '/user-details/owner/address-enter'
-  const nextUrl = '/check-your-answers'
+  const nextUrlApplicantContactDetails =
+    '/user-details/applicant/contact-details'
+  const nextUrlCheckYourAnswers = '/check-your-answers'
 
   let document
 
@@ -72,14 +74,6 @@ describe('/user-details/owner/address-enter route', () => {
         TestHelper.checkBackLink(document)
       })
 
-      it('should have the correct help text for 1 address returned', () => {
-        const element = document.querySelector(`#${elementIds.helpText}`)
-        expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual(
-          'If your business owns the item, give your business address.'
-        )
-      })
-
       it('should have the correct Call to Action button', () => {
         const element = document.querySelector(`#${elementIds.continue}`)
         expect(element).toBeTruthy()
@@ -88,114 +82,321 @@ describe('/user-details/owner/address-enter route', () => {
     })
 
     describe('GET: No address mode', () => {
-      beforeEach(async () => {
-        RedisService.get = jest.fn().mockReturnValue(JSON.stringify([]))
+      describe('Owned by applicant', () => {
+        beforeEach(async () => {
+          RedisService.get = jest
+            .fn()
+            .mockReturnValueOnce('yes')
+            .mockReturnValueOnce(JSON.stringify([]))
 
-        document = await TestHelper.submitGetRequest(server, getOptions)
+          document = await TestHelper.submitGetRequest(server, getOptions)
+        })
+
+        it('should have the correct page heading for no addresses returned', () => {
+          const element = document.querySelector(
+            `#${elementIds.pageHeading} > legend > h1`
+          )
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'No results, you will need to enter the address'
+          )
+        })
+
+        it('should have the correct help text for no addresses returned', () => {
+          const element = document.querySelector(`#${elementIds.helpText}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'If your business owns the item, give your business address.'
+          )
+        })
+
+        it('should have the correct form fields that are NOT be pre-populated with test data', () => {
+          _checkFormFields(document, {
+            addressLine1: '',
+            addressLine2: '',
+            townOrCity: '',
+            postcode: ''
+          })
+        })
       })
 
-      it('should have the correct page heading for 1 address returned', () => {
-        const element = document.querySelector(
-          `#${elementIds.pageHeading} > legend > h1`
-        )
-        expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual(
-          'No results, you will need to enter the address'
-        )
-      })
+      describe('Not owned by applicant', () => {
+        beforeEach(async () => {
+          RedisService.get = jest
+            .fn()
+            .mockReturnValueOnce('no')
+            .mockReturnValueOnce(JSON.stringify([]))
 
-      it('should have the correct form fields that are NOT be pre-populated with test data', () => {
-        _checkFormFields(document, {
-          addressLine1: '',
-          addressLine2: '',
-          townOrCity: '',
-          postcode: ''
+          document = await TestHelper.submitGetRequest(server, getOptions)
+        })
+
+        it('should have the correct page heading for no addresses returned', () => {
+          const element = document.querySelector(
+            `#${elementIds.pageHeading} > legend > h1`
+          )
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'No results, you will need to enter the address'
+          )
+        })
+
+        it('should have the correct help text for no addresses returned', () => {
+          const element = document.querySelector(`#${elementIds.helpText}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'If the owner is a business, give the business address.'
+          )
+        })
+
+        it('should have the correct form fields that are NOT be pre-populated with test data', () => {
+          _checkFormFields(document, {
+            addressLine1: '',
+            addressLine2: '',
+            townOrCity: '',
+            postcode: ''
+          })
         })
       })
     })
 
     describe('GET: Single address mode', () => {
-      beforeEach(async () => {
-        RedisService.get = jest
-          .fn()
-          .mockReturnValue(JSON.stringify(singleAddress))
+      describe('Owned by applicant', () => {
+        beforeEach(async () => {
+          RedisService.get = jest
+            .fn()
+            .mockReturnValueOnce('yes')
+            .mockReturnValueOnce(JSON.stringify(singleAddress))
 
-        document = await TestHelper.submitGetRequest(server, getOptions)
+          document = await TestHelper.submitGetRequest(server, getOptions)
+        })
+
+        it('should have the correct page heading for 1 address returned', () => {
+          const element = document.querySelector(
+            `#${elementIds.pageHeading} > legend > h1`
+          )
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'Edit your address'
+          )
+        })
+
+        it('should have the correct help text for 1 address returned', () => {
+          const element = document.querySelector(`#${elementIds.helpText}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'If your business owns the item, give your business address.'
+          )
+        })
+
+        it('should have the correct form fields that are NOT be pre-populated with test data', () => {
+          _checkFormFields(document, {
+            addressLine1: 'Buckingham Palace',
+            addressLine2: 'Westminster',
+            townOrCity: 'London',
+            postcode: 'SW1A 1AA'
+          })
+        })
       })
 
-      it('should have the correct page heading for 1 address returned', () => {
-        const element = document.querySelector(
-          `#${elementIds.pageHeading} > legend > h1`
-        )
-        expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual('Edit your address')
-      })
+      describe('Not owned by applicant', () => {
+        beforeEach(async () => {
+          RedisService.get = jest
+            .fn()
+            .mockReturnValueOnce('no')
+            .mockReturnValueOnce(JSON.stringify(singleAddress))
 
-      it('should have the correct form fields that are NOT be pre-populated with test data', () => {
-        _checkFormFields(document, {
-          addressLine1: 'Buckingham Palace',
-          addressLine2: 'Westminster',
-          townOrCity: 'London',
-          postcode: 'SW1A 1AA'
+          document = await TestHelper.submitGetRequest(server, getOptions)
+        })
+
+        it('should have the correct page heading for 1 address returned', () => {
+          const element = document.querySelector(
+            `#${elementIds.pageHeading} > legend > h1`
+          )
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            "Edit the owner's address"
+          )
+        })
+
+        it('should have the correct help text for 1 address returned', () => {
+          const element = document.querySelector(`#${elementIds.helpText}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'If the owner is a business, give the business address.'
+          )
+        })
+
+        it('should have the correct form fields that are NOT be pre-populated with test data', () => {
+          _checkFormFields(document, {
+            addressLine1: 'Buckingham Palace',
+            addressLine2: 'Westminster',
+            townOrCity: 'London',
+            postcode: 'SW1A 1AA'
+          })
         })
       })
     })
 
     describe('GET: Multiple address mode', () => {
-      beforeEach(async () => {
-        RedisService.get = jest
-          .fn()
-          .mockReturnValue(JSON.stringify(multipleAddresses))
+      describe('Owned by applicant', () => {
+        beforeEach(async () => {
+          RedisService.get = jest
+            .fn()
+            .mockReturnValueOnce('yes')
+            .mockReturnValueOnce(JSON.stringify(multipleAddresses))
 
-        document = await TestHelper.submitGetRequest(server, getOptions)
+          document = await TestHelper.submitGetRequest(server, getOptions)
+        })
+
+        it('should have the correct page heading for multiple addresses returned', () => {
+          const element = document.querySelector(
+            `#${elementIds.pageHeading} > legend > h1`
+          )
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'Enter your address'
+          )
+        })
+
+        it('should have the correct help text for multiple addresses returned', () => {
+          const element = document.querySelector(`#${elementIds.helpText}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'If your business owns the item, give your business address.'
+          )
+        })
+
+        it('should have the correct form fields that are NOT be pre-populated with test data', () => {
+          _checkFormFields(document, {
+            addressLine1: '',
+            addressLine2: '',
+            townOrCity: '',
+            postcode: ''
+          })
+        })
       })
 
-      it('should have the correct page heading for 1 address returned', () => {
-        const element = document.querySelector(
-          `#${elementIds.pageHeading} > legend > h1`
-        )
-        expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual('Enter your address')
-      })
+      describe('Not owned by applicant', () => {
+        beforeEach(async () => {
+          RedisService.get = jest
+            .fn()
+            .mockReturnValueOnce('no')
+            .mockReturnValueOnce(JSON.stringify(multipleAddresses))
 
-      it('should have the correct form fields that are NOT be pre-populated with test data', () => {
-        _checkFormFields(document, {
-          addressLine1: '',
-          addressLine2: '',
-          townOrCity: '',
-          postcode: ''
+          document = await TestHelper.submitGetRequest(server, getOptions)
+        })
+
+        it('should have the correct page heading for multiple addresses returned', () => {
+          const element = document.querySelector(
+            `#${elementIds.pageHeading} > legend > h1`
+          )
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            "Enter the owner's address"
+          )
+        })
+
+        it('should have the correct help text for multiple addresses returned', () => {
+          const element = document.querySelector(`#${elementIds.helpText}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'If the owner is a business, give the business address.'
+          )
+        })
+
+        it('should have the correct form fields that are NOT be pre-populated with test data', () => {
+          _checkFormFields(document, {
+            addressLine1: '',
+            addressLine2: '',
+            townOrCity: '',
+            postcode: ''
+          })
         })
       })
     })
 
     describe('GET: Too many addresses mode', () => {
+      const maxAddressCount = 51
+      const addresses = []
       beforeEach(async () => {
-        const maxAddressCount = 51
-        const addresses = []
         for (let i = 0; i < maxAddressCount; i++) {
           addresses.push(singleAddress)
         }
-        RedisService.get = jest.fn().mockReturnValue(JSON.stringify(addresses))
-
-        document = await TestHelper.submitGetRequest(server, getOptions)
       })
 
-      it('should have the correct page heading for 1 address returned', () => {
-        const element = document.querySelector(
-          `#${elementIds.pageHeading} > legend > h1`
-        )
-        expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual(
-          'Too many results, you will need to enter the address'
-        )
+      describe('Owned by applicant', () => {
+        beforeEach(async () => {
+          RedisService.get = jest
+            .fn()
+            .mockReturnValueOnce('yes')
+            .mockReturnValueOnce(JSON.stringify(addresses))
+
+          document = await TestHelper.submitGetRequest(server, getOptions)
+        })
+
+        it('should have the correct page heading for too many addresses returned', () => {
+          const element = document.querySelector(
+            `#${elementIds.pageHeading} > legend > h1`
+          )
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'Too many results, you will need to enter the address'
+          )
+        })
+
+        it('should have the correct help text for too many addresses returned', () => {
+          const element = document.querySelector(`#${elementIds.helpText}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'If your business owns the item, give your business address.'
+          )
+        })
+
+        it('should have the correct form fields that are NOT be pre-populated with test data', () => {
+          _checkFormFields(document, {
+            addressLine1: '',
+            addressLine2: '',
+            townOrCity: '',
+            postcode: ''
+          })
+        })
       })
 
-      it('should have the correct form fields that are NOT be pre-populated with test data', () => {
-        _checkFormFields(document, {
-          addressLine1: '',
-          addressLine2: '',
-          townOrCity: '',
-          postcode: ''
+      describe('Not owned by applicant', () => {
+        beforeEach(async () => {
+          RedisService.get = jest
+            .fn()
+            .mockReturnValueOnce('no')
+            .mockReturnValueOnce(JSON.stringify(addresses))
+
+          document = await TestHelper.submitGetRequest(server, getOptions)
+        })
+
+        it('should have the correct page heading for too many addresses returned', () => {
+          const element = document.querySelector(
+            `#${elementIds.pageHeading} > legend > h1`
+          )
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'Too many results, you will need to enter the address'
+          )
+        })
+
+        it('should have the correct help text for too many addresses returned', () => {
+          const element = document.querySelector(`#${elementIds.helpText}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'If the owner is a business, give the business address.'
+          )
+        })
+
+        it('should have the correct form fields that are NOT be pre-populated with test data', () => {
+          _checkFormFields(document, {
+            addressLine1: '',
+            addressLine2: '',
+            townOrCity: '',
+            postcode: ''
+          })
         })
       })
     })
@@ -203,12 +404,10 @@ describe('/user-details/owner/address-enter route', () => {
 
   describe('POST', () => {
     let postOptions
+    const redisKeyOwnerAddress = 'owner.address'
+    const redisKeyApplicantAddress = 'applicant.address'
 
     beforeEach(async () => {
-      RedisService.get = jest
-        .fn()
-        .mockReturnValue(JSON.stringify(singleAddress))
-
       postOptions = {
         method: 'POST',
         url,
@@ -216,20 +415,92 @@ describe('/user-details/owner/address-enter route', () => {
       }
     })
 
-    describe('Success: address-enter', () => {
-      it('should redirect to the correct page', async () => {
+    describe('Success: Owned by applicant', () => {
+      beforeEach(async () => {
+        RedisService.get = jest
+          .fn()
+          .mockReturnValueOnce('yes')
+          .mockReturnValueOnce(JSON.stringify(singleAddress))
+          .mockReturnValueOnce('yes')
+      })
+
+      it('should store the selected address in Redis and progress to the next route when the user selects an address', async () => {
         postOptions.payload = {
           addressLine1: 'A Big House',
           townOrCity: 'London',
           postcode: 'SW1A 1AA'
         }
-        const response = await TestHelper.submitPostRequest(server, postOptions)
 
-        expect(response.headers.location).toEqual(nextUrl)
+        expect(RedisService.set).toBeCalledTimes(0)
+
+        const response = await TestHelper.submitPostRequest(
+          server,
+          postOptions,
+          302
+        )
+
+        expect(RedisService.set).toBeCalledTimes(2)
+        expect(RedisService.set).toBeCalledWith(
+          expect.any(Object),
+          redisKeyOwnerAddress,
+          'A Big House, London, SW1A 1AA'
+        )
+        expect(RedisService.set).toBeCalledWith(
+          expect.any(Object),
+          redisKeyApplicantAddress,
+          'A Big House, London, SW1A 1AA'
+        )
+
+        expect(response.headers.location).toEqual(nextUrlCheckYourAnswers)
+      })
+    })
+
+    describe('Success: Not owned by applicant', () => {
+      beforeEach(async () => {
+        RedisService.get = jest
+          .fn()
+          .mockReturnValueOnce('no')
+          .mockReturnValueOnce(JSON.stringify(singleAddress))
+          .mockReturnValueOnce('no')
+      })
+
+      it('should store the selected address in Redis and progress to the next route when the user selects an address', async () => {
+        postOptions.payload = {
+          addressLine1: 'A Big House',
+          townOrCity: 'London',
+          postcode: 'SW1A 1AA'
+        }
+
+        expect(RedisService.set).toBeCalledTimes(0)
+
+        const response = await TestHelper.submitPostRequest(
+          server,
+          postOptions,
+          302
+        )
+
+        expect(RedisService.set).toBeCalledTimes(1)
+        expect(RedisService.set).toBeCalledWith(
+          expect.any(Object),
+          redisKeyOwnerAddress,
+          'A Big House, London, SW1A 1AA'
+        )
+
+        expect(response.headers.location).toEqual(
+          nextUrlApplicantContactDetails
+        )
       })
     })
 
     describe('Failure: address-enter', () => {
+      beforeEach(async () => {
+        RedisService.get = jest
+          .fn()
+          .mockReturnValueOnce('yes')
+          .mockReturnValueOnce(JSON.stringify(singleAddress))
+          .mockReturnValueOnce('yes')
+      })
+
       it('should display a validation error message if the user does not enter address line 1', async () => {
         postOptions.payload = {
           addressLine1: '',

--- a/test/routes/owner/address-enter.route.test.js
+++ b/test/routes/owner/address-enter.route.test.js
@@ -23,7 +23,7 @@ const elementIds = {
   continue: 'continue'
 }
 
-describe('/address-enter route', () => {
+describe('/user-details/owner/address-enter route', () => {
   let server
   const url = '/user-details/owner/address-enter'
   const nextUrl = '/check-your-answers'
@@ -94,7 +94,7 @@ describe('/address-enter route', () => {
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
 
-      it('should have the correct page title for 1 address returned', () => {
+      it('should have the correct page heading for 1 address returned', () => {
         const element = document.querySelector(
           `#${elementIds.pageHeading} > legend > h1`
         )
@@ -123,7 +123,7 @@ describe('/address-enter route', () => {
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
 
-      it('should have the correct page title for 1 address returned', () => {
+      it('should have the correct page heading for 1 address returned', () => {
         const element = document.querySelector(
           `#${elementIds.pageHeading} > legend > h1`
         )
@@ -150,7 +150,7 @@ describe('/address-enter route', () => {
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
 
-      it('should have the correct page title for 1 address returned', () => {
+      it('should have the correct page heading for 1 address returned', () => {
         const element = document.querySelector(
           `#${elementIds.pageHeading} > legend > h1`
         )
@@ -180,7 +180,7 @@ describe('/address-enter route', () => {
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
 
-      it('should have the correct page title for 1 address returned', () => {
+      it('should have the correct page heading for 1 address returned', () => {
         const element = document.querySelector(
           `#${elementIds.pageHeading} > legend > h1`
         )

--- a/test/routes/owner/address-enter.route.test.js
+++ b/test/routes/owner/address-enter.route.test.js
@@ -14,7 +14,7 @@ const {
 } = require('../../mock-data/addresses')
 
 const elementIds = {
-  pageHeading: 'pageHeading',
+  pageTitle: 'pageTitle',
   helpText: 'helpText',
   addressLine1: 'addressLine1',
   addressLine2: 'addressLine2',
@@ -94,7 +94,7 @@ describe('/user-details/owner/address-enter route', () => {
 
         it('should have the correct page heading for no addresses returned', () => {
           const element = document.querySelector(
-            `#${elementIds.pageHeading} > legend > h1`
+            `#${elementIds.pageTitle} > legend > h1`
           )
           expect(element).toBeTruthy()
           expect(TestHelper.getTextContent(element)).toEqual(
@@ -132,7 +132,7 @@ describe('/user-details/owner/address-enter route', () => {
 
         it('should have the correct page heading for no addresses returned', () => {
           const element = document.querySelector(
-            `#${elementIds.pageHeading} > legend > h1`
+            `#${elementIds.pageTitle} > legend > h1`
           )
           expect(element).toBeTruthy()
           expect(TestHelper.getTextContent(element)).toEqual(
@@ -172,7 +172,7 @@ describe('/user-details/owner/address-enter route', () => {
 
         it('should have the correct page heading for 1 address returned', () => {
           const element = document.querySelector(
-            `#${elementIds.pageHeading} > legend > h1`
+            `#${elementIds.pageTitle} > legend > h1`
           )
           expect(element).toBeTruthy()
           expect(TestHelper.getTextContent(element)).toEqual(
@@ -210,7 +210,7 @@ describe('/user-details/owner/address-enter route', () => {
 
         it('should have the correct page heading for 1 address returned', () => {
           const element = document.querySelector(
-            `#${elementIds.pageHeading} > legend > h1`
+            `#${elementIds.pageTitle} > legend > h1`
           )
           expect(element).toBeTruthy()
           expect(TestHelper.getTextContent(element)).toEqual(
@@ -250,7 +250,7 @@ describe('/user-details/owner/address-enter route', () => {
 
         it('should have the correct page heading for multiple addresses returned', () => {
           const element = document.querySelector(
-            `#${elementIds.pageHeading} > legend > h1`
+            `#${elementIds.pageTitle} > legend > h1`
           )
           expect(element).toBeTruthy()
           expect(TestHelper.getTextContent(element)).toEqual(
@@ -288,7 +288,7 @@ describe('/user-details/owner/address-enter route', () => {
 
         it('should have the correct page heading for multiple addresses returned', () => {
           const element = document.querySelector(
-            `#${elementIds.pageHeading} > legend > h1`
+            `#${elementIds.pageTitle} > legend > h1`
           )
           expect(element).toBeTruthy()
           expect(TestHelper.getTextContent(element)).toEqual(
@@ -336,7 +336,7 @@ describe('/user-details/owner/address-enter route', () => {
 
         it('should have the correct page heading for too many addresses returned', () => {
           const element = document.querySelector(
-            `#${elementIds.pageHeading} > legend > h1`
+            `#${elementIds.pageTitle} > legend > h1`
           )
           expect(element).toBeTruthy()
           expect(TestHelper.getTextContent(element)).toEqual(
@@ -374,7 +374,7 @@ describe('/user-details/owner/address-enter route', () => {
 
         it('should have the correct page heading for too many addresses returned', () => {
           const element = document.querySelector(
-            `#${elementIds.pageHeading} > legend > h1`
+            `#${elementIds.pageTitle} > legend > h1`
           )
           expect(element).toBeTruthy()
           expect(TestHelper.getTextContent(element)).toEqual(

--- a/test/routes/owner/address-find.route.test.js
+++ b/test/routes/owner/address-find.route.test.js
@@ -24,7 +24,7 @@ describe('/user-details/owner/address-find route', () => {
   const nextUrlMultipleAddresses = '/user-details/owner/address-choose'
 
   const elementIds = {
-    pageHeading: 'pageHeading',
+    pageTitle: 'pageTitle',
     helpText: 'helpText',
     nameOrNumber: 'nameOrNumber',
     postcode: 'postcode',
@@ -75,7 +75,7 @@ describe('/user-details/owner/address-find route', () => {
 
     it('should have the correct page heading', () => {
       const element = document.querySelector(
-        `#${elementIds.pageHeading} > legend > h1`
+        `#${elementIds.pageTitle} > legend > h1`
       )
       expect(element).toBeTruthy()
       expect(TestHelper.getTextContent(element)).toEqual(
@@ -142,7 +142,7 @@ describe('/user-details/owner/address-find route', () => {
 
     it('should have the correct page heading', () => {
       const element = document.querySelector(
-        `#${elementIds.pageHeading} > legend > h1`
+        `#${elementIds.pageTitle} > legend > h1`
       )
       expect(element).toBeTruthy()
       expect(TestHelper.getTextContent(element)).toEqual(

--- a/test/routes/owner/address-find.route.test.js
+++ b/test/routes/owner/address-find.route.test.js
@@ -16,7 +16,7 @@ const {
   multipleAddresses
 } = require('../../mock-data/addresses')
 
-describe('/address-find route', () => {
+describe('/user-details/owner/address-find route', () => {
   let server
   const url = '/user-details/owner/address-find'
   const nextUrlEnterAddress = '/user-details/owner/address-enter'
@@ -71,7 +71,7 @@ describe('/address-find route', () => {
       TestHelper.checkBackLink(document)
     })
 
-    it('should have the correct page title', () => {
+    it('should have the correct page heading', () => {
       const element = document.querySelector(
         `#${elementIds.pageHeading} > legend > h1`
       )
@@ -129,7 +129,7 @@ describe('/address-find route', () => {
       }
     })
 
-    describe('Success: Owner-applicant', () => {
+    describe('Success: Owned by applicant', () => {
       const redisKey = 'address-find'
 
       it('should store the address array in Redis and progress to the next route when a single address is returned by the search', async () => {
@@ -225,7 +225,7 @@ describe('/address-find route', () => {
       })
     })
 
-    describe('Failure: Owner-applicant', () => {
+    describe('Failure: Owned by applicant', () => {
       it('should display a validation error message if the user does not enter the postcode', async () => {
         postOptions.payload = {
           postcode: ''

--- a/test/routes/owner/address-international.route.test.js
+++ b/test/routes/owner/address-international.route.test.js
@@ -15,7 +15,7 @@ describe('/user-details/owner/address-international route', () => {
   const nextUrlApplicantDetails = '/user-details/applicant/contact-details'
 
   const elementIds = {
-    pageHeading: 'pageHeading',
+    pageTitle: 'pageTitle',
     helpText: 'helpText',
     internationalAddress: 'internationalAddress',
     continue: 'continue'

--- a/test/routes/owner/contact-details.route.test.js
+++ b/test/routes/owner/contact-details.route.test.js
@@ -45,7 +45,7 @@ describe('user-details/owner/contact-details route', () => {
     jest.clearAllMocks()
   })
 
-  describe('GET: Owner applicant', () => {
+  describe('GET: Owned by applicant', () => {
     const getOptions = {
       method: 'GET',
       url

--- a/test/routes/owner/contact-details.route.test.js
+++ b/test/routes/owner/contact-details.route.test.js
@@ -8,11 +8,10 @@ const { ServerEvents } = require('../../../server/utils/constants')
 jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 
-describe('/contact-details route', () => {
+describe('user-details/owner/contact-details route', () => {
   let server
   const url = '/user-details/owner/contact-details'
   const nextUrl = '/user-details/owner/address-find'
-  const nextUrlNonOwnerApplicant = '/user-details/applicant/contact-details'
 
   const elementIds = {
     pageHeading: 'pageHeading',
@@ -66,7 +65,7 @@ describe('/contact-details route', () => {
       TestHelper.checkBackLink(document)
     })
 
-    it('should have the correct page title', () => {
+    it('should have the correct page heading', () => {
       const element = document.querySelector(`#${elementIds.pageHeading}`)
       expect(element).toBeTruthy()
       expect(TestHelper.getTextContent(element)).toEqual('Your contact details')
@@ -128,7 +127,7 @@ describe('/contact-details route', () => {
       TestHelper.checkBackLink(document)
     })
 
-    it('should have the correct page title', () => {
+    it('should have the correct page heading', () => {
       const element = document.querySelector(`#${elementIds.pageHeading}`)
       expect(element).toBeTruthy()
       expect(TestHelper.getTextContent(element)).toEqual(
@@ -178,7 +177,7 @@ describe('/contact-details route', () => {
       }
     })
 
-    describe('Success: Owner-applicant', () => {
+    describe('Success: Owned by applicant', () => {
       beforeEach(() => {
         RedisService.get = jest.fn().mockReturnValue('yes')
       })
@@ -204,7 +203,7 @@ describe('/contact-details route', () => {
       })
     })
 
-    describe('Success: Non-owner-applicant', () => {
+    describe('Success: Not owned by applicant', () => {
       beforeEach(() => {
         RedisService.get = jest.fn().mockReturnValue('no')
       })
@@ -226,11 +225,11 @@ describe('/contact-details route', () => {
 
         expect(RedisService.set).toBeCalledTimes(2)
 
-        expect(response.headers.location).toEqual(nextUrlNonOwnerApplicant)
+        expect(response.headers.location).toEqual(nextUrl)
       })
     })
 
-    describe('Failure: Owner-applicant', () => {
+    describe('Failure: Owned by applicant', () => {
       beforeEach(() => {
         RedisService.get = jest.fn().mockReturnValue('yes')
       })
@@ -306,7 +305,7 @@ describe('/contact-details route', () => {
       })
     })
 
-    describe('Failure: Non-owner-applicant', () => {
+    describe('Failure: Not owned by applicant', () => {
       beforeEach(() => {
         RedisService.get = jest.fn().mockReturnValue('no')
       })

--- a/test/routes/owner/contact-details.route.test.js
+++ b/test/routes/owner/contact-details.route.test.js
@@ -14,7 +14,7 @@ describe('user-details/owner/contact-details route', () => {
   const nextUrl = '/user-details/owner/address-find'
 
   const elementIds = {
-    pageHeading: 'pageHeading',
+    pageTitle: 'pageTitle',
     name: 'name',
     ownerApplicant: {
       businessName: 'businessName'
@@ -66,7 +66,7 @@ describe('user-details/owner/contact-details route', () => {
     })
 
     it('should have the correct page heading', () => {
-      const element = document.querySelector(`#${elementIds.pageHeading}`)
+      const element = document.querySelector(`#${elementIds.pageTitle}`)
       expect(element).toBeTruthy()
       expect(TestHelper.getTextContent(element)).toEqual('Your contact details')
     })
@@ -128,7 +128,7 @@ describe('user-details/owner/contact-details route', () => {
     })
 
     it('should have the correct page heading', () => {
-      const element = document.querySelector(`#${elementIds.pageHeading}`)
+      const element = document.querySelector(`#${elementIds.pageTitle}`)
       expect(element).toBeTruthy()
       expect(TestHelper.getTextContent(element)).toEqual(
         "Owner's contact details"

--- a/test/routes/taken-from-elephant.route.test.js
+++ b/test/routes/taken-from-elephant.route.test.js
@@ -60,7 +60,7 @@ describe('/taken-from-elephant route', () => {
       TestHelper.checkBackLink(document)
     })
 
-    it('should have the correct page title', () => {
+    it('should have the correct page heading', () => {
       const element = document.querySelector('.govuk-fieldset__legend')
       expect(element).toBeTruthy()
       expect(TestHelper.getTextContent(element)).toEqual(

--- a/test/routes/what-type-of-item-is-it.route.test.js
+++ b/test/routes/what-type-of-item-is-it.route.test.js
@@ -63,10 +63,12 @@ describe('/what-type-of-item-is-it route', () => {
       TestHelper.checkBackLink(document)
     })
 
-    it('should have the correct page title', () => {
+    it('should have the correct page heading', () => {
       const element = document.querySelector('.govuk-fieldset__heading')
       expect(element).toBeTruthy()
-      expect(TestHelper.getTextContent(element)).toEqual('What is your ivory item?')
+      expect(TestHelper.getTextContent(element)).toEqual(
+        'What is your ivory item?'
+      )
     })
 
     it('should have the correct radio buttons', () => {
@@ -119,19 +121,27 @@ describe('/what-type-of-item-is-it route', () => {
     it('should have the correct summary text title', () => {
       const element = document.querySelector('.govuk-details__summary-text')
       expect(element).toBeTruthy()
-      expect(TestHelper.getTextContent(element)).toEqual('I need more help to work this out')
+      expect(TestHelper.getTextContent(element)).toEqual(
+        'I need more help to work this out'
+      )
     })
 
     it('should have the correct summary text details', () => {
       const element = document.querySelector('.govuk-details__text')
       expect(element).toBeTruthy()
-      expect(TestHelper.getTextContent(element)).toEqual('Use our eligibility checker to check if you can sell or hire out your item.')
+      expect(TestHelper.getTextContent(element)).toEqual(
+        'Use our eligibility checker to check if you can sell or hire out your item.'
+      )
     })
 
     it('should have the correct summary text link', () => {
-      const element = document.querySelector(`#${elementIds.eligibilityChecker}`)
+      const element = document.querySelector(
+        `#${elementIds.eligibilityChecker}`
+      )
       expect(element).toBeTruthy()
-      expect(TestHelper.getTextContent(element)).toEqual('check if you can sell or hire out your item')
+      expect(TestHelper.getTextContent(element)).toEqual(
+        'check if you can sell or hire out your item'
+      )
       expect(element.href).toEqual('about:blank#')
     })
 

--- a/test/routes/who-owns-the-item.route.test.js
+++ b/test/routes/who-owns-the-item.route.test.js
@@ -58,7 +58,7 @@ describe('/ivory-integral route', () => {
       TestHelper.checkBackLink(document)
     })
 
-    it('should have the correct page title', () => {
+    it('should have the correct page heading', () => {
       const element = document.querySelector('.govuk-fieldset__legend')
       expect(element).toBeTruthy()
       expect(TestHelper.getTextContent(element)).toEqual('Who owns the item?')

--- a/test/routes/who-owns-the-item.route.test.js
+++ b/test/routes/who-owns-the-item.route.test.js
@@ -147,7 +147,7 @@ const _checkSelectedRadioAction = async (
   selectedOption,
   nextUrl
 ) => {
-  const redisKey = 'owner-applicant'
+  const redisKey = 'owned-by-applicant'
   postOptions.payload.whoOwnsItem = selectedOption
 
   expect(RedisService.set).toBeCalledTimes(0)

--- a/test/utils/general.test.js
+++ b/test/utils/general.test.js
@@ -1,19 +1,29 @@
 'use strict'
 
-const { convertToTitleCase } = require('../../server/utils/general')
+const {
+  convertToCommaSeparatedTitleCase
+} = require('../../server/utils/general')
 
 describe('General utils', () => {
-  describe('convertToTitleCase method', () => {
+  describe('convertToCommaSeparatedTitleCase method', () => {
     it('should convert strings to title case', () => {
-      expect(convertToTitleCase('')).toBeUndefined()
+      expect(convertToCommaSeparatedTitleCase('')).toBeUndefined()
 
-      expect(convertToTitleCase('the quick brown fox')).toEqual(
+      expect(convertToCommaSeparatedTitleCase('the quick brown fox')).toEqual(
         'The Quick Brown Fox'
       )
 
-      expect(convertToTitleCase('THE, QUICK, BROWN, FOX')).toEqual(
-        'The, Quick, Brown, Fox'
-      )
+      expect(
+        convertToCommaSeparatedTitleCase('THE, QUICK, BROWN, FOX')
+      ).toEqual('The, Quick, Brown, Fox')
+
+      expect(
+        convertToCommaSeparatedTitleCase('THE\nQUICK\nBROWN\nFOX')
+      ).toEqual('The, Quick, Brown, Fox')
+
+      expect(
+        convertToCommaSeparatedTitleCase('THE\r\nQUICK\r\nBROWN\r\nFOX')
+      ).toEqual('The, Quick, Brown, Fox')
     })
   })
 })


### PR DESCRIPTION
Refactored existing "owner' address screens into a /common folder to allow reuse. Added new Applicant address screens.

Also, fixed page titles throughout the application. The page heading needs to be provided in the context in the GET and POST for every route, in order to ensure that the HTML 'title' element is set correctly.


e.g. 

context = {
  pageTitle: 'What is your ivory item?',
  // etc
}

Previously we had a mixture of different values being passed in, such as title, pageHeading, etc.

pageTitle needs to be used in all cases going forward.