### PR TITLE
Add Redis password environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ LOG_LEVEL=warn
 # The configuration for Redis
 REDIS_HOST='127.0.0.1'
 REDIS_PORT=6379
+REDIS_PASSWORD=password
 
 # The configuration for Session tracking
 COOKIE_VALIDATION_PASSWORD=password

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Digital service to support the Ivory Act.
 
 The default values will be used if the environment variables are missing or commented out.
 
-| name                       | description                | required | default         |            valid                   | notes |
+| name                       | description                | required | default         |               valid                | notes |
 | -------------------------- | -------------------------- | :------: | --------------- | :--------------------------------: | ----- |
 | NODE_ENV                   | Node environment           |    no    |                 |    development,test,production     |       |
 | PORT                       | Port number                |    no    | 3000            |                                    |       |
@@ -14,7 +14,8 @@ The default values will be used if the environment variables are missing or comm
 | COOKIE_VALIDATION_PASSWORD | Cookie encoding password   |   yes    |                 |          Any text string           |       |
 | REDIS_HOST                 | Redis server IP address    |    no    | 127.0.0.1       |                                    |       |
 | REDIS_PORT                 | Redis port number          |    no    | 6379            |                                    |       |
-| SERVICE_API_ENABLED        | Enable/disable ivory API   |    no    | false           |            true,false              |       |
+| REDIS_PASSWORD             | Redis password             |    no    |                 |                                    |       |
+| SERVICE_API_ENABLED        | Enable/disable ivory API   |    no    | false           |             true,false             |       |
 | SERVICE_API_HOST           | Ivory API IP address       |    no    | 127.0.0.1       |                                    |       |
 | SERVICE_API_PORT           | Ivory API port number      |    no    | 3010            |                                    |       |
 | ADDRESS_LOOKUP_ENABLED     | Enable/disable address API |    no    | false           |             true,false             |       |

--- a/server/plugins/redis.plugin.js
+++ b/server/plugins/redis.plugin.js
@@ -7,7 +7,8 @@ module.exports = {
   options: {
     settings: {
       host: config.redisHost,
-      port: config.redisPort
+      port: config.redisPort,
+      password: config.redisPassword
     },
     decorate: true
   }

--- a/server/utils/config.js
+++ b/server/utils/config.js
@@ -15,6 +15,7 @@ const schema = joi.object().keys({
   logLevel: joi.string().default('warn'),
   redisHost: joi.string().default('127.0.0.1'),
   redisPort: joi.number().default(6379),
+  redisPassword: joi.string(),
   serviceApiEnabled: joi
     .bool()
     .valid(true, false)
@@ -46,6 +47,7 @@ const config = {
   logLevel: process.env.LOG_LEVEL,
   redisHost: process.env.REDIS_HOST,
   redisPort: process.env.REDIS_PORT,
+  redisPassword: process.env.REDIS_PASSWORD,
   serviceApiEnabled: process.env.SERVICE_API_ENABLED,
   serviceApiHost: process.env.SERVICE_API_HOST,
   serviceApiPort: process.env.SERVICE_API_PORT,


### PR DESCRIPTION
Added Redis password environment variable for use when deploying to Azure environments.

N.B. - Now gives the following warning locally but still seems to work OK:

[WARN] This Redis server's `default` user does not require a password, but a password was supplied