### PR TITLE
Fixed cookie timeout problem - config not being applied.

### DIFF
--- a/server/utils/cookie-config.js
+++ b/server/utils/cookie-config.js
@@ -2,7 +2,7 @@
 const config = require('./config')
 
 const cookieOptions = {
-  ttl: undefined, // Session lifespan (deleted when browser closed)
+  ttl: config.cookieTimeout, // Timeout after number of milliseconds specified in the config
   isSecure: true, // Secure
   isHttpOnly: true, // and non-secure
   isSameSite: 'None', // Attach cookies on cross-site requests


### PR DESCRIPTION
IVORY-410

User session cookies should expire after 24 hours.

The cookie timeout specified in the config was not being applied, therefore the cookies would not time out in any browser. This is now fixed.