### PR TITLE
Describe the item page (S10 and S2 descriptions)

### DIFF
--- a/server/routes/check-your-answers.route.js
+++ b/server/routes/check-your-answers.route.js
@@ -4,6 +4,8 @@ const { Paths, Views, RedisKeys } = require('../utils/constants')
 const RedisService = require('../services/redis.service')
 const { buildErrorSummary, Validators } = require('../utils/validation')
 
+const NOT_APPLICABLE = 'N/A'
+
 const handlers = {
   get: async (request, h) => {
     return h.view(Views.CHECK_YOUR_ANSWERS, {
@@ -29,12 +31,23 @@ const handlers = {
 }
 
 const _getContext = async request => {
+  const itemDescription = JSON.parse(
+    await RedisService.get(request, RedisKeys.DESCRIBE_THE_ITEM)
+  )
+
   return {
     pageTitle: 'Check your answers (incomplete)',
     whatTypeOfItemIsIt: await RedisService.get(
       request,
       RedisKeys.WHAT_TYPE_OF_ITEM_IS_IT
     ),
+
+    whatIsItem: itemDescription.whatIsItem,
+    whereIsIvory: itemDescription.whereIsIvory,
+    uniqueFeatures: itemDescription.uniqueFeatures || NOT_APPLICABLE,
+    whereMade: itemDescription.whereMade || NOT_APPLICABLE,
+    whenMade: itemDescription.whenMade || NOT_APPLICABLE,
+
     ivoryVolume: await RedisService.get(request, RedisKeys.IVORY_VOLUME),
     ivoryAge: await RedisService.get(request, RedisKeys.IVORY_AGE),
     ivoryIntegral: await RedisService.get(request, RedisKeys.IVORY_INTEGRAL),

--- a/server/routes/describe-the-item.route.js
+++ b/server/routes/describe-the-item.route.js
@@ -1,13 +1,28 @@
 'use strict'
 
-const { Paths, RedisKeys, Views, ItemType } = require('../utils/constants')
+const {
+  CharacterLimits,
+  ItemType,
+  Paths,
+  RedisKeys,
+  Views
+} = require('../utils/constants')
+const {
+  addPayloadToContext,
+  formatNumberWithCommas
+} = require('../utils/general')
 const RedisService = require('../services/redis.service')
-const { buildErrorSummary } = require('../utils/validation')
+const { buildErrorSummary, Validators } = require('../utils/validation')
 
 const handlers = {
-  get: (request, h) => {
+  get: async (request, h) => {
+    const itemType = await RedisService.get(
+      request,
+      RedisKeys.WHAT_TYPE_OF_ITEM_IS_IT
+    )
+
     return h.view(Views.DESCRIBE_THE_ITEM, {
-      ..._getContext()
+      ...(await _getContext(request, itemType))
     })
   },
 
@@ -15,18 +30,24 @@ const handlers = {
     const payload = request.payload
     const errors = _validateForm(payload)
 
+    const itemType = await RedisService.get(
+      request,
+      RedisKeys.WHAT_TYPE_OF_ITEM_IS_IT
+    )
+
     if (errors.length) {
       return h
         .view(Views.DESCRIBE_THE_ITEM, {
-          ..._getContext(),
+          ...(await _getContext(request, itemType)),
           ...buildErrorSummary(errors)
         })
         .code(400)
     }
 
-    const itemType = await RedisService.get(
+    await RedisService.set(
       request,
-      RedisKeys.WHAT_TYPE_OF_ITEM_IS_IT
+      RedisKeys.DESCRIBE_THE_ITEM,
+      JSON.stringify(payload)
     )
 
     switch (itemType) {
@@ -42,20 +63,89 @@ const handlers = {
   }
 }
 
-const _getContext = () => {
-  return {
-    pageTitle: 'Tell us about the item'
+const _getContext = async (request, itemType) => {
+  const itemDescription = JSON.parse(
+    await RedisService.get(request, RedisKeys.DESCRIBE_THE_ITEM)
+  )
+
+  const context = {
+    pageTitle: 'Tell us about the item',
+    isSection2: itemType === ItemType.HIGH_VALUE
   }
+
+  if (itemDescription) {
+    for (const fieldName in itemDescription) {
+      context[fieldName] = itemDescription[fieldName]
+    }
+  }
+
+  addPayloadToContext(request, context)
+
+  return context
 }
 
 const _validateForm = payload => {
   const errors = []
 
-  // TODO Validation
+  if (Validators.empty(payload.whatIsItem)) {
+    errors.push({
+      name: 'whatIsItem',
+      text: 'You must tell us what the item is'
+    })
+  } else if (Validators.maxLength(payload.whatIsItem, CharacterLimits.Input)) {
+    errors.push({
+      name: 'whatIsItem',
+      text: `You must use fewer than ${formatNumberWithCommas(
+        CharacterLimits.Input
+      )} characters to tell us what the item is`
+    })
+  }
+
+  if (Validators.empty(payload.whereIsIvory)) {
+    errors.push({
+      name: 'whereIsIvory',
+      text: 'You must tell us where the ivory is'
+    })
+  } else if (
+    Validators.maxLength(payload.whereIsIvory, CharacterLimits.Input)
+  ) {
+    errors.push({
+      name: 'whereIsIvory',
+      text: `You must use fewer than ${formatNumberWithCommas(
+        CharacterLimits.Input
+      )} characters to tell us where the ivory is`
+    })
+  }
+
+  if (Validators.maxLength(payload.uniqueFeatures, CharacterLimits.Input)) {
+    errors.push({
+      name: 'uniqueFeatures',
+      text: `You must use fewer than ${formatNumberWithCommas(
+        CharacterLimits.Input
+      )} characters to describe any unique, identifying features`
+    })
+  }
+
+  if (Validators.maxLength(payload.whereMade, CharacterLimits.Input)) {
+    errors.push({
+      name: 'whereMade',
+      text: `You must use fewer than ${formatNumberWithCommas(
+        CharacterLimits.Input
+      )} characters to tell us where the item was made`
+    })
+  }
+
+  if (Validators.maxLength(payload.whenMade, CharacterLimits.Input)) {
+    errors.push({
+      name: 'whenMade',
+      text: `You must use fewer than ${formatNumberWithCommas(
+        CharacterLimits.Input
+      )} characters to tell us when the item was made`
+    })
+  }
 
   return errors
 }
-
 module.exports = [
   {
     method: 'GET',

--- a/server/routes/describe-the-item.route.js
+++ b/server/routes/describe-the-item.route.js
@@ -64,20 +64,16 @@ const handlers = {
 }
 
 const _getContext = async (request, itemType) => {
-  const itemDescription = JSON.parse(
-    await RedisService.get(request, RedisKeys.DESCRIBE_THE_ITEM)
-  )
-
   const context = {
     pageTitle: 'Tell us about the item',
     isSection2: itemType === ItemType.HIGH_VALUE
   }
 
-  if (itemDescription) {
-    for (const fieldName in itemDescription) {
-      context[fieldName] = itemDescription[fieldName]
-    }
-  }
+  const itemDescription = JSON.parse(
+    await RedisService.get(request, RedisKeys.DESCRIBE_THE_ITEM)
+  )
+
+  _addRedisDataToContext(context, itemDescription)
 
   addPayloadToContext(request, context)
 
@@ -146,6 +142,15 @@ const _validateForm = payload => {
 
   return errors
 }
+
+const _addRedisDataToContext = (context, itemDescription) => {
+  if (itemDescription) {
+    for (const fieldName in itemDescription) {
+      context[fieldName] = itemDescription[fieldName]
+    }
+  }
+}
+
 module.exports = [
   {
     method: 'GET',

--- a/server/routes/upload-photos.route.js
+++ b/server/routes/upload-photos.route.js
@@ -16,7 +16,7 @@ const TWO_MINUTES_IN_MS = 120000
 
 const MAX_FILES = 1
 const THUMBNAIL_WIDTH = 1000
-const ALLOWED_EXTENSIONS = ['.JPG', '.JPEG', '.PNG', '.HEIC']
+const ALLOWED_EXTENSIONS = ['.JPG', '.JPEG', '.PNG']
 
 const handlers = {
   get: async (request, h) => {

--- a/server/routes/upload-photos.route.js
+++ b/server/routes/upload-photos.route.js
@@ -11,6 +11,9 @@ const { buildErrorSummary } = require('../utils/validation')
 // TODO: Confirm max individual file size
 const MAX_MEGABYES = 32
 
+// TODO: Decide on request timeout
+const TWO_MINUTES_IN_MS = 120000
+
 const MAX_FILES = 1
 const THUMBNAIL_WIDTH = 1000
 const ALLOWED_EXTENSIONS = ['.JPG', '.JPEG', '.PNG', '.HEIC']
@@ -198,7 +201,8 @@ module.exports = [
         multipart: {
           output: 'file'
         },
-        parse: true
+        parse: true,
+        timeout: TWO_MINUTES_IN_MS
       }
     }
   }

--- a/server/routes/upload-photos.route.js
+++ b/server/routes/upload-photos.route.js
@@ -13,7 +13,7 @@ const MAX_MEGABYES = 32
 
 const MAX_FILES = 1
 const THUMBNAIL_WIDTH = 1000
-const ALLOWED_EXTENSIONS = ['.JPG', '.JPEG', '.PNG']
+const ALLOWED_EXTENSIONS = ['.JPG', '.JPEG', '.PNG', '.HEIC']
 
 const handlers = {
   get: async (request, h) => {
@@ -128,6 +128,7 @@ const _getContext = async request => {
   return {
     pageTitle: !hideHelpText ? 'Add a photo of your item' : 'Add another photo',
     hideHelpText,
+    accept: '.jpg,.jpeg,.png',
     files,
     thumbnails,
     yourPhotosUrl: Paths.YOUR_PHOTOS

--- a/server/routes/what-type-of-item-is-it.route.js
+++ b/server/routes/what-type-of-item-is-it.route.js
@@ -8,7 +8,7 @@ const { buildErrorSummary, Validators } = require('../utils/validation')
 const handlers = {
   get: async (request, h) => {
     return h.view(Views.WHAT_TYPE_OF_ITEM_IS_IT, {
-      ..._getContext()
+      ...(await _getContext(request))
     })
   },
 
@@ -19,7 +19,7 @@ const handlers = {
     if (errors.length) {
       return h
         .view(Views.WHAT_TYPE_OF_ITEM_IS_IT, {
-          ..._getContext(),
+          ...(await _getContext(request)),
           ...buildErrorSummary(errors)
         })
         .code(400)
@@ -42,7 +42,12 @@ const handlers = {
   }
 }
 
-const _getContext = () => {
+const _getContext = async request => {
+  const whatTypeOfItemIsIt = await RedisService.get(
+    request,
+    RedisKeys.WHAT_TYPE_OF_ITEM_IS_IT
+  )
+
   return {
     pageTitle: 'What is your ivory item?',
     items: [
@@ -52,7 +57,8 @@ const _getContext = () => {
         hint: {
           text:
             'Any replacement ivory must have been harvested before 1 January 1975.'
-        }
+        },
+        checked: whatTypeOfItemIsIt === ItemType.MUSICAL
       },
       {
         value: ItemType.TEN_PERCENT,
@@ -60,7 +66,8 @@ const _getContext = () => {
         hint: {
           text:
             'The ivory must be integral to the item. Any replacement ivory must have been harvested before 1 January 1975.'
-        }
+        },
+        checked: whatTypeOfItemIsIt === ItemType.TEN_PERCENT
       },
       {
         value: ItemType.MINIATURE,
@@ -68,7 +75,8 @@ const _getContext = () => {
         hint: {
           text:
             'Any replacement ivory must have been harvested before 1 January 1975.'
-        }
+        },
+        checked: whatTypeOfItemIsIt === ItemType.MINIATURE
       },
       {
         value: ItemType.MUSEUM,
@@ -76,7 +84,8 @@ const _getContext = () => {
         hint: {
           text:
             'This cannot be raw (‘unworked’) ivory. You don’t need to tell us if you are a qualifying museum that’s selling or hiring out an ivory item to another qualifying museum.'
-        }
+        },
+        checked: whatTypeOfItemIsIt === ItemType.MUSEUM
       },
       {
         value: ItemType.HIGH_VALUE,
@@ -84,7 +93,8 @@ const _getContext = () => {
         hint: {
           text:
             'Any replacement ivory must have been harvested before 1 January 1975.'
-        }
+        },
+        checked: whatTypeOfItemIsIt === ItemType.HIGH_VALUE
       }
     ]
   }

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -112,6 +112,7 @@ const RedisKeys = {
   APPLICANT_ADDRESS: 'applicant.address',
   APPLICANT_EMAIL_ADDRESS: 'applicant.emailAddress',
   APPLICANT_NAME: 'applicant.name',
+  DESCRIBE_THE_ITEM: 'describe-the-item',
   INTENTION_FOR_ITEM: 'intention-for-item',
   IVORY_ADDED: 'ivory-added',
   IVORY_AGE: 'ivory-age',

--- a/server/views/check-your-answers.html
+++ b/server/views/check-your-answers.html
@@ -34,6 +34,91 @@
           },
           {
             key: {
+              text: "What is the item?" 
+            },
+            value: {
+              text: whatIsItem
+            },
+            actions: {
+              items: [
+                {
+                  href: "describe-the-item",
+                  text: "Change",
+                  visuallyHiddenText: "What is the item?"
+                }
+              ]
+            }
+          },
+          {
+            key: {
+              text: "Where is the ivory on it?" 
+            },
+            value: {
+              text: whereIsIvory
+            },
+            actions: {
+              items: [
+                {
+                  href: "describe-the-item",
+                  text: "Change",
+                  visuallyHiddenText: "Where is the ivory on it?"
+                }
+              ]
+            }
+          },
+          {
+            key: {
+              text: "Describe any unique, identifying features?" 
+            },
+            value: {
+              text: uniqueFeatures
+            },
+            actions: {
+              items: [
+                {
+                  href: "describe-the-item",
+                  text: "Change",
+                  visuallyHiddenText: "Describe any unique, identifying features?"
+                }
+              ]
+            }
+          },
+          {
+            key: {
+              text: "Where was it made?" 
+            },
+            value: {
+              text: whereMade
+            },
+            actions: {
+              items: [
+                {
+                  href: "describe-the-item",
+                  text: "Change",
+                  visuallyHiddenText: "Where was it made?"
+                }
+              ]
+            }
+          },
+          {
+            key: {
+              text: "When was it made?" 
+            },
+            value: {
+              text: whenMade
+            },
+            actions: {
+              items: [
+                {
+                  href: "describe-the-item",
+                  text: "Change",
+                  visuallyHiddenText: "When was it made?"
+                }
+              ]
+            }
+          },
+          {
+            key: {
               text: "How do you know the item has less than... ivory by volume?"
             },
             value: {

--- a/server/views/describe-the-item.html
+++ b/server/views/describe-the-item.html
@@ -1,6 +1,7 @@
 {% extends 'form-layout.html' %}
 
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block formContent %}
@@ -8,8 +9,88 @@
   <div class="govuk-grid-row">
 
     <div class="govuk-grid-column-two-thirds">
+      
+      {% call govukFieldset({
+          attributes: {
+            id: "pageTitle"
+          },
+          legend: {
+            text: pageTitle,
+            classes: "govuk-fieldset__legend--l",
+            isPageHeading: true
+          }
+      }) %}
 
-      <h1 id="pageTitle" class="govuk-heading-l">{{ pageTitle }}</h1>
+      {{ govukInput({
+          label: {
+            html: '<span class="govuk-!-font-weight-bold">What is the item?</span>'
+          },
+          hint: {
+            text: "For example, 'sword', 'chest of drawers'"
+          },
+          id: "whatIsItem",
+          name: "whatIsItem",
+          value: whatIsItem,
+          errorMessage: fieldErrors['whatIsItem']
+      }) }}
+
+      {{ govukInput({
+          label: {
+            html: '<span class="govuk-!-font-weight-bold">Where is the ivory on it?</span>'
+          },
+          hint: {
+            text: "For example, 'scabbard has ivory inlay', 'chest has ivory knobs'"
+          },
+          id: "whereIsIvory",
+          name: "whereIsIvory",
+          value: whereIsIvory,
+          errorMessage: fieldErrors['whereIsIvory']
+      }) }}
+
+      {{ govukInput({
+          label: {
+            html: '<span class="govuk-!-font-weight-bold">Describe any unique, identifying features (optional)</span>'
+          },
+          hint: {
+            text: "For example, 'handle has a carved image of a soldier', 'one of the feet is cracked'"
+          },
+          id: "uniqueFeatures",
+          name: "uniqueFeatures",
+          value: uniqueFeatures,
+          errorMessage: fieldErrors['uniqueFeatures']
+      }) }}      
+
+      {% if isSection2 %}
+
+        {{ govukInput({
+            label: {
+              html: '<span class="govuk-!-font-weight-bold">Where was it made? (optional)</span>'
+            },
+            hint: {
+              text: "For example, 'Japan', 'Europe'"
+            },
+            id: "whereMade",
+            name: "whereMade",
+            value: whereMade,
+            errorMessage: fieldErrors['whereMade']
+        }) }}      
+
+        {{ govukInput({
+            label: {
+              html: '<span class="govuk-!-font-weight-bold">When was it made? (optional)</span>'
+            },
+            hint: {
+              text: "For example, '5th century', 'Georgian era'"
+            },
+            id: "whenMade",
+            name: "whenMade",
+            value: whenMade,
+            errorMessage: fieldErrors['whenMade']
+        }) }}     
+
+      {% endif %}
+
+    {% endcall %}
 
       {{ govukButton({
           attributes: {

--- a/server/views/upload-photos.html
+++ b/server/views/upload-photos.html
@@ -22,7 +22,7 @@
 
       {{ govukFileUpload({
         attributes: {
-          accept: ".jpg,.jpeg,.png"
+          accept: accept
         },
         id: "files",
         name: "files",

--- a/server/views/who-owns-the-item.html
+++ b/server/views/who-owns-the-item.html
@@ -20,16 +20,7 @@
             }
           },
           errorMessage: fieldErrors['whoOwnsItem'],
-          items: [
-            {
-              value: "I own it",
-              text: "I own it"
-            },
-            {
-              value: "Someone else owns it",
-              text: "Someone else owns it"
-            }
-          ]
+          items: items
         }) }}
 
         {{ govukButton({

--- a/test/routes/describe-the-item.route.test.js
+++ b/test/routes/describe-the-item.route.test.js
@@ -1,0 +1,389 @@
+'use strict'
+
+const createServer = require('../../server')
+
+const TestHelper = require('../utils/test-helper')
+
+jest.mock('../../server/services/redis.service')
+const RedisService = require('../../server/services/redis.service')
+
+const CharacterLimits = require('../mock-data/character-limits')
+
+const ItemTypes = {
+  MUSICAL: 'Musical instrument made before 1975 with less than 20% ivory',
+  TEN_PERCENT: 'Item made before 3 March 1947 with less than 10% ivory',
+  MINIATURE:
+    'Portrait miniature made before 1918 with a surface area less than 320 square centimetres',
+  MUSEUM: 'Item to be sold or hired out to a qualifying museum',
+  HIGH_VALUE:
+    'Item made before 1918 that has outstandingly high artistic, cultural or historical value'
+}
+
+describe('/describe-the-item route', () => {
+  let server
+  const url = '/describe-the-item'
+
+  const nextUrls = {
+    ivoryAge: '/ivory-age',
+    ivoryVolume: '/ivory-volume',
+    uploadPhotos: '/upload-photos',
+    whyIsItemRMI: '/why-is-item-rmi'
+  }
+
+  const elementIds = {
+    pageTitle: 'pageTitle',
+    whatIsItem: 'whatIsItem',
+    whereIsIvory: 'whereIsIvory',
+    uniqueFeatures: 'uniqueFeatures',
+    whereMade: 'whereMade',
+    whenMade: 'whenMade',
+    continue: 'continue'
+  }
+
+  const itemDescription = {
+    whatIsItem: 'chest of drawers',
+    whereIsIvory: 'chest has ivory knobs',
+    uniqueFeatures: 'one of the feet is cracked',
+    whereMade: 'Europe',
+    whenMade: 'Georgian era'
+  }
+
+  let document
+
+  beforeAll(async () => {
+    server = await createServer()
+  })
+
+  afterAll(() => {
+    server.stop()
+  })
+
+  beforeEach(() => {
+    _createMocks()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GET', () => {
+    const getOptions = {
+      method: 'GET',
+      url
+    }
+
+    describe('GET: non-RMI', () => {
+      beforeEach(async () => {
+        RedisService.get = jest
+          .fn()
+          .mockReturnValueOnce(ItemTypes.MUSICAL)
+          .mockReturnValueOnce(JSON.stringify(itemDescription))
+
+        document = await TestHelper.submitGetRequest(server, getOptions)
+      })
+
+      it('should have the Beta banner', () => {
+        TestHelper.checkBetaBanner(document)
+      })
+
+      it('should have the Back link', () => {
+        TestHelper.checkBackLink(document)
+      })
+
+      it('should have the correct page heading', () => {
+        const element = document.querySelector(
+          `#${elementIds.pageTitle} > legend > h1`
+        )
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          'Tell us about the item'
+        )
+      })
+
+      it('should have the "what is the item" form field', () => {
+        TestHelper.checkFormField(
+          document,
+          elementIds.whatIsItem,
+          'What is the item?',
+          "For example, 'sword', 'chest of drawers'",
+          itemDescription.whatIsItem
+        )
+      })
+
+      it('should have the "where is the ivory" form field', () => {
+        TestHelper.checkFormField(
+          document,
+          elementIds.whereIsIvory,
+          'Where is the ivory on it?',
+          "For example, 'scabbard has ivory inlay', 'chest has ivory knobs'",
+          itemDescription.whereIsIvory
+        )
+      })
+
+      it('should have the "unique features" form field', () => {
+        TestHelper.checkFormField(
+          document,
+          elementIds.uniqueFeatures,
+          'Describe any unique, identifying features (optional)',
+          "For example, 'handle has a carved image of a soldier', 'one of the feet is cracked'",
+          itemDescription.uniqueFeatures
+        )
+      })
+
+      it('should NOT have the "where was it made" form field', () => {
+        const element = document.querySelector(`#${elementIds.whereMade}`)
+        expect(element).toBeFalsy()
+      })
+
+      it('should NOT have the "when was it made" form field', () => {
+        const element = document.querySelector(`#${elementIds.whenMade}`)
+        expect(element).toBeFalsy()
+      })
+
+      it('should have the correct Call to Action button', () => {
+        const element = document.querySelector(`#${elementIds.continue}`)
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual('Continue')
+      })
+    })
+
+    describe('GET: RMI', () => {
+      beforeEach(async () => {
+        RedisService.get = jest
+          .fn()
+          .mockReturnValueOnce(ItemTypes.HIGH_VALUE)
+          .mockReturnValueOnce(JSON.stringify(itemDescription))
+
+        document = await TestHelper.submitGetRequest(server, getOptions)
+      })
+
+      it('should have the "where was it made" form field', () => {
+        TestHelper.checkFormField(
+          document,
+          elementIds.whereMade,
+          'Where was it made? (optional)',
+          "For example, 'Japan', 'Europe'",
+          itemDescription.whereMade
+        )
+      })
+
+      it('should have the "when was it made" form field', () => {
+        TestHelper.checkFormField(
+          document,
+          elementIds.whenMade,
+          'When was it made? (optional)',
+          "For example, '5th century', 'Georgian era'",
+          itemDescription.whenMade
+        )
+      })
+    })
+  })
+
+  describe('POST', () => {
+    let postOptions
+
+    beforeEach(() => {
+      postOptions = {
+        method: 'POST',
+        url,
+        payload: {}
+      }
+    })
+
+    describe('Success', () => {
+      it('should store the query terms and address array in Redis and progress to the next route for HIGH VALUE items', async () => {
+        await _checkSuccessfulPost(
+          ItemTypes.HIGH_VALUE,
+          itemDescription,
+          postOptions,
+          server,
+          nextUrls.whyIsItemRMI
+        )
+      })
+
+      it('should store the query terms and address array in Redis and progress to the next route for MINIATURE items', async () => {
+        await _checkSuccessfulPost(
+          ItemTypes.MINIATURE,
+          itemDescription,
+          postOptions,
+          server,
+          nextUrls.ivoryAge
+        )
+      })
+
+      it('should store the query terms and address array in Redis and progress to the next route for MUSEUM items', async () => {
+        await _checkSuccessfulPost(
+          ItemTypes.MUSEUM,
+          itemDescription,
+          postOptions,
+          server,
+          nextUrls.uploadPhotos
+        )
+      })
+
+      it('should store the query terms and address array in Redis and progress to the next route for 10 PERCENT items', async () => {
+        await _checkSuccessfulPost(
+          ItemTypes.TEN_PERCENT,
+          itemDescription,
+          postOptions,
+          server,
+          nextUrls.ivoryVolume
+        )
+      })
+
+      it('should store the query terms and address array in Redis and progress to the next route for MUSICAL items', async () => {
+        await _checkSuccessfulPost(
+          ItemTypes.MUSICAL,
+          itemDescription,
+          postOptions,
+          server,
+          nextUrls.ivoryVolume
+        )
+      })
+    })
+
+    describe('Failure', () => {
+      beforeEach(() => {
+        RedisService.get = jest
+          .fn()
+          .mockReturnValueOnce(ItemTypes.HIGH_VALUE)
+          .mockReturnValueOnce(JSON.stringify(itemDescription))
+      })
+
+      it('should display a validation error message if the user does not enter "What is the item?"', async () => {
+        postOptions.payload = {
+          whatIsItem: '',
+          whereIsIvory: 'SOME_VALUE_2'
+        }
+        await TestHelper.checkFormFieldValidation(
+          postOptions,
+          server,
+          elementIds.whatIsItem,
+          'You must tell us what the item is'
+        )
+      })
+
+      it('should display a validation error message if "What is the item?" is too long', async () => {
+        postOptions.payload = {
+          whatIsItem: `${CharacterLimits.fourThousandCharacters}X`,
+          whereIsIvory: 'SOME_VALUE_2'
+        }
+        await TestHelper.checkFormFieldValidation(
+          postOptions,
+          server,
+          elementIds.whatIsItem,
+          'You must use fewer than 4,000 characters to tell us what the item is'
+        )
+      })
+
+      it('should display a validation error message if the user does not enter "Where is the ivory"', async () => {
+        postOptions.payload = {
+          whatIsItem: 'SOME_VALUE_1',
+          whereIsIvory: ''
+        }
+        await TestHelper.checkFormFieldValidation(
+          postOptions,
+          server,
+          elementIds.whereIsIvory,
+          'You must tell us where the ivory is'
+        )
+      })
+
+      it('should display a validation error message if "Where is the ivory?" is too long', async () => {
+        postOptions.payload = {
+          whatIsItem: 'SOME_VALUE_1',
+          whereIsIvory: `${CharacterLimits.fourThousandCharacters}X`
+        }
+        await TestHelper.checkFormFieldValidation(
+          postOptions,
+          server,
+          elementIds.whereIsIvory,
+          'You must use fewer than 4,000 characters to tell us where the ivory is'
+        )
+      })
+
+      it('should display a validation error message if "Unique features" is too long', async () => {
+        postOptions.payload = {
+          whatIsItem: 'SOME_VALUE_1',
+          whereIsIvory: 'SOME_VALUE_2',
+          uniqueFeatures: `${CharacterLimits.fourThousandCharacters}X`
+        }
+        await TestHelper.checkFormFieldValidation(
+          postOptions,
+          server,
+          elementIds.uniqueFeatures,
+          'You must use fewer than 4,000 characters to describe any unique, identifying features'
+        )
+      })
+
+      it('should display a validation error message if "Where made" is too long', async () => {
+        postOptions.payload = {
+          whatIsItem: 'SOME_VALUE_1',
+          whereIsIvory: 'SOME_VALUE_2',
+          whereMade: `${CharacterLimits.fourThousandCharacters}X`
+        }
+        await TestHelper.checkFormFieldValidation(
+          postOptions,
+          server,
+          elementIds.whereMade,
+          'You must use fewer than 4,000 characters to tell us where the item was made'
+        )
+      })
+
+      it('should display a validation error message if "When made" is too long', async () => {
+        postOptions.payload = {
+          whatIsItem: 'SOME_VALUE_1',
+          whereIsIvory: 'SOME_VALUE_2',
+          whenMade: `${CharacterLimits.fourThousandCharacters}X`
+        }
+        await TestHelper.checkFormFieldValidation(
+          postOptions,
+          server,
+          elementIds.whenMade,
+          'You must use fewer than 4,000 characters to tell us when the item was made'
+        )
+      })
+
+      it('should NOT display any validation error messages if the optional fields are not entered', async () => {
+        postOptions.payload = {
+          whatIsItem: 'SOME_VALUE_1',
+          whereIsIvory: 'SOME_VALUE_2',
+          uniqueFeatures: '',
+          whereMade: '',
+          whenMade: ''
+        }
+        await TestHelper.submitPostRequest(server, postOptions, 302)
+      })
+    })
+  })
+})
+
+const _createMocks = () => {
+  RedisService.set = jest.fn()
+}
+
+const _checkSuccessfulPost = async (
+  itemType,
+  itemDescription,
+  postOptions,
+  server,
+  nextUrl
+) => {
+  RedisService.get = jest
+    .fn()
+    .mockReturnValueOnce(itemType)
+    .mockReturnValueOnce(JSON.stringify(itemDescription))
+
+  postOptions.payload = itemDescription
+
+  const response = await TestHelper.submitPostRequest(server, postOptions, 302)
+
+  expect(RedisService.set).toBeCalledTimes(1)
+  expect(RedisService.set).toBeCalledWith(
+    expect.any(Object),
+    'describe-the-item',
+    JSON.stringify(itemDescription)
+  )
+
+  expect(response.headers.location).toEqual(nextUrl)
+}


### PR DESCRIPTION
IVORY-352: Describe the item page

This change adds the content for the /describe-the-item page.

Included is a function called _addRedisDataToContext. This is responsible for populating the page on GET if we are returning there later, e.g. from Check Your Answers.

A similar fix has been carried out on the following pages:

- what-type-of-item-is-it
- who-owns-the-item

Also included is an increase to the request timeout on the Upload page to 2 minutes to fix a problem that occurred when uploading large files.