### PR TITLE
Modify page flow in /legal-responsibility after visiting Check Your Answers page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/routes/legal-responsibility.route.js
+++ b/server/routes/legal-responsibility.route.js
@@ -10,8 +10,14 @@ const handlers = {
     })
   },
 
-  post: (request, h) => {
-    return h.redirect(Paths.UPLOAD_PHOTO)
+  post: async (request, h) => {
+    const uploadData = JSON.parse(
+      await RedisService.get(request, RedisKeys.UPLOAD_PHOTO)
+    )
+
+    return uploadData && uploadData.files && uploadData.files.length
+      ? h.redirect(Paths.YOUR_PHOTOS)
+      : h.redirect(Paths.UPLOAD_PHOTO)
   }
 }
 

--- a/test/routes/legal-responsibility.route.test.js
+++ b/test/routes/legal-responsibility.route.test.js
@@ -12,7 +12,8 @@ const RedisService = require('../../server/services/redis.service')
 describe('/legal-responsibility route', () => {
   let server
   const url = '/legal-responsibility'
-  const nextUrl = '/upload-photo'
+  const nextUrlNoPhotos = '/upload-photo'
+  const nextUrlSomePhotos = '/your-photos'
 
   const elementIds = {
     pageTitle: 'pageTitle',
@@ -152,13 +153,32 @@ describe('/legal-responsibility route', () => {
     })
 
     describe('Success', () => {
-      it('should redirect', async () => {
+      it('should redirect the correct route when there are no uploaded photos', async () => {
+        RedisService.get = jest.fn().mockResolvedValue(JSON.stringify({}))
+
         const response = await TestHelper.submitPostRequest(server, postOptions)
-        expect(response.headers.location).toEqual(nextUrl)
+        expect(response.headers.location).toEqual(nextUrlNoPhotos)
+      })
+
+      it('should redirect the correct route when there are some uploaded photos', async () => {
+        RedisService.get = jest
+          .fn()
+          .mockResolvedValue(JSON.stringify(mockPhotos))
+
+        const response = await TestHelper.submitPostRequest(server, postOptions)
+        expect(response.headers.location).toEqual(nextUrlSomePhotos)
       })
     })
   })
 })
+
+const mockPhotos = {
+  files: ['1.png'],
+  fileData: ['file-data'],
+  fileSizes: [100],
+  thumbnails: ['1-thumbnail.png'],
+  thumbnailData: ['thumbnail-data']
+}
 
 const _createMocks = () => {
   TestHelper.createMocks()


### PR DESCRIPTION
IVORY-444: Modify page flow after visiting Check Your Answers

When at the /legal-responsibility page, if there are already some uploaded photos, the next page is now /your-photos, otherwise the next page is /upload-photo.