### PR TITLE
Address screens - Fixed various issues found during testing.

### DIFF
--- a/server/routes/common/address-confirm.route.js
+++ b/server/routes/common/address-confirm.route.js
@@ -82,6 +82,11 @@ const _getContext = async (request, addressType) => {
 
   context.address = addresses[0].Address
 
+  _convertSingleLineAddressToMultipleLines(
+    context,
+    addresses[0].Address.AddressLine
+  )
+
   return context
 }
 
@@ -98,6 +103,11 @@ const _getContextForApplicantAddressType = () => {
   return {
     pageTitle: 'Confirm your address'
   }
+}
+
+const _convertSingleLineAddressToMultipleLines = (context, address) => {
+  context.addressLines = address.split(',')
+  context.addressLines = context.addressLines.map(address => address.trim())
 }
 
 module.exports = {

--- a/server/routes/common/address-enter.route.js
+++ b/server/routes/common/address-enter.route.js
@@ -167,9 +167,11 @@ const _validateForm = payload => {
 }
 
 const _getAddressFieldsFromAddress = address => {
+  const buildingName = _getBuildingName(address)
+
   return {
-    addressLine1: address.SubBuildingName
-      ? convertToCommaSeparatedTitleCase(address.SubBuildingName)
+    addressLine1: buildingName
+      ? convertToCommaSeparatedTitleCase(buildingName)
       : `${convertToCommaSeparatedTitleCase(
           address.BuildingNumber
         )} ${convertToCommaSeparatedTitleCase(address.Street)}`,
@@ -191,6 +193,10 @@ const _concatenateAddressFields = payload => {
   return Object.keys(payload)
     .map(key => payload[key])
     .join(', ')
+}
+
+const _getBuildingName = address => {
+  return address.BuildingName || address.SubBuildingName
 }
 
 module.exports = {

--- a/server/routes/common/address-international.route.js
+++ b/server/routes/common/address-international.route.js
@@ -120,7 +120,7 @@ const _getContextForApplicantAddressType = () => {
   return {
     pageTitle: 'Enter your address',
     hintText:
-      'If your business is helping someone else sell their item, give your business address.'
+      'If your business is helping someone else sell their item, give your business address'
   }
 }
 

--- a/server/services/address.service.js
+++ b/server/services/address.service.js
@@ -75,7 +75,7 @@ module.exports = class AddressService {
 
     const response = await fetch(url, searchOptions)
 
-    return response.json()
+    return response.status === 200 ? response.json() : []
   }
 }
 
@@ -103,7 +103,7 @@ const _convertPostcodeToUpperCase = address => {
  * Check if the address lookup certificate is a file or a base64 string.
  * If it's a string convert it back to binary
  * @returns address lookup certificate as binary
-*/
+ */
 const _getCertificate = () => {
   if (config.addressLookupPfxCert) {
     return config.addressLookupPfxCert.toUpperCase().endsWith('.PFX')

--- a/server/views/user-details/address-confirm.html
+++ b/server/views/user-details/address-confirm.html
@@ -8,9 +8,13 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 id="pageTitle" class="govuk-heading-l">{{ pageTitle }}</h1>
 
-      <p id="address" class="govuk-body">{{ address.AddressLine }}</p>
+      {% for address in addressLines %}
+        <p id="address-{{ loop.index }}" class="govuk-body govuk-!-margin-bottom-1">{{ address }}</p>
+      {% endfor %}
 
-      <p><a id="editTheAddress" href="/user-details/owner/address-enter" class="govuk-link">Edit the address</a></p>
+      <p class="govuk-body govuk-!-margin-top-4">
+        <a id="editTheAddress" href="/user-details/owner/address-enter" class="govuk-link">Edit the address</a>
+      </p>
 
       {{ govukButton({
           attributes: {

--- a/test/routes/applicant/address-confirm.route.test.js
+++ b/test/routes/applicant/address-confirm.route.test.js
@@ -20,7 +20,10 @@ describe('/user-details/applicant/address-confirm route', () => {
 
   const elementIds = {
     pageTitle: 'pageTitle',
-    address: 'address',
+    address1: 'address-1',
+    address2: 'address-2',
+    address3: 'address-3',
+    address4: 'address-4',
     editTheAddress: 'editTheAddress',
     confirmAndContinue: 'confirmAndContinue'
   }
@@ -79,10 +82,28 @@ describe('/user-details/applicant/address-confirm route', () => {
       })
 
       it('should show the selected address', () => {
-        const element = document.querySelector(`#${elementIds.address}`)
+        let element = document.querySelector(`#${elementIds.address1}`)
         expect(element).toBeTruthy()
         expect(TestHelper.getTextContent(element)).toEqual(
-          singleAddress[0].Address.AddressLine
+          singleAddress[0].Address.SubBuildingName
+        )
+
+        element = document.querySelector(`#${elementIds.address2}`)
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          singleAddress[0].Address.Locality
+        )
+
+        element = document.querySelector(`#${elementIds.address3}`)
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          singleAddress[0].Address.Town
+        )
+
+        element = document.querySelector(`#${elementIds.address4}`)
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          singleAddress[0].Address.Postcode
         )
       })
 

--- a/test/routes/applicant/address-international.route.test.js
+++ b/test/routes/applicant/address-international.route.test.js
@@ -64,7 +64,7 @@ describe('/user-details/applicant/address-international route', () => {
         document,
         elementIds.internationalAddress,
         'Enter your address',
-        'If your business is helping someone else sell their item, give your business address.'
+        'If your business is helping someone else sell their item, give your business address'
       )
     })
 

--- a/test/routes/owner/address-confirm.route.test.js
+++ b/test/routes/owner/address-confirm.route.test.js
@@ -22,7 +22,10 @@ describe('/user-details/owner/address-confirm route', () => {
 
   const elementIds = {
     pageTitle: 'pageTitle',
-    address: 'address',
+    address1: 'address-1',
+    address2: 'address-2',
+    address3: 'address-3',
+    address4: 'address-4',
     editTheAddress: 'editTheAddress',
     confirmAndContinue: 'confirmAndContinue'
   }
@@ -81,10 +84,28 @@ describe('/user-details/owner/address-confirm route', () => {
       })
 
       it('should show the selected address', () => {
-        const element = document.querySelector(`#${elementIds.address}`)
+        let element = document.querySelector(`#${elementIds.address1}`)
         expect(element).toBeTruthy()
         expect(TestHelper.getTextContent(element)).toEqual(
-          singleAddress[0].Address.AddressLine
+          singleAddress[0].Address.SubBuildingName
+        )
+
+        element = document.querySelector(`#${elementIds.address2}`)
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          singleAddress[0].Address.Locality
+        )
+
+        element = document.querySelector(`#${elementIds.address3}`)
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          singleAddress[0].Address.Town
+        )
+
+        element = document.querySelector(`#${elementIds.address4}`)
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          singleAddress[0].Address.Postcode
         )
       })
 
@@ -133,10 +154,28 @@ describe('/user-details/owner/address-confirm route', () => {
       })
 
       it('should show the selected address', () => {
-        const element = document.querySelector(`#${elementIds.address}`)
+        let element = document.querySelector(`#${elementIds.address1}`)
         expect(element).toBeTruthy()
         expect(TestHelper.getTextContent(element)).toEqual(
-          singleAddress[0].Address.AddressLine
+          singleAddress[0].Address.SubBuildingName
+        )
+
+        element = document.querySelector(`#${elementIds.address2}`)
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          singleAddress[0].Address.Locality
+        )
+
+        element = document.querySelector(`#${elementIds.address3}`)
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          singleAddress[0].Address.Town
+        )
+
+        element = document.querySelector(`#${elementIds.address4}`)
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          singleAddress[0].Address.Postcode
         )
       })
 


### PR DESCRIPTION
Removed full stop on International Address screen.

Reformatted address using multiple lines on Confirm Address screen.

Fixed issue on address entry screen - now pre-populates using BuildingName or SubBuildingName fields, depending on which is populated in the API

Handled 204 response codes in the Address Service, returning an empty array.