### PR TITLE
Add S2 confirmation emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,7 @@ ADDRESS_LOOKUP_ENABLED=false
 
 # The configuration for Gov Notify
 #GOV_NOTIFY_KEY=
+#GOV_NOTIFY_TEMPLATE_ID_CONFIRM_SECTION_2=
 #GOV_NOTIFY_TEMPLATE_ID_CONFIRM_SECTION_10=
 
 # The configuration for Gov Pay

--- a/server/routes/service-complete.route.js
+++ b/server/routes/service-complete.route.js
@@ -38,9 +38,7 @@ const handlers = {
 
     const context = await _getContext(request, isSection2)
 
-    if (!isSection2) {
-      _sendConfirmationEmail(request, context, itemType)
-    }
+    _sendConfirmationEmail(request, isSection2, context, itemType)
 
     return h.view(Views.SERVICE_COMPLETE, {
       ...context
@@ -97,7 +95,12 @@ const _paymentFailed = state =>
 const _paymentError = state =>
   state && state.status && state.status === PaymentResult.ERROR
 
-const _sendConfirmationEmail = async (request, context, itemType) => {
+const _sendConfirmationEmail = async (
+  request,
+  isSection2,
+  context,
+  itemType
+) => {
   let messageSent = await RedisService.get(
     request,
     RedisKeys.CONFIRMATION_EMAIL_SENT
@@ -111,6 +114,7 @@ const _sendConfirmationEmail = async (request, context, itemType) => {
     }
 
     messageSent = await NotificationService.sendConfirmationEmail(
+      isSection2,
       context.applicantEmail,
       data
     )

--- a/server/services/notification.service.js
+++ b/server/services/notification.service.js
@@ -7,7 +7,7 @@ const config = require('../utils/config')
 const NotifyClient = require('notifications-node-client').NotifyClient
 
 class NotificationService {
-  static async sendConfirmationEmail (recipientEmail, data) {
+  static async sendConfirmationEmail (isSection2, recipientEmail, data) {
     const notifyClient = new NotifyClient(config.govNotifyKey)
 
     const personalisation = {
@@ -23,7 +23,9 @@ class NotificationService {
       )
 
       await notifyClient.sendEmail(
-        config.govNotifyTemplateIdConfirmSection10,
+        isSection2
+          ? config.govNotifyTemplateIdConfirmSection2
+          : config.govNotifyTemplateIdConfirmSection10,
         recipientEmail,
         {
           personalisation,

--- a/test/routes/service-complete.route.test.js
+++ b/test/routes/service-complete.route.test.js
@@ -342,10 +342,10 @@ describe('/service-complete route', () => {
         PaymentService.lookupPayment = jest.fn().mockReturnValue(payment)
       })
 
-      it('should NOT send a confirmation email', async () => {
+      it('should send a confirmation email', async () => {
         expect(NotificationService.sendConfirmationEmail).toBeCalledTimes(0)
         document = await TestHelper.submitGetRequest(server, getOptions)
-        expect(NotificationService.sendConfirmationEmail).toBeCalledTimes(0)
+        expect(NotificationService.sendConfirmationEmail).toBeCalledTimes(1)
       })
     })
   })

--- a/test/services/notification.service.test.js
+++ b/test/services/notification.service.test.js
@@ -23,6 +23,7 @@ describe('Address service', () => {
     const RECIPIENT_NAME = 'RECIPIENT_NAME'
     it('should make payments using the payment service', async () => {
       const result = await NotificationService.sendConfirmationEmail(
+        false,
         RECIPIENT_EMAIL,
         {
           fullName: RECIPIENT_NAME,


### PR DESCRIPTION
IVORY-447: Add S2 confirmation emails

This change adds the sending of confirmation emails for Section 2 applicaitons.