### PR TITLE
IVORY-327: Added help text to choose-address screen.

### DIFF
--- a/server/routes/common/address-choose.route.js
+++ b/server/routes/common/address-choose.route.js
@@ -77,7 +77,7 @@ const _getContext = async (request, addressType) => {
   )
 
   const addresses = JSON.parse(
-    await RedisService.get(request, RedisKeys.ADDRESS_FIND)
+    await RedisService.get(request, RedisKeys.ADDRESS_FIND_RESULTS)
   )
 
   const items = addresses.map(item => {
@@ -95,6 +95,8 @@ const _getContext = async (request, addressType) => {
 
   context.addresses = items
 
+  await _addBuildingNameOrNumberAndPostcodeToContext(request, context)
+
   return context
 }
 
@@ -111,6 +113,25 @@ const _getContextForApplicantAddressType = () => {
   return {
     pageTitle: 'Choose your address'
   }
+}
+
+const _addBuildingNameOrNumberAndPostcodeToContext = async (
+  request,
+  context
+) => {
+  const nameOrNumber = await RedisService.get(
+    request,
+    RedisKeys.ADDRESS_FIND_NAME_OR_NUMBER
+  )
+
+  const postcode = await RedisService.get(
+    request,
+    RedisKeys.ADDRESS_FIND_POSTCODE
+  )
+
+  context.showHelpText = nameOrNumber && postcode
+  context.nameOrNumber = nameOrNumber
+  context.postcode = postcode
 }
 
 const _validateForm = payload => {

--- a/server/routes/common/address-confirm.route.js
+++ b/server/routes/common/address-confirm.route.js
@@ -77,7 +77,7 @@ const _getContext = async (request, addressType) => {
   }
 
   const addresses = JSON.parse(
-    await RedisService.get(request, RedisKeys.ADDRESS_FIND)
+    await RedisService.get(request, RedisKeys.ADDRESS_FIND_RESULTS)
   )
 
   context.address = addresses[0].Address

--- a/server/routes/common/address-enter.route.js
+++ b/server/routes/common/address-enter.route.js
@@ -85,7 +85,7 @@ const _getContext = async (request, addressType, isGet) => {
   )
 
   const addresses = JSON.parse(
-    await RedisService.get(request, RedisKeys.ADDRESS_FIND)
+    await RedisService.get(request, RedisKeys.ADDRESS_FIND_RESULTS)
   )
 
   const resultSize = addresses.length

--- a/server/routes/common/address-find.route.js
+++ b/server/routes/common/address-find.route.js
@@ -52,9 +52,22 @@ const handlers = {
       payload.nameOrNumber,
       payload.postcode
     )
+
     await RedisService.set(
       request,
-      RedisKeys.ADDRESS_FIND,
+      RedisKeys.ADDRESS_FIND_NAME_OR_NUMBER,
+      payload.nameOrNumber
+    )
+
+    await RedisService.set(
+      request,
+      RedisKeys.ADDRESS_FIND_POSTCODE,
+      payload.postcode
+    )
+
+    await RedisService.set(
+      request,
+      RedisKeys.ADDRESS_FIND_RESULTS,
       JSON.stringify(searchResults)
     )
 

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -53,7 +53,9 @@ const Views = {
 }
 
 const RedisKeys = {
-  ADDRESS_FIND: 'address-find',
+  ADDRESS_FIND_NAME_OR_NUMBER: 'address-find.nameOrNumber',
+  ADDRESS_FIND_POSTCODE: 'address-find.postcode',
+  ADDRESS_FIND_RESULTS: 'address-find.results',
   APPLICANT_ADDRESS: 'applicant.address',
   APPLICANT_EMAIL_ADDRESS: 'applicant.emailAddress',
   APPLICANT_NAME: 'applicant.name',

--- a/server/views/user-details/address-choose.html
+++ b/server/views/user-details/address-choose.html
@@ -9,16 +9,17 @@
 
     <div class="govuk-grid-column-two-thirds">
 
+
+      <h1 id="pageTitle" class="govuk-heading-l">{{ pageTitle }}</h1>
+
+      {% if showHelpText %}
+        <p id="helpText1">No results for "{{ nameOrNumber }}".</p>
+        <p id="helpText2">Here are all the results for {{ postcode }}.</p>
+      {% endif %}
+
       {{ govukRadios({
         idPrefix: "address",
         name: "address",
-        fieldset: {
-          legend: {
-            text: pageTitle,
-            isPageHeading: true,
-            classes: "govuk-fieldset__legend--l"
-          }
-        },
         errorMessage: fieldErrors['address'],
         items: addresses
       }) }}

--- a/test/routes/owner/address-choose.route.test.js
+++ b/test/routes/owner/address-choose.route.test.js
@@ -25,6 +25,8 @@ describe('/user-details/owner/address-choose route', () => {
 
   const elementIds = {
     pageTitle: 'pageTitle',
+    helpText1: 'helpText1',
+    helpText2: 'helpText2',
     address: 'address',
     address2: 'address-2',
     address3: 'address-3',
@@ -32,7 +34,15 @@ describe('/user-details/owner/address-choose route', () => {
     continue: 'continue'
   }
 
+  const nameOrNumber = '123'
+  const postcode = 'AB12 3CD'
+
   let document
+
+  const getOptions = {
+    method: 'GET',
+    url
+  }
 
   beforeAll(async done => {
     server = await createServer()
@@ -54,16 +64,14 @@ describe('/user-details/owner/address-choose route', () => {
   })
 
   describe('GET', () => {
-    const getOptions = {
-      method: 'GET',
-      url
-    }
     describe('GET: Owned by applicant', () => {
       beforeEach(async () => {
         RedisService.get = jest
           .fn()
           .mockReturnValueOnce('yes')
           .mockReturnValueOnce(JSON.stringify(multipleAddresses))
+          .mockReturnValueOnce(nameOrNumber)
+          .mockReturnValueOnce(postcode)
 
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
@@ -77,10 +85,24 @@ describe('/user-details/owner/address-choose route', () => {
       })
 
       it('should have the correct page heading', () => {
-        const element = document.querySelector('.govuk-fieldset__heading')
+        const element = document.querySelector(`#${elementIds.pageTitle}`)
         expect(element).toBeTruthy()
         expect(TestHelper.getTextContent(element)).toEqual(
           'Choose your address'
+        )
+      })
+
+      it('should have the help text if name/number and postcode were entered', () => {
+        let element = document.querySelector(`#${elementIds.helpText1}`)
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          `No results for "${nameOrNumber}".`
+        )
+
+        element = document.querySelector(`#${elementIds.helpText2}`)
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          `Here are all the results for ${postcode}.`
         )
       })
 
@@ -123,12 +145,37 @@ describe('/user-details/owner/address-choose route', () => {
       })
     })
 
+    describe('GET: Owned by applicant - Hidden help text', () => {
+      beforeEach(async () => {
+        const nameOrNumber = undefined
+
+        RedisService.get = jest
+          .fn()
+          .mockReturnValueOnce('yes')
+          .mockReturnValueOnce(JSON.stringify(multipleAddresses))
+          .mockReturnValueOnce(nameOrNumber)
+          .mockReturnValueOnce(postcode)
+
+        document = await TestHelper.submitGetRequest(server, getOptions)
+      })
+
+      it('should have hidden help text if the name/number was not entered', () => {
+        let element = document.querySelector(`#${elementIds.helpText1}`)
+        expect(element).toBeFalsy()
+
+        element = document.querySelector(`#${elementIds.helpText2}`)
+        expect(element).toBeFalsy()
+      })
+    })
+
     describe('GET: Not owned by applicant', () => {
       beforeEach(async () => {
         RedisService.get = jest
           .fn()
           .mockReturnValueOnce('no')
           .mockReturnValueOnce(JSON.stringify(multipleAddresses))
+          .mockReturnValueOnce(nameOrNumber)
+          .mockReturnValueOnce(postcode)
 
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
@@ -142,10 +189,24 @@ describe('/user-details/owner/address-choose route', () => {
       })
 
       it('should have the correct page heading', () => {
-        const element = document.querySelector('.govuk-fieldset__heading')
+        const element = document.querySelector(`#${elementIds.pageTitle}`)
         expect(element).toBeTruthy()
         expect(TestHelper.getTextContent(element)).toEqual(
           "Choose the owner's address"
+        )
+      })
+
+      it('should have the help text if name/number and postcode were entered', () => {
+        let element = document.querySelector(`#${elementIds.helpText1}`)
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          `No results for "${nameOrNumber}".`
+        )
+
+        element = document.querySelector(`#${elementIds.helpText2}`)
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          `Here are all the results for ${postcode}.`
         )
       })
 
@@ -185,6 +246,29 @@ describe('/user-details/owner/address-choose route', () => {
         const element = document.querySelector(`#${elementIds.continue}`)
         expect(element).toBeTruthy()
         expect(TestHelper.getTextContent(element)).toEqual('Continue')
+      })
+    })
+
+    describe('GET: Not owned by applicant - Hidden help text', () => {
+      beforeEach(async () => {
+        const nameOrNumber = undefined
+
+        RedisService.get = jest
+          .fn()
+          .mockReturnValueOnce('no')
+          .mockReturnValueOnce(JSON.stringify(multipleAddresses))
+          .mockReturnValueOnce(nameOrNumber)
+          .mockReturnValueOnce(postcode)
+
+        document = await TestHelper.submitGetRequest(server, getOptions)
+      })
+
+      it('should have hidden help text if the name/number was not entered', () => {
+        let element = document.querySelector(`#${elementIds.helpText1}`)
+        expect(element).toBeFalsy()
+
+        element = document.querySelector(`#${elementIds.helpText2}`)
+        expect(element).toBeFalsy()
       })
     })
   })


### PR DESCRIPTION
IVORY-327

Added help text to choose-address screen, only visible when a building name / number value and postcode has been entered in the find-address screen but there are no matching addresses.

To facilitate this the nameOrNumber and postcode fields are stored in Redis in the find-address screen and then accessed in the choose-address screen.