### PR TITLE
Suppress logging of 401 errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/plugins/error-pages.plugin.js
+++ b/server/plugins/error-pages.plugin.js
@@ -17,12 +17,14 @@ module.exports = {
         if (response.isBoom) {
           const statusCode = response.output.statusCode
 
-          // Log the error
-          request.log('error', {
-            statusCode,
-            message: response.message,
-            stack: response.data ? response.data.stack : response.stack
-          })
+          // Log the error, unless it is just a basic authenication issue
+          if (statusCode !== StatusCodes.UNAUTHORIZED) {
+            request.log('error', {
+              statusCode,
+              message: response.message,
+              stack: response.data ? response.data.stack : response.stack
+            })
+          }
 
           if (statusCode === StatusCodes.PAGE_NOT_FOUND) {
             return h.redirect(Paths.PAGE_NOT_FOUND)

--- a/server/routes/errors/page-not-found.route.js
+++ b/server/routes/errors/page-not-found.route.js
@@ -21,5 +21,11 @@ module.exports = [
     method: 'GET',
     path: `${Paths.PAGE_NOT_FOUND}`,
     handler: handlers.get
+  },
+  {
+    // Catch all route
+    method: 'GET',
+    path: '/{p*}',
+    handler: handlers.get
   }
 ]


### PR DESCRIPTION
When basic authentication is turned on, the server writes information to the console whenever the user is prompted for their username and password. These error logs are unnecessary and misleading, as the authentication server error was handled normally, therefore it makes sense to suppress this error logging.

Another thing that was added was a "catch all" for 404 errors (page not found), because otherwise if basic authentication is turned on, the login prompt appears and the user presses 'cancel' then a 404 error occurs. Adding this catch-all prevents that from happening. 