### PR TITLE
Fixed error when saving Museum item type records

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/routes/save-record.route.js
+++ b/server/routes/save-record.route.js
@@ -166,7 +166,7 @@ const _getCommonFields = async (request, itemDescription) => {
     [DataVerseFieldName.WHY_AGE_EXEMPT]: _getAgeExemptionReasonCodes(ivoryAge),
     [DataVerseFieldName.WHY_AGE_EXEMPT_OTHER_REASON]: ivoryAge
       ? ivoryAge.otherReason
-      : '',
+      : null,
     [DataVerseFieldName.WHERE_IS_THE_IVORY]: itemDescription.whereIsIvory,
     [DataVerseFieldName.ITEM_SUMMARY]: itemDescription.whatIsItem,
     [DataVerseFieldName.UNIQUE_FEATURES]: itemDescription.uniqueFeatures,

--- a/server/routes/save-record.route.js
+++ b/server/routes/save-record.route.js
@@ -246,7 +246,7 @@ const _getAgeExemptionReasonCodes = ivoryAgeReasons =>
     ? ivoryAgeReasons.ivoryAge
         .map(ivoryAgeReason => AgeExemptionReasonLookup[ivoryAgeReason])
         .join(',')
-    : ''
+    : null
 
 const _getIntentionCategoryCode = intention => IntentionLookup[intention]
 


### PR DESCRIPTION
IVORY-446: Error when saving Museum item type records

When the Item Type is Museam, there was an error saving the record in PowerApps, because empty values were being passed in as empty strings rather than null, which are not valid values.