### PR TITLE
GOV Pay return URL fix

### DIFF
--- a/server/services/payment.service.js
+++ b/server/services/payment.service.js
@@ -20,7 +20,7 @@ module.exports = class PaymentService {
       amount: amountInPence,
       reference,
       description,
-      return_url: `${config.serviceHost}:${config.servicePort}${Paths.SERVICE_COMPLETE}`,
+      return_url: `${config.serviceHost}${Paths.SERVICE_COMPLETE}`,
       email
     }
 


### PR DESCRIPTION
IVORY 336 and 337 - return URL not working

Removed separate PORT from return URL, now provided as part of the SERVICE_HOST environment variable if needed


e.g.SERVICE_HOST=http://localhost:3000

