### PR TITLE
International Address screen help text

### DIFF
--- a/server/routes/common/address-international.route.js
+++ b/server/routes/common/address-international.route.js
@@ -107,12 +107,12 @@ const _getContextForOwnerAddressType = ownedByApplicant => {
   if (ownedByApplicant === Options.YES) {
     context = {
       pageTitle: 'Enter your address',
-      hintText: 'If your business owns the item, give your business address.'
+      helpText: 'If your business owns the item, give your business address.'
     }
   } else {
     context = {
       pageTitle: "Enter the owner's address",
-      hintText: 'If the owner is a business, give the business address.'
+      helpText: 'If the owner is a business, give the business address.'
     }
   }
   return context
@@ -121,8 +121,8 @@ const _getContextForOwnerAddressType = ownedByApplicant => {
 const _getContextForApplicantAddressType = () => {
   return {
     pageTitle: 'Enter your address',
-    hintText:
-      'If your business is helping someone else sell their item, give your business address'
+    helpText:
+      'If your business is helping someone else sell their item, give your business address.'
   }
 }
 

--- a/server/views/user-details/address-choose.html
+++ b/server/views/user-details/address-choose.html
@@ -13,8 +13,8 @@
       <h1 id="pageTitle" class="govuk-heading-l">{{ pageTitle }}</h1>
 
       {% if showHelpText %}
-        <p id="helpText1">No results for "{{ nameOrNumber }}".</p>
-        <p id="helpText2">Here are all the results for {{ postcode }}.</p>
+        <p id="helpText1" class="govuk-body">No results for "{{ nameOrNumber }}".</p>
+        <p id="helpText2" class="govuk-body">Here are all the results for {{ postcode }}.</p>
       {% endif %}
 
       {{ govukRadios({

--- a/server/views/user-details/address-international.html
+++ b/server/views/user-details/address-international.html
@@ -8,30 +8,23 @@
   <div class="govuk-grid-row">
 
     <div class="govuk-grid-column-two-thirds">
-        {{ govukTextarea({
-          name: "internationalAddress",
-          id: "internationalAddress",
-          label: {
-            text: pageTitle,
-            classes: "govuk-label--l",
-            isPageHeading: true,
-            attributes: {
-              id: "pageTitle"
-            }
-          },
-          value: internationalAddress,
-          hint: {
-            text: hintText
-          },
-          errorMessage: fieldErrors['internationalAddress']
-        }) }}
+      <h1 id="pageTitle" class="govuk-heading-l">{{ pageTitle }}</h1>
 
-        {{ govukButton({
-            attributes: {
-              id: "continue"
-            },
-            text:  "Continue"
-        }) }}
+      <p id="helpText" class="govuk-body">{{ helpText }}</p>
+
+      {{ govukTextarea({
+        name: "internationalAddress",
+        id: "internationalAddress",
+        value: internationalAddress,
+        errorMessage: fieldErrors['internationalAddress']
+      }) }}
+
+      {{ govukButton({
+          attributes: {
+            id: "continue"
+          },
+          text:  "Continue"
+      }) }}
     </div>
   </div>
 {% endblock %}

--- a/test/routes/applicant/address-international.route.test.js
+++ b/test/routes/applicant/address-international.route.test.js
@@ -61,12 +61,26 @@ describe('/user-details/applicant/address-international route', () => {
       TestHelper.checkBackLink(document)
     })
 
+    it('should have the correct page heading', () => {
+      const element = document.querySelector(`#${elementIds.pageTitle}`)
+      expect(element).toBeTruthy()
+      expect(TestHelper.getTextContent(element)).toEqual('Enter your address')
+    })
+
+    it('should have the correct help text', () => {
+      const element = document.querySelector(`#${elementIds.helpText}`)
+      expect(element).toBeTruthy()
+      expect(TestHelper.getTextContent(element)).toEqual(
+        'If your business is helping someone else sell their item, give your business address.'
+      )
+    })
+
     it('should have the "Enter your address" form field', () => {
       TestHelper.checkFormField(
         document,
         elementIds.internationalAddress,
-        'Enter your address',
-        'If your business is helping someone else sell their item, give your business address'
+        '',
+        ''
       )
     })
 

--- a/test/routes/owner/address-international.route.test.js
+++ b/test/routes/owner/address-international.route.test.js
@@ -64,12 +64,26 @@ describe('/user-details/owner/address-international route', () => {
       TestHelper.checkBackLink(document)
     })
 
+    it('should have the correct page heading', () => {
+      const element = document.querySelector(`#${elementIds.pageTitle}`)
+      expect(element).toBeTruthy()
+      expect(TestHelper.getTextContent(element)).toEqual('Enter your address')
+    })
+
+    it('should have the correct help text', () => {
+      const element = document.querySelector(`#${elementIds.helpText}`)
+      expect(element).toBeTruthy()
+      expect(TestHelper.getTextContent(element)).toEqual(
+        'If your business owns the item, give your business address.'
+      )
+    })
+
     it('should have the "Enter your address" form field', () => {
       TestHelper.checkFormField(
         document,
         elementIds.internationalAddress,
-        'Enter your address',
-        'If your business owns the item, give your business address.'
+        '',
+        ''
       )
     })
 
@@ -104,8 +118,8 @@ describe('/user-details/owner/address-international route', () => {
       TestHelper.checkFormField(
         document,
         elementIds.internationalAddress,
-        "Enter the owner's address",
-        'If the owner is a business, give the business address.'
+        '',
+        ''
       )
     })
 

--- a/test/utils/test-helper.js
+++ b/test/utils/test-helper.js
@@ -165,13 +165,20 @@ module.exports = class TestHelper {
     }
 
     element = document.querySelector(`[for="${fieldName}"]`)
-    expect(element).toBeTruthy()
-    expect(TestHelper.getTextContent(element)).toEqual(expectedLabel)
 
+    if (expectedLabel) {
+      expect(element).toBeTruthy()
+      expect(TestHelper.getTextContent(element)).toEqual(expectedLabel)
+    } else {
+      expect(element).toBeFalsy()
+    }
+
+    element = document.querySelector(`#${fieldName}-hint`)
     if (expectedHint) {
-      element = document.querySelector(`#${fieldName}-hint`)
       expect(element).toBeTruthy()
       expect(TestHelper.getTextContent(element)).toEqual(expectedHint)
+    } else {
+      expect(element).toBeFalsy()
     }
   }
 


### PR DESCRIPTION
Reworked address-international so that the help text is rendered as a separate P tag in black text rather than grey hint text.