### PR TITLE
Update can-continue route to match new dynamic copy

### DIFF
--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -172,6 +172,7 @@ const RedisKeys = {
   SALE_INTENTION: 'sale-intention',
   UPLOAD_PHOTOS: 'upload-photos',
   UPLOAD_PHOTOS_ERROR: 'upload-photos.error',
+  USED_CHECKER: 'used-checker',
   WHAT_TYPE_OF_ITEM_IS_IT: 'what-type-of-item-is-it',
   WHERE_IS_ITEM: 'where-is-item',
   YOUR_PHOTOS: 'your-photos'

--- a/server/views/can-continue.html
+++ b/server/views/can-continue.html
@@ -10,18 +10,24 @@
 
       <h1 class="govuk-heading-l" id="pageTitle">{{ pageTitle }}</h1>
 
-        <p class="govuk-body" id="listHeading">You’ll need to:</p>
+        <p class="govuk-body" id="listHeading">The following pages will guide you through the process.</p>
 
-        <ul class="govuk-list govuk-list--bullet">
-          <li id="listItem-1">describe the item and how it meets the exemption criteria</li>
-          <li id="listItem-2">upload some photos of it</li>
-          <li id="listItem-3">provide contact details</li>
+        <ol class="govuk-list govuk-list--number">
+          <li id="listItem-1">Add up to 6 photos of the item.</li>
+          <li id="listItem-2">Describe the item and how it meets the exemption criteria.</li>
+
           {% for additionalStep in additionalSteps %}
             <li id="additionalStep-{{ loop.index }}">{{ additionalStep }}</li>
           {% endfor %}
-        </ul>
+        </ol>
 
-        <p class="govuk-body" id="finalParagraph">{{ finalParagraph }}</p>
+        <div class="govuk-inset-text">
+          <p class="govuk-body" id="timeoutParagraph">You can stop half-way through and come back later. We’ll delete your answers if you close your browser or take more than 24 hours to complete the service.</p>
+        </div>
+        
+        {% if isSection2 %}
+          <p class="govuk-body" id="finalParagraph">After you’ve paid for your application, you’ll need to wait up to 30 days for it to be approved by an expert. If it is successful, we’ll send you an exemption certificate so you can sell or hire out your item.</p>
+        {% endif %}
 
       {{ govukButton({
           attributes: {
@@ -31,7 +37,10 @@
         })
       }}
 
-      <p class="govuk-body"><a id="cancelLink" class="govuk-link" href="/">Cancel</a></p>
+      {% if usedChecker %}
+        <p class="govuk-body"><a id="cancelLink" class="govuk-link" href="{{ cancelLink }}">Cancel</a></p>
+      {% endif %}
+
     </div>
   </div>
 {% endblock %}

--- a/test/routes/can-continue.route.test.js
+++ b/test/routes/can-continue.route.test.js
@@ -18,13 +18,19 @@ describe('/ivory-volume route', () => {
     listHeading: 'listHeading',
     listItem1: 'listItem-1',
     listItem2: 'listItem-2',
-    listItem3: 'listItem-3',
     additionalStep1: 'additionalStep-1',
     additionalStep2: 'additionalStep-2',
+    additionalStep3: 'additionalStep-3',
+    timeoutParagraph: 'timeoutParagraph',
     finalParagraph: 'finalParagraph',
     cancelLink: 'cancelLink',
     continue: 'continue'
   }
+
+  const section2Description =
+    'Item made before 1918 that has outstandingly high artistic, cultural or historical value'
+  const section10Description =
+    'Musical instrument made before 1975 with less than 20% ivory'
 
   let document
 
@@ -50,122 +56,389 @@ describe('/ivory-volume route', () => {
       url
     }
 
-    describe('GET: Has the correct details when it is NOT a S2 (high value) item', () => {
-      beforeEach(async () => {
-        document = await TestHelper.submitGetRequest(server, getOptions)
+    describe('Section 2 (high value items)', () => {
+      describe('Used checker', () => {
+        beforeEach(async () => {
+          RedisService.get = jest
+            .fn()
+            .mockResolvedValueOnce('true')
+            .mockResolvedValueOnce(section2Description)
+
+          document = await TestHelper.submitGetRequest(server, getOptions)
+        })
+
+        it('should have the Beta banner', () => {
+          TestHelper.checkBetaBanner(document)
+        })
+
+        it('should have the Back link', () => {
+          TestHelper.checkBackLink(document)
+        })
+
+        it('should have the correct page heading', () => {
+          const element = document.querySelector(`#${elementIds.pageTitle}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'You can now apply for an exemption certificate'
+          )
+        })
+
+        it('should have the correct list heading', () => {
+          const element = document.querySelector(`#${elementIds.listHeading}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'The following pages will guide you through the process.'
+          )
+        })
+
+        it('should have the correct list items', () => {
+          let element = document.querySelector(`#${elementIds.listItem1}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'Add up to 6 photos of the item.'
+          )
+
+          element = document.querySelector(`#${elementIds.listItem2}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'Describe the item and how it meets the exemption criteria.'
+          )
+        })
+
+        it('should have the correct additional list items', () => {
+          let element = document.querySelector(`#${elementIds.additionalStep1}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'Upload any documents that support your application.'
+          )
+
+          element = document.querySelector(`#${elementIds.additionalStep2}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'Provide contact details.'
+          )
+
+          element = document.querySelector(`#${elementIds.additionalStep3}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'Pay a non-refundable administration fee of £250.'
+          )
+        })
+
+        it('should have the correct timeout paragraph', () => {
+          const element = document.querySelector(
+            `#${elementIds.timeoutParagraph}`
+          )
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'You can stop half-way through and come back later. We’ll delete your answers if you close your browser or take more than 24 hours to complete the service.'
+          )
+        })
+
+        it('should have the correct final paragraph', () => {
+          const element = document.querySelector(
+            `#${elementIds.finalParagraph}`
+          )
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'After you’ve paid for your application, you’ll need to wait up to 30 days for it to be approved by an expert. If it is successful, we’ll send you an exemption certificate so you can sell or hire out your item.'
+          )
+        })
+
+        it('should have the correct Call to Action button', () => {
+          const element = document.querySelector(`#${elementIds.continue}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual('Continue')
+        })
+
+        it('should have the correct "Cancel" link', () => {
+          const element = document.querySelector(`#${elementIds.cancelLink}`)
+          TestHelper.checkLink(element, 'Cancel', 'https://www.gov.uk/')
+        })
       })
 
-      it('should have the Beta banner', () => {
-        TestHelper.checkBetaBanner(document)
-      })
+      describe('Not used checker', () => {
+        beforeEach(async () => {
+          RedisService.get = jest
+            .fn()
+            .mockResolvedValueOnce('false')
+            .mockResolvedValueOnce(section2Description)
 
-      it('should have the Back link', () => {
-        TestHelper.checkBackLink(document)
-      })
+          document = await TestHelper.submitGetRequest(server, getOptions)
+        })
 
-      it('should have the correct page heading', () => {
-        const element = document.querySelector(`#${elementIds.pageTitle}`)
-        expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual(
-          'You must now make a self-assessment to sell or hire out your item'
-        )
-      })
+        it('should have the Beta banner', () => {
+          TestHelper.checkBetaBanner(document)
+        })
 
-      it('should have the correct list heading', () => {
-        const element = document.querySelector(`#${elementIds.listHeading}`)
-        expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual('You’ll need to:')
-      })
+        it('should have the Back link', () => {
+          TestHelper.checkBackLink(document)
+        })
 
-      it('should have the correct list item', () => {
-        const element = document.querySelector(`#${elementIds.listItem1}`)
-        expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual(
-          'describe the item and how it meets the exemption criteria'
-        )
-      })
+        it('should have the correct page heading', () => {
+          const element = document.querySelector(`#${elementIds.pageTitle}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'You must now apply for an exemption certificate'
+          )
+        })
 
-      it('should have the correct list item', () => {
-        const element = document.querySelector(`#${elementIds.listItem2}`)
-        expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual(
-          'upload some photos of it'
-        )
-      })
+        it('should have the correct list heading', () => {
+          const element = document.querySelector(`#${elementIds.listHeading}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'The following pages will guide you through the process.'
+          )
+        })
 
-      it('should have the correct list item', () => {
-        const element = document.querySelector(`#${elementIds.listItem3}`)
-        expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual(
-          'provide contact details'
-        )
-      })
+        it('should have the correct list items', () => {
+          let element = document.querySelector(`#${elementIds.listItem1}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'Add up to 6 photos of the item.'
+          )
 
-      it('should have the correct list item', () => {
-        const element = document.querySelector(`#${elementIds.additionalStep1}`)
-        expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual(
-          'pay an administration fee of £20'
-        )
-      })
+          element = document.querySelector(`#${elementIds.listItem2}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'Describe the item and how it meets the exemption criteria.'
+          )
+        })
 
-      it('should have the correct final paragraph', () => {
-        const element = document.querySelector(`#${elementIds.finalParagraph}`)
-        expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual(
-          'As soon as you successfully make the payment, you’ll be able to sell the item or hire it out.'
-        )
-      })
+        it('should have the correct additional list items', () => {
+          let element = document.querySelector(`#${elementIds.additionalStep1}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'Upload any documents that support your application.'
+          )
 
-      it('should have the correct Call to Action button', () => {
-        const element = document.querySelector(`#${elementIds.continue}`)
-        expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual('Continue')
-      })
+          element = document.querySelector(`#${elementIds.additionalStep2}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'Provide contact details.'
+          )
 
-      it('should have the correct "Cancel" link', () => {
-        const element = document.querySelector(`#${elementIds.cancelLink}`)
-        TestHelper.checkLink(element, 'Cancel', '/')
+          element = document.querySelector(`#${elementIds.additionalStep3}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'Pay a non-refundable administration fee of £250.'
+          )
+        })
+
+        it('should have the correct timeout paragraph', () => {
+          const element = document.querySelector(
+            `#${elementIds.timeoutParagraph}`
+          )
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'You can stop half-way through and come back later. We’ll delete your answers if you close your browser or take more than 24 hours to complete the service.'
+          )
+        })
+
+        it('should have the correct final paragraph', () => {
+          const element = document.querySelector(
+            `#${elementIds.finalParagraph}`
+          )
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'After you’ve paid for your application, you’ll need to wait up to 30 days for it to be approved by an expert. If it is successful, we’ll send you an exemption certificate so you can sell or hire out your item.'
+          )
+        })
+
+        it('should have the correct Call to Action button', () => {
+          const element = document.querySelector(`#${elementIds.continue}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual('Continue')
+        })
+
+        it('should NOT have the "Cancel" link', () => {
+          const element = document.querySelector(`#${elementIds.cancelLink}`)
+          expect(element).toBeFalsy()
+        })
       })
     })
 
-    describe('GET: Has the correct details when it IS a S2 (high value) item', () => {
-      beforeEach(async () => {
-        RedisService.get = jest.fn().mockReturnValue(ItemType.HIGH_VALUE)
+    describe('Section 10 (non high value items)', () => {
+      describe('Used checker', () => {
+        beforeEach(async () => {
+          RedisService.get = jest
+            .fn()
+            .mockResolvedValueOnce('true')
+            .mockResolvedValueOnce(section10Description)
 
-        document = await TestHelper.submitGetRequest(server, getOptions)
+          document = await TestHelper.submitGetRequest(server, getOptions)
+        })
+
+        it('should have the Beta banner', () => {
+          TestHelper.checkBetaBanner(document)
+        })
+
+        it('should have the Back link', () => {
+          TestHelper.checkBackLink(document)
+        })
+
+        it('should have the correct page heading', () => {
+          const element = document.querySelector(`#${elementIds.pageTitle}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'You can now make a self-assessment to sell or hire out your item'
+          )
+        })
+
+        it('should have the correct list heading', () => {
+          const element = document.querySelector(`#${elementIds.listHeading}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'The following pages will guide you through the process.'
+          )
+        })
+
+        it('should have the correct list items', () => {
+          let element = document.querySelector(`#${elementIds.listItem1}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'Add up to 6 photos of the item.'
+          )
+
+          element = document.querySelector(`#${elementIds.listItem2}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'Describe the item and how it meets the exemption criteria.'
+          )
+        })
+
+        it('should have the correct additional list items', () => {
+          let element = document.querySelector(`#${elementIds.additionalStep1}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'Provide contact details.'
+          )
+
+          element = document.querySelector(`#${elementIds.additionalStep2}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'Pay a non-refundable administration fee of £20.'
+          )
+        })
+
+        it('should have the correct timeout paragraph', () => {
+          const element = document.querySelector(
+            `#${elementIds.timeoutParagraph}`
+          )
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'You can stop half-way through and come back later. We’ll delete your answers if you close your browser or take more than 24 hours to complete the service.'
+          )
+        })
+
+        it('should NOT have the final paragraph', () => {
+          const element = document.querySelector(
+            `#${elementIds.finalParagraph}`
+          )
+          expect(element).toBeFalsy()
+        })
+
+        it('should have the correct Call to Action button', () => {
+          const element = document.querySelector(`#${elementIds.continue}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual('Continue')
+        })
+
+        it('should have the correct "Cancel" link', () => {
+          const element = document.querySelector(`#${elementIds.cancelLink}`)
+          TestHelper.checkLink(element, 'Cancel', 'https://www.gov.uk/')
+        })
       })
 
-      it('should have the correct page heading', () => {
-        const element = document.querySelector(`#${elementIds.pageTitle}`)
-        expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual(
-          'You must now apply for an exemption certificate'
-        )
-      })
+      describe('Not used checker', () => {
+        beforeEach(async () => {
+          RedisService.get = jest
+            .fn()
+            .mockResolvedValueOnce('false')
+            .mockResolvedValueOnce(section10Description)
 
-      it('should have the correct list item', () => {
-        const element = document.querySelector(`#${elementIds.additionalStep1}`)
-        expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual(
-          'pay a non-refundable administration fee of £250'
-        )
-      })
+          document = await TestHelper.submitGetRequest(server, getOptions)
+        })
 
-      it('should have the correct list item', () => {
-        const element = document.querySelector(`#${elementIds.additionalStep2}`)
-        expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual(
-          'wait 30 days for your application to be approved by an expert'
-        )
-      })
+        it('should have the Beta banner', () => {
+          TestHelper.checkBetaBanner(document)
+        })
 
-      it('should have the correct final paragraph', () => {
-        const element = document.querySelector(`#${elementIds.finalParagraph}`)
-        expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual(
-          'If your application is successful, we will send you an exemption certificate so you can sell or hire out your item.'
-        )
+        it('should have the Back link', () => {
+          TestHelper.checkBackLink(document)
+        })
+
+        it('should have the correct page heading', () => {
+          const element = document.querySelector(`#${elementIds.pageTitle}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'You must now make a self-assessment to sell or hire out your item'
+          )
+        })
+
+        it('should have the correct list heading', () => {
+          const element = document.querySelector(`#${elementIds.listHeading}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'The following pages will guide you through the process.'
+          )
+        })
+
+        it('should have the correct list items', () => {
+          let element = document.querySelector(`#${elementIds.listItem1}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'Add up to 6 photos of the item.'
+          )
+
+          element = document.querySelector(`#${elementIds.listItem2}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'Describe the item and how it meets the exemption criteria.'
+          )
+        })
+
+        it('should have the correct additional list items', () => {
+          let element = document.querySelector(`#${elementIds.additionalStep1}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'Provide contact details.'
+          )
+
+          element = document.querySelector(`#${elementIds.additionalStep2}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'Pay a non-refundable administration fee of £20.'
+          )
+        })
+
+        it('should have the correct timeout paragraph', () => {
+          const element = document.querySelector(
+            `#${elementIds.timeoutParagraph}`
+          )
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual(
+            'You can stop half-way through and come back later. We’ll delete your answers if you close your browser or take more than 24 hours to complete the service.'
+          )
+        })
+
+        it('should NOT have the final paragraph', () => {
+          const element = document.querySelector(
+            `#${elementIds.finalParagraph}`
+          )
+          expect(element).toBeFalsy()
+        })
+
+        it('should have the correct Call to Action button', () => {
+          const element = document.querySelector(`#${elementIds.continue}`)
+          expect(element).toBeTruthy()
+          expect(TestHelper.getTextContent(element)).toEqual('Continue')
+        })
+
+        it('should NOT have the "Cancel" link', () => {
+          const element = document.querySelector(`#${elementIds.cancelLink}`)
+          expect(element).toBeFalsy()
+        })
       })
     })
   })

--- a/test/routes/eligibility-checker/how-certain.route.test.js
+++ b/test/routes/eligibility-checker/how-certain.route.test.js
@@ -1,5 +1,8 @@
 'use strict'
 
+jest.mock('../../../server/services/redis.service')
+const RedisService = require('../../../server/services/redis.service')
+
 const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
@@ -8,7 +11,8 @@ describe('/eligibility-checker/how-certain route', () => {
   let server
   const url = '/eligibility-checker/how-certain'
   const nextUrlTypeOfItem = '/what-type-of-item-is-it'
-  const nextUrlContainElephantIvory = '/eligibility-checker/contain-elephant-ivory'
+  const nextUrlContainElephantIvory =
+    '/eligibility-checker/contain-elephant-ivory'
 
   const elementIds = {
     help1: 'help1',
@@ -26,6 +30,14 @@ describe('/eligibility-checker/how-certain route', () => {
 
   afterAll(() => {
     server.stop()
+  })
+
+  beforeEach(() => {
+    _createMocks()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
   })
 
   describe('GET', () => {
@@ -49,19 +61,25 @@ describe('/eligibility-checker/how-certain route', () => {
     it('should have the correct page heading', () => {
       const element = document.querySelector('.govuk-fieldset__legend')
       expect(element).toBeTruthy()
-      expect(TestHelper.getTextContent(element)).toEqual('How certain are you that your item is exempt?')
+      expect(TestHelper.getTextContent(element)).toEqual(
+        'How certain are you that your item is exempt?'
+      )
     })
 
     it('should have the correct help text 1', () => {
       const element = document.querySelector(`#${elementIds.help1}`)
       expect(element).toBeTruthy()
-      expect(TestHelper.getTextContent(element)).toEqual('To use this service, you must be completely certain.')
+      expect(TestHelper.getTextContent(element)).toEqual(
+        'To use this service, you must be completely certain.'
+      )
     })
 
     it('should have the correct help text 2', () => {
       const element = document.querySelector(`#${elementIds.help2}`)
       expect(element).toBeTruthy()
-      expect(TestHelper.getTextContent(element)).toEqual('If you’re still unsure, we can help you decide.')
+      expect(TestHelper.getTextContent(element)).toEqual(
+        'If you’re still unsure, we can help you decide.'
+      )
     })
 
     it('should have the correct radio buttons', () => {
@@ -104,7 +122,8 @@ describe('/eligibility-checker/how-certain route', () => {
           postOptions,
           server,
           'Completely',
-          nextUrlTypeOfItem
+          nextUrlTypeOfItem,
+          true
         )
       })
 
@@ -113,7 +132,8 @@ describe('/eligibility-checker/how-certain route', () => {
           postOptions,
           server,
           'I’d like some help to work this out',
-          nextUrlContainElephantIvory
+          nextUrlContainElephantIvory,
+          false
         )
       })
     })
@@ -137,15 +157,30 @@ describe('/eligibility-checker/how-certain route', () => {
   })
 })
 
+const _createMocks = () => {
+  RedisService.set = jest.fn()
+}
+
 const _checkSelectedRadioAction = async (
   postOptions,
   server,
   selectedOption,
-  nextUrl
+  nextUrl,
+  expectedRedisValue
 ) => {
   postOptions.payload.howCertain = selectedOption
 
+  expect(RedisService.set).toBeCalledTimes(0)
+
   const response = await TestHelper.submitPostRequest(server, postOptions)
+
+  expect(RedisService.set).toBeCalledTimes(1)
+
+  expect(RedisService.set).toBeCalledWith(
+    expect.any(Object),
+    'used-checker',
+    expectedRedisValue
+  )
 
   expect(response.headers.location).toEqual(nextUrl)
 }

--- a/test/routes/eligibility-checker/how-certain.route.test.js
+++ b/test/routes/eligibility-checker/how-certain.route.test.js
@@ -123,7 +123,7 @@ describe('/eligibility-checker/how-certain route', () => {
           server,
           'Completely',
           nextUrlTypeOfItem,
-          true
+          false
         )
       })
 
@@ -133,7 +133,7 @@ describe('/eligibility-checker/how-certain route', () => {
           server,
           'I’d like some help to work this out',
           nextUrlContainElephantIvory,
-          false
+          true
         )
       })
     })


### PR DESCRIPTION
IVORY-368

The can-continue route has been updated. There is now new copy that is dynamic based on two conditions:

1. Whether or not it is a Section 2 item
2. Whether or not the user has used the eligibility checker