### PR TITLE
Convert input postcode to uppercase

### DIFF
--- a/server/routes/common/address-find.route.js
+++ b/server/routes/common/address-find.route.js
@@ -64,7 +64,7 @@ const handlers = {
     await RedisService.set(
       request,
       RedisKeys.ADDRESS_FIND_POSTCODE,
-      payload.postcode
+      payload.postcode.toUpperCase()
     )
 
     await RedisService.set(


### PR DESCRIPTION
Fixed a bug I noticed during prep for the last demo.

In the Find Address screen, whatever postcode the user has input needs to be saved in Redis in upper case, as it gets played back to them in the Choose Address screen if they have entered a building name or house number that isn't matched.