### PR TITLE
Fixed missing copy on image upload screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/views/upload-photos.html
+++ b/server/views/upload-photos.html
@@ -26,15 +26,15 @@
           </ul>
 
           <h2 id="helpTextSubHeading" class="govuk-heading-m">Upload photo</h2>
-
-          <p id="helpText5" class="govuk-body">The photo must be:</p>
-
-          <ul id="helpText6" class="govuk-list govuk-list--bullet">
-            <li>in JPG or PNG format</li>
-            <li>smaller than {{ maximumFileSize }}mb</li>
-          </ul>
         </span>
       {% endif %}
+
+        <p id="helpText5" class="govuk-body">The photo must be:</p>
+
+        <ul id="helpText6" class="govuk-list govuk-list--bullet">
+          <li>in JPG or PNG format</li>
+          <li>smaller than {{ maximumFileSize }}mb</li>
+        </ul>
 
       {{ govukFileUpload({
         attributes: {

--- a/test/routes/upload-photos.route.test.js
+++ b/test/routes/upload-photos.route.test.js
@@ -177,14 +177,17 @@ describe('/upload-photos route', () => {
         expect(TestHelper.getTextContent(element)).toEqual('Add another photo')
       })
 
-      it('should not have the help text', () => {
+      it('should have the correct help text', () => {
         TestHelper.checkElementsDoNotExist(document, [
           `#${elementIds.helpText1}`,
           `#${elementIds.helpText2}`,
           `#${elementIds.helpText3}`,
           `#${elementIds.helpText4} > li:nth-child(1)`,
           `#${elementIds.helpText4} > li:nth-child(2)`,
-          `#${elementIds.helpTextSubHeading}`,
+          `#${elementIds.helpTextSubHeading}`
+        ])
+
+        TestHelper.checkElementsExist(document, [
           `#${elementIds.helpText5}`,
           `#${elementIds.helpText6} > li:nth-child(1)`,
           `#${elementIds.helpText6} > li:nth-child(2)`

--- a/test/services/active-directory-auth.service.test.TODO.js
+++ b/test/services/active-directory-auth.service.test.TODO.js
@@ -1,0 +1,44 @@
+'use strict'
+
+// const nock = require('nock')
+// const config = require('../../server/utils/config')
+
+jest.mock('adal-node')
+// const AdalNode = require('adal-node')
+
+const ActiveDirectorAuthService = require('../../server/services/active-directory-auth.service')
+
+describe('ActiveDirectorAuth service', () => {
+  beforeEach(() => {
+    _createMocks()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('getToken method', () => {
+    it('should get an auth token', async () => {
+      const response = await ActiveDirectorAuthService.getToken()
+
+      console.log(response)
+      // const body = {
+      //   key1: 'value 1',
+      //   key2: 'value 2',
+      //   key3: 'value 3'
+      // }
+      // expect(ActiveDirectoryAuthService.getToken).toBeCalledTimes(0)
+      // const entity = await ODataService.createRecord(body, true)
+      // expect(ActiveDirectoryAuthService.getToken).toBeCalledTimes(1)
+      // expect(entity).toEqual({
+      //   cre2c_ivorysection2caseid: mockSection2Entity.cre2c_ivorysection2caseid
+      // })
+    })
+  })
+})
+
+const _createMocks = () => {
+  // const AuthenticationContext = AdalNode.AuthenticationContext
+  // const context = new AuthenticationContext(authorityUrl)
+  // context.acquireTokenWithClientCredentials(
+}

--- a/test/utils/test-helper.js
+++ b/test/utils/test-helper.js
@@ -108,7 +108,7 @@ module.exports = class TestHelper {
     if (elementIds && Array.isArray(elementIds) && elementIds.length) {
       for (let i = 0; i < elementIds.length; i++) {
         try {
-          expect(document.querySelector(`#${elementIds[i]}`)).toBeTruthy()
+          expect(document.querySelector(`${elementIds[i]}`)).toBeTruthy()
         } catch (e) {
           throw new Error(`Element with ID [${elementIds[i]}] does not exist`)
         }


### PR DESCRIPTION
Fixed bug in /upload-photos screen, some helptext should always be displayed regardless of how many images have been uploaded. This is now fixed.