### PR TITLE
Bug fixes - 441 and 443

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/routes/ivory-integral.route.js
+++ b/server/routes/ivory-integral.route.js
@@ -34,7 +34,7 @@ const handlers = {
       RedisKeys.IVORY_INTEGRAL,
       payload.ivoryIsIntegral
     )
-    return h.redirect(Paths.UPLOAD_PHOTO)
+    return h.redirect(Paths.IVORY_AGE)
   }
 }
 

--- a/server/routes/ivory-volume.route.js
+++ b/server/routes/ivory-volume.route.js
@@ -2,6 +2,7 @@
 
 const {
   CharacterLimits,
+  ItemType,
   IvoryVolumeReasons,
   Paths,
   RedisKeys,
@@ -46,7 +47,14 @@ const handlers = {
       JSON.stringify(payload)
     )
 
-    return h.redirect(Paths.IVORY_AGE)
+    const itemType = await RedisService.get(
+      request,
+      RedisKeys.WHAT_TYPE_OF_ITEM_IS_IT
+    )
+
+    return h.redirect(
+      itemType === ItemType.TEN_PERCENT ? Paths.IVORY_INTEGRAL : Paths.IVORY_AGE
+    )
   }
 }
 

--- a/server/views/intention-for-item.html
+++ b/server/views/intention-for-item.html
@@ -20,7 +20,8 @@
           }
         },
         errorMessage: fieldErrors['intentionForItem'],
-        items: items
+        items: items,
+        value: intentionForItem
       }) }}
 
       {{ govukButton({

--- a/server/views/ivory-volume.html
+++ b/server/views/ivory-volume.html
@@ -22,16 +22,13 @@
         }) }}
       {% endset -%}
 
+      <h1 id="pageTitle" class="govuk-heading-l">{{ pageTitle }}</h1>
+
+      <p class="govuk-body" id="para1">You must keep any physical evidence that supports your answer. We may ask for it at a later date, if we decide to check your self-assessment.</p>
+
       {{ govukRadios({
         idPrefix: "ivoryVolume",
         name: "ivoryVolume",
-        fieldset: {
-          legend: {
-            text: pageTitle,
-            isPageHeading: true,
-            classes: "govuk-fieldset__legend--l"
-          }
-        },
         errorMessage: fieldErrors['ivoryVolume'],
         items: [
           {

--- a/test/routes/intention-for-item.route.test.js
+++ b/test/routes/intention-for-item.route.test.js
@@ -69,21 +69,24 @@ describe('/intention-for-item route', () => {
         document,
         elementIds.intentionForItem,
         'Sell it',
-        'Sell it'
+        'Sell it',
+        true
       )
 
       TestHelper.checkRadioOption(
         document,
         elementIds.intentionForItem2,
         'Hire it out',
-        'Hire it out'
+        'Hire it out',
+        false
       )
 
       TestHelper.checkRadioOption(
         document,
         elementIds.intentionForItem3,
         "I'm not sure yet",
-        "I'm not sure yet"
+        "I'm not sure yet",
+        false
       )
     })
 
@@ -150,6 +153,8 @@ describe('/intention-for-item route', () => {
 
 const _createMocks = () => {
   TestHelper.createMocks()
+
+  RedisService.get = jest.fn().mockResolvedValue('Sell it')
 }
 
 const _checkSelectedRadioAction = async (

--- a/test/routes/ivory-integral.route.test.js
+++ b/test/routes/ivory-integral.route.test.js
@@ -11,7 +11,7 @@ const RedisService = require('../../server/services/redis.service')
 describe('/ivory-integral route', () => {
   let server
   const url = '/ivory-integral'
-  const nextUrlUploadPhotos = '/upload-photo'
+  const nextUrl = '/ivory-age'
 
   const elementIds = {
     ivoryIsIntegral: 'ivoryIsIntegral',
@@ -111,7 +111,7 @@ describe('/ivory-integral route', () => {
           postOptions,
           server,
           'The ivory is essential to the design or function of the item',
-          nextUrlUploadPhotos
+          nextUrl
         )
       })
 
@@ -120,7 +120,7 @@ describe('/ivory-integral route', () => {
           postOptions,
           server,
           'You cannot remove the ivory easily or without damaging the item',
-          nextUrlUploadPhotos
+          nextUrl
         )
       })
 
@@ -129,7 +129,7 @@ describe('/ivory-integral route', () => {
           postOptions,
           server,
           'Both of the above',
-          nextUrlUploadPhotos
+          nextUrl
         )
       })
     })

--- a/test/routes/ivory-volume.route.test.js
+++ b/test/routes/ivory-volume.route.test.js
@@ -19,6 +19,8 @@ describe('/ivory-volume route', () => {
   const nextUrl = '/ivory-age'
 
   const elementIds = {
+    pageTitle: 'pageTitle',
+    para1: 'para1',
     ivoryVolume: 'ivoryVolume',
     ivoryVolume2: 'ivoryVolume-2',
     ivoryVolume3: 'ivoryVolume-3',
@@ -70,10 +72,18 @@ describe('/ivory-volume route', () => {
       })
 
       it('should have the correct page heading', () => {
-        const element = document.querySelector('.govuk-fieldset__legend')
+        const element = document.querySelector(`#${elementIds.pageTitle}`)
         expect(element).toBeTruthy()
         expect(TestHelper.getTextContent(element)).toEqual(
           'How do you know the item has less than 10% ivory by volume?'
+        )
+      })
+
+      it('should have the correct help text', () => {
+        const element = document.querySelector(`#${elementIds.para1}`)
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          'You must keep any physical evidence that supports your answer. We may ask for it at a later date, if we decide to check your self-assessment.'
         )
       })
 
@@ -133,7 +143,7 @@ describe('/ivory-volume route', () => {
       })
 
       it('should have the correct page heading', () => {
-        const element = document.querySelector('.govuk-fieldset__legend')
+        const element = document.querySelector(`#${elementIds.pageTitle}`)
         expect(element).toBeTruthy()
         expect(TestHelper.getTextContent(element)).toEqual(
           'How do you know the item has less than 20% ivory by volume?'


### PR DESCRIPTION
IVORY-441: Populate /intention-for-item screen
IVORY-442: Bug in page flow
IVORY-443: Missing help text on /ivory-volume screen

This fixes an issue when returning to the intention-for-item screen from Check Your Answers - the previously selected value was not being selected when returning to the page.

Also fixes a bug in the page flow for <10% items.

Also adds missing help text on /ivory-volume screen