### PR TITLE
Revert change that added help text to the /ivory-volume page

### DIFF
--- a/server/views/ivory-volume.html
+++ b/server/views/ivory-volume.html
@@ -24,8 +24,6 @@
 
       <h1 id="pageTitle" class="govuk-heading-l">{{ pageTitle }}</h1>
 
-      <p class="govuk-body" id="para1">You must keep any physical evidence that supports your answer. We may ask for it at a later date, if we decide to check your self-assessment.</p>
-
       {{ govukRadios({
         idPrefix: "ivoryVolume",
         name: "ivoryVolume",

--- a/test/routes/ivory-volume.route.test.js
+++ b/test/routes/ivory-volume.route.test.js
@@ -20,7 +20,6 @@ describe('/ivory-volume route', () => {
 
   const elementIds = {
     pageTitle: 'pageTitle',
-    para1: 'para1',
     ivoryVolume: 'ivoryVolume',
     ivoryVolume2: 'ivoryVolume-2',
     ivoryVolume3: 'ivoryVolume-3',
@@ -76,14 +75,6 @@ describe('/ivory-volume route', () => {
         expect(element).toBeTruthy()
         expect(TestHelper.getTextContent(element)).toEqual(
           'How do you know the item has less than 10% ivory by volume?'
-        )
-      })
-
-      it('should have the correct help text', () => {
-        const element = document.querySelector(`#${elementIds.para1}`)
-        expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual(
-          'You must keep any physical evidence that supports your answer. We may ask for it at a later date, if we decide to check your self-assessment.'
         )
       })
 


### PR DESCRIPTION
IVORY-443: Remove help text

Revert change that added help text to the /ivory-volume page