### PR TITLE
Improvements to address parsing

### DIFF
--- a/server/routes/common/address-enter.route.js
+++ b/server/routes/common/address-enter.route.js
@@ -194,14 +194,8 @@ const _validateForm = payload => {
 }
 
 const _getAddressFieldsFromAddress = address => {
-  const buildingName = _getBuildingName(address)
-
   return {
-    addressLine1: buildingName
-      ? convertToCommaSeparatedTitleCase(buildingName)
-      : `${convertToCommaSeparatedTitleCase(
-          address.BuildingNumber
-        )} ${convertToCommaSeparatedTitleCase(address.Street)}`,
+    addressLine1: convertToCommaSeparatedTitleCase(_buildAddressLine1(address)),
     addressLine2: convertToCommaSeparatedTitleCase(address.Locality),
     townOrCity: convertToCommaSeparatedTitleCase(address.Town),
     postcode: address.Postcode
@@ -222,8 +216,34 @@ const _concatenateAddressFields = payload => {
     .join(', ')
 }
 
-const _getBuildingName = address => {
-  return address.BuildingName || address.SubBuildingName
+const _buildAddressLine1 = address => {
+  let addressLine1 = ''
+  const buildingNameOrNumber = _getBuildingNameOrNumber(address)
+
+  if (buildingNameOrNumber) {
+    addressLine1 += buildingNameOrNumber
+  }
+
+  if (address.Street) {
+    addressLine1 += address.Street
+  } else {
+    addressLine1 = addressLine1.substring(0, addressLine1.length - 2)
+  }
+
+  return addressLine1
+}
+
+const _getBuildingNameOrNumber = address => {
+  let nameOrNumber = ''
+  const fields = ['BuildingName', 'SubBuildingName', 'BuildingNumber']
+
+  for (const field of fields) {
+    const value = address[field]
+    if (value && value.length) {
+      nameOrNumber += `${value}, `
+    }
+  }
+  return nameOrNumber
 }
 
 module.exports = {

--- a/server/views/user-details/address-choose.html
+++ b/server/views/user-details/address-choose.html
@@ -9,7 +9,6 @@
 
     <div class="govuk-grid-column-two-thirds">
 
-
       <h1 id="pageTitle" class="govuk-heading-l">{{ pageTitle }}</h1>
 
       {% if showHelpText %}


### PR DESCRIPTION
IVORY-339

Addresses coming back from the address API can have a combination of one or more different values that make up the first line of the address:

BuildingName, SubBuildingName, BuildingNumber, Street

Any of these may be missing.

This change parses the above fields and builds up a comma-separated addressLine1 according to which one of these are present in the address.