### PR TITLE
Various code and unit test refactoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/routes/accessibility-statement.route.js
+++ b/server/routes/accessibility-statement.route.js
@@ -1,8 +1,5 @@
 'use strict'
 
-// TODO GA
-// const AnalyticsService = require('../services/analytics.service')
-
 const config = require('../utils/config')
 const { Paths, Views } = require('../utils/constants')
 

--- a/server/routes/accessibility-statement.route.js
+++ b/server/routes/accessibility-statement.route.js
@@ -1,5 +1,8 @@
 'use strict'
 
+// TODO GA
+// const AnalyticsService = require('../services/analytics.service')
+
 const config = require('../utils/config')
 const { Paths, Views } = require('../utils/constants')
 

--- a/server/routes/accessibility-statement.route.js
+++ b/server/routes/accessibility-statement.route.js
@@ -7,10 +7,13 @@ const config = require('../utils/config')
 const { Paths, Views } = require('../utils/constants')
 
 const handlers = {
-  get: async (request, h) =>
-    h.view(Views.ACCESSIBILITY_STATEMENT, {
-      ..._getContext(request)
+  get: (request, h) => {
+    const context = _getContext(request)
+
+    return h.view(Views.ACCESSIBILITY_STATEMENT, {
+      ...context
     })
+  }
 }
 
 module.exports = [

--- a/server/routes/check-your-answers.route.js
+++ b/server/routes/check-your-answers.route.js
@@ -16,8 +16,10 @@ const { buildErrorSummary, Validators } = require('../utils/validation')
 
 const handlers = {
   get: async (request, h) => {
+    const context = await _getContext(request)
+
     return h.view(Views.CHECK_YOUR_ANSWERS, {
-      ...(await _getContext(request))
+      ...context
     })
   },
 

--- a/server/routes/check-your-answers.route.js
+++ b/server/routes/check-your-answers.route.js
@@ -1,15 +1,17 @@
 'use strict'
 
+const AnalyticsService = require('../services/analytics.service')
+const RedisService = require('../services/redis.service')
+
 const {
+  Analytics,
   ItemType,
   Paths,
   Views,
   RedisKeys,
-  Options,
-  Analytics
+  Options
 } = require('../utils/constants')
 const { getIvoryVolumePercentage } = require('../utils/general')
-const RedisService = require('../services/redis.service')
 const { buildErrorSummary, Validators } = require('../utils/validation')
 
 const handlers = {
@@ -20,28 +22,29 @@ const handlers = {
   },
 
   post: async (request, h) => {
+    const context = await _getContext(request)
     const payload = request.payload
     const errors = _validateForm(payload)
 
     if (errors.length) {
-      await request.ga.event({
+      AnalyticsService.sendEvent(request, {
         category: Analytics.Category.ERROR,
         action: JSON.stringify(errors),
-        label: (await _getContext(request)).pageTitle
+        label: context.pageTitle
       })
 
       return h
         .view(Views.CHECK_YOUR_ANSWERS, {
-          ...(await _getContext(request)),
+          ...context,
           ...buildErrorSummary(errors)
         })
         .code(400)
     }
 
-    await request.ga.event({
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.MAIN_QUESTIONS,
       action: Analytics.Action.CONFIRM,
-      label: (await _getContext(request)).pageTitle
+      label: context.pageTitle
     })
 
     return h.redirect(Paths.MAKE_PAYMENT)

--- a/server/routes/common/address-choose.route.js
+++ b/server/routes/common/address-choose.route.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const AnalyticsService = require('../../services/analytics.service')
+const RedisService = require('../../services/redis.service')
+
 const {
   AddressType,
   Options,
@@ -8,7 +11,6 @@ const {
   Views,
   Analytics
 } = require('../../utils/constants')
-const RedisService = require('../../services/redis.service')
 const { buildErrorSummary, Validators } = require('../../utils/validation')
 
 const getAddressType = request =>
@@ -30,7 +32,7 @@ const handlers = {
     const errors = _validateForm(payload)
 
     if (errors.length) {
-      await request.ga.event({
+      AnalyticsService.sendEvent(request, {
         category: Analytics.Category.ERROR,
         action: JSON.stringify(errors),
         label: `Address choose - ${addressType}`
@@ -49,7 +51,7 @@ const handlers = {
       RedisKeys.OWNED_BY_APPLICANT
     )
 
-    await request.ga.event({
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.MAIN_QUESTIONS,
       action: `${Analytics.Action.SELECTED} address`,
       label: `Address choose - ${addressType}`

--- a/server/routes/common/address-confirm.route.js
+++ b/server/routes/common/address-confirm.route.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const AnalyticsService = require('../../services/analytics.service')
+const RedisService = require('../../services/redis.service')
+
 const {
   AddressType,
   Options,
@@ -8,7 +11,6 @@ const {
   Views,
   Analytics
 } = require('../../utils/constants')
-const RedisService = require('../../services/redis.service')
 
 const getAddressType = request =>
   request.route.path === Paths.OWNER_ADDRESS_CONFIRM
@@ -33,7 +35,7 @@ const handlers = {
       RedisKeys.OWNED_BY_APPLICANT
     )
 
-    await request.ga.event({
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.MAIN_QUESTIONS,
       action: Analytics.Action.CONFIRM,
       label: context.pageTitle

--- a/server/routes/common/address-confirm.route.js
+++ b/server/routes/common/address-confirm.route.js
@@ -21,8 +21,10 @@ const handlers = {
   get: async (request, h) => {
     const addressType = getAddressType(request)
 
+    const context = await _getContext(request, addressType)
+
     return h.view(Views.ADDRESS_CONFIRM, {
-      ...(await _getContext(request, addressType))
+      ...context
     })
   },
 

--- a/server/routes/common/address-enter.route.js
+++ b/server/routes/common/address-enter.route.js
@@ -29,8 +29,10 @@ const handlers = {
   get: async (request, h) => {
     const addressType = getAddressType(request)
 
+    const context = await _getContext(request, addressType)
+
     return h.view(Views.ADDRESS_ENTER, {
-      ...(await _getContext(request, addressType, true))
+      ...context
     })
   },
 
@@ -95,7 +97,7 @@ const handlers = {
   }
 }
 
-const _getContext = async (request, addressType, isGet) => {
+const _getContext = async (request, addressType, isGet = true) => {
   const context = {}
 
   const ownedByApplicant = await RedisService.get(

--- a/server/routes/common/address-enter.route.js
+++ b/server/routes/common/address-enter.route.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const AnalyticsService = require('../../services/analytics.service')
+const RedisService = require('../../services/redis.service')
+
 const {
   AddressType,
   CharacterLimits,
@@ -9,9 +12,9 @@ const {
   Views,
   Analytics
 } = require('../../utils/constants')
-const { formatNumberWithCommas } = require('../../utils/general')
-const RedisService = require('../../services/redis.service')
 const { buildErrorSummary, Validators } = require('../../utils/validation')
+const { formatNumberWithCommas } = require('../../utils/general')
+
 const {
   addPayloadToContext,
   convertToCommaSeparatedTitleCase
@@ -38,7 +41,7 @@ const handlers = {
     const context = await _getContext(request, addressType, false)
 
     if (errors.length) {
-      await request.ga.event({
+      AnalyticsService.sendEvent(request, {
         category: Analytics.Category.ERROR,
         action: JSON.stringify(errors),
         label: context.pageTitle
@@ -57,7 +60,7 @@ const handlers = {
       RedisKeys.OWNED_BY_APPLICANT
     )
 
-    await request.ga.event({
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.MAIN_QUESTIONS,
       action: Analytics.Action.ENTERED,
       label: context.pageTitle

--- a/server/routes/common/address-find.route.js
+++ b/server/routes/common/address-find.route.js
@@ -29,8 +29,14 @@ const handlers = {
       RedisKeys.OWNED_BY_APPLICANT
     )
 
+    const context = await _getContext(
+      request,
+      getAddressType(request),
+      ownedByApplicant
+    )
+
     return h.view(Views.ADDRESS_FIND, {
-      ...(await _getContext(request, getAddressType(request), ownedByApplicant))
+      ...context
     })
   },
 
@@ -54,7 +60,7 @@ const handlers = {
 
       return h
         .view(Views.ADDRESS_FIND, {
-          ...(await _getContext(request, addressType, ownedByApplicant)),
+          ...context,
           ...buildErrorSummary(errors)
         })
         .code(400)
@@ -70,8 +76,7 @@ const handlers = {
       action: `${
         payload.nameOrNumber ? 'Property name or number' : 'Postcode only'
       } entered`,
-      label: (await _getContext(request, addressType, ownedByApplicant))
-        .pageTitle
+      label: context.pageTitle
     })
 
     await RedisService.set(

--- a/server/routes/common/address-find.route.js
+++ b/server/routes/common/address-find.route.js
@@ -1,5 +1,9 @@
 'use strict'
 
+const AnalyticsService = require('../../services/analytics.service')
+const AddressService = require('../../services/address.service')
+const RedisService = require('../../services/redis.service')
+
 const {
   AddressType,
   CharacterLimits,
@@ -9,11 +13,9 @@ const {
   Options,
   Analytics
 } = require('../../utils/constants')
-const { formatNumberWithCommas } = require('../../utils/general')
-const AddressService = require('../../services/address.service')
-const RedisService = require('../../services/redis.service')
 const { buildErrorSummary, Validators } = require('../../utils/validation')
 const { addPayloadToContext } = require('../../utils/general')
+const { formatNumberWithCommas } = require('../../utils/general')
 
 const getAddressType = request =>
   request.route.path === Paths.OWNER_ADDRESS_FIND
@@ -39,14 +41,15 @@ const handlers = {
     )
 
     const addressType = getAddressType(request)
+    const context = await _getContext(request, addressType, ownedByApplicant)
     const payload = request.payload
     const errors = _validateForm(payload, addressType, ownedByApplicant)
 
     if (errors.length) {
-      await request.ga.event({
+      AnalyticsService.sendEvent(request, {
         category: Analytics.Category.ERROR,
         action: JSON.stringify(errors),
-        label: (await _getContext(request, addressType, ownedByApplicant)).pageTitle
+        label: context.pageTitle
       })
 
       return h
@@ -62,10 +65,13 @@ const handlers = {
       payload.postcode
     )
 
-    await request.ga.event({
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.MAIN_QUESTIONS,
-      action: `${payload.nameOrNumber ? 'Property name or number' : 'Postcode only'} entered`,
-      label: (await _getContext(request, addressType, ownedByApplicant)).pageTitle
+      action: `${
+        payload.nameOrNumber ? 'Property name or number' : 'Postcode only'
+      } entered`,
+      label: (await _getContext(request, addressType, ownedByApplicant))
+        .pageTitle
     })
 
     await RedisService.set(

--- a/server/routes/common/address-international.route.js
+++ b/server/routes/common/address-international.route.js
@@ -28,9 +28,10 @@ const getAddressType = request =>
 const handlers = {
   get: async (request, h) => {
     const addressType = getAddressType(request)
+    const context = await _getContext(request, addressType)
 
     return h.view(Views.ADDRESS_INTERNATIONAL, {
-      ...(await _getContext(request, addressType))
+      ...context
     })
   },
 

--- a/server/routes/cookie-policy.route.js
+++ b/server/routes/cookie-policy.route.js
@@ -1,12 +1,18 @@
 'use strict'
 
+// TODO GA
+// const AnalyticsService = require('../services/analytics.service')
+
 const { Paths, Views } = require('../utils/constants')
 
 const handlers = {
-  get: async (request, h) =>
-    h.view(Views.COOKIE_POLICY, {
-      ..._getContext(request)
+  get: async (request, h) => {
+    const context = _getContext(request)
+
+    return h.view(Views.COOKIE_POLICY, {
+      ...context
     })
+  }
 }
 
 module.exports = [

--- a/server/routes/cookie-policy.route.js
+++ b/server/routes/cookie-policy.route.js
@@ -1,8 +1,5 @@
 'use strict'
 
-// TODO GA
-// const AnalyticsService = require('../services/analytics.service')
-
 const { Paths, Views } = require('../utils/constants')
 
 const handlers = {

--- a/server/routes/eligibility-checker/are-you-a-museum.route.js
+++ b/server/routes/eligibility-checker/are-you-a-museum.route.js
@@ -1,38 +1,43 @@
 'use strict'
 
+const AnalyticsService = require('../../services/analytics.service')
+const RedisService = require('../../services/redis.service')
+
 const {
+  Analytics,
   ItemType,
   Paths,
   RedisKeys,
   Views,
-  Options,
-  Analytics
+  Options
 } = require('../../utils/constants')
-const RedisService = require('../../services/redis.service')
 const { buildErrorSummary, Validators } = require('../../utils/validation')
 const { getStandardOptions } = require('../../utils/general')
 
 const handlers = {
   get: (request, h) => {
+    const context = _getContext(request)
+
     return h.view(Views.ARE_YOU_A_MUSEUM, {
-      ..._getContext()
+      ...context
     })
   },
 
   post: async (request, h) => {
+    const context = _getContext(request)
     const payload = request.payload
     const errors = _validateForm(payload)
 
     if (errors.length) {
-      await request.ga.event({
+      AnalyticsService.sendEvent(request, {
         category: Analytics.Category.ERROR,
         action: JSON.stringify(errors),
-        label: _getContext().pageTitle
+        label: context.pageTitle
       })
 
       return h
         .view(Views.ARE_YOU_A_MUSEUM, {
-          ..._getContext(),
+          ...context,
           ...buildErrorSummary(errors)
         })
         .code(400)
@@ -44,10 +49,10 @@ const handlers = {
       payload.areYouAMuseum === Options.YES
     )
 
-    await request.ga.event({
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.ELIGIBILITY_CHECKER,
       action: `${Analytics.Action.SELECTED} ${payload.areYouAMuseum}`,
-      label: _getContext().pageTitle
+      label: context.pageTitle
     })
 
     switch (payload.areYouAMuseum) {

--- a/server/routes/eligibility-checker/are-you-a-museum.route.js
+++ b/server/routes/eligibility-checker/are-you-a-museum.route.js
@@ -16,7 +16,7 @@ const { getStandardOptions } = require('../../utils/general')
 
 const handlers = {
   get: (request, h) => {
-    const context = _getContext(request)
+    const context = _getContext()
 
     return h.view(Views.ARE_YOU_A_MUSEUM, {
       ...context
@@ -24,7 +24,7 @@ const handlers = {
   },
 
   post: async (request, h) => {
-    const context = _getContext(request)
+    const context = _getContext()
     const payload = request.payload
     const errors = _validateForm(payload)
 

--- a/server/routes/eligibility-checker/cannot-continue.route.js
+++ b/server/routes/eligibility-checker/cannot-continue.route.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// const AnalyticsService = require('../../services/analytics.service')
+const AnalyticsService = require('../../services/analytics.service')
 const RedisService = require('../../services/redis.service')
 
 const {
@@ -8,19 +8,19 @@ const {
   Paths,
   RedisKeys,
   Views,
-  Urls
-  // Analytics
+  Urls,
+  Analytics
 } = require('../../utils/constants')
 
 const handlers = {
   get: async (request, h) => {
     const context = await _getContext(request)
 
-    // AnalyticsService.sendEvent(request, {
-    //   category: Analytics.Category.SERVICE_COMPLETE,
-    //   action: Analytics.Action.DROPOUT,
-    //   label: context.pageTitle
-    // })
+    AnalyticsService.sendEvent(request, {
+      category: Analytics.Category.SERVICE_COMPLETE,
+      action: Analytics.Action.DROPOUT,
+      label: context.pageTitle
+    })
 
     return h.view(Views.CANNOT_CONTINUE, {
       ...context
@@ -28,13 +28,13 @@ const handlers = {
   },
 
   post: async (request, h) => {
-    // const context = await _getContext(request)
+    const context = await _getContext(request)
 
-    // AnalyticsService.sendEvent(request, {
-    //   category: Analytics.Category.SERVICE_COMPLETE,
-    //   action: `${Analytics.Action.SELECTED} Finish and redirect button`,
-    //   label: context.pageTitle
-    // })
+    AnalyticsService.sendEvent(request, {
+      category: Analytics.Category.SERVICE_COMPLETE,
+      action: `${Analytics.Action.SELECTED} Finish and redirect button`,
+      label: context.pageTitle
+    })
 
     return h.redirect(Urls.GOV_UK_HOME)
   }

--- a/server/routes/eligibility-checker/cannot-continue.route.js
+++ b/server/routes/eligibility-checker/cannot-continue.route.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const AnalyticsService = require('../../services/analytics.service')
+// const AnalyticsService = require('../../services/analytics.service')
 const RedisService = require('../../services/redis.service')
 
 const {
@@ -8,19 +8,19 @@ const {
   Paths,
   RedisKeys,
   Views,
-  Urls,
-  Analytics
+  Urls
+  // Analytics
 } = require('../../utils/constants')
 
 const handlers = {
   get: async (request, h) => {
     const context = await _getContext(request)
 
-    AnalyticsService.sendEvent(request, {
-      category: Analytics.Category.SERVICE_COMPLETE,
-      action: Analytics.Action.DROPOUT,
-      label: context.pageTitle
-    })
+    // AnalyticsService.sendEvent(request, {
+    //   category: Analytics.Category.SERVICE_COMPLETE,
+    //   action: Analytics.Action.DROPOUT,
+    //   label: context.pageTitle
+    // })
 
     return h.view(Views.CANNOT_CONTINUE, {
       ...context
@@ -28,13 +28,13 @@ const handlers = {
   },
 
   post: async (request, h) => {
-    const context = await _getContext(request)
+    // const context = await _getContext(request)
 
-    AnalyticsService.sendEvent(request, {
-      category: Analytics.Category.SERVICE_COMPLETE,
-      action: `${Analytics.Action.SELECTED} Finish and redirect button`,
-      label: context.pageTitle
-    })
+    // AnalyticsService.sendEvent(request, {
+    //   category: Analytics.Category.SERVICE_COMPLETE,
+    //   action: `${Analytics.Action.SELECTED} Finish and redirect button`,
+    //   label: context.pageTitle
+    // })
 
     return h.redirect(Urls.GOV_UK_HOME)
   }

--- a/server/routes/eligibility-checker/cannot-continue.route.js
+++ b/server/routes/eligibility-checker/cannot-continue.route.js
@@ -1,6 +1,8 @@
 'use strict'
 
+const AnalyticsService = require('../../services/analytics.service')
 const RedisService = require('../../services/redis.service')
+
 const {
   Options,
   Paths,
@@ -12,22 +14,26 @@ const {
 
 const handlers = {
   get: async (request, h) => {
-    await request.ga.event({
+    const context = await _getContext(request)
+
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.SERVICE_COMPLETE,
       action: Analytics.Action.DROPOUT,
-      label: (await _getContext(request)).pageTitle
+      label: context.pageTitle
     })
 
     return h.view(Views.CANNOT_CONTINUE, {
-      ...(await _getContext(request))
+      ...context
     })
   },
 
   post: async (request, h) => {
-    await request.ga.event({
+    const context = await _getContext(request)
+
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.SERVICE_COMPLETE,
       action: `${Analytics.Action.SELECTED} Finish and redirect button`,
-      label: (await _getContext(request)).pageTitle
+      label: context.pageTitle
     })
 
     return h.redirect(Urls.GOV_UK_HOME)

--- a/server/routes/eligibility-checker/cannot-continue.route.js
+++ b/server/routes/eligibility-checker/cannot-continue.route.js
@@ -1,12 +1,12 @@
 'use strict'
 
 // const AnalyticsService = require('../../services/analytics.service')
-// const RedisService = require('../../services/redis.service')
+const RedisService = require('../../services/redis.service')
 
 const {
-  // Options,
+  Options,
   Paths,
-  // RedisKeys,
+  RedisKeys,
   Views,
   Urls
   // Analytics
@@ -41,11 +41,10 @@ const handlers = {
 }
 
 const _getContext = async request => {
-  // const containsElephantIvoryIdk =
-  //   (await RedisService.get(request, RedisKeys.CONTAIN_ELEPHANT_IVORY)) ===
-  //   Options.I_DONT_KNOW
+  const containsElephantIvoryIdk =
+    (await RedisService.get(request, RedisKeys.CONTAIN_ELEPHANT_IVORY)) ===
+    Options.I_DONT_KNOW
 
-  const containsElephantIvoryIdk = true
   return {
     pageTitle: 'You cannot continue',
     helpText1a: `To use this service, you must know for sure whether your item ${

--- a/server/routes/eligibility-checker/cannot-continue.route.js
+++ b/server/routes/eligibility-checker/cannot-continue.route.js
@@ -1,12 +1,12 @@
 'use strict'
 
 // const AnalyticsService = require('../../services/analytics.service')
-const RedisService = require('../../services/redis.service')
+// const RedisService = require('../../services/redis.service')
 
 const {
-  Options,
+  // Options,
   Paths,
-  RedisKeys,
+  // RedisKeys,
   Views,
   Urls
   // Analytics
@@ -41,10 +41,11 @@ const handlers = {
 }
 
 const _getContext = async request => {
-  const containsElephantIvoryIdk =
-    (await RedisService.get(request, RedisKeys.CONTAIN_ELEPHANT_IVORY)) ===
-    Options.I_DONT_KNOW
+  // const containsElephantIvoryIdk =
+  //   (await RedisService.get(request, RedisKeys.CONTAIN_ELEPHANT_IVORY)) ===
+  //   Options.I_DONT_KNOW
 
+  const containsElephantIvoryIdk = true
   return {
     pageTitle: 'You cannot continue',
     helpText1a: `To use this service, you must know for sure whether your item ${

--- a/server/routes/eligibility-checker/cannot-trade.route.js
+++ b/server/routes/eligibility-checker/cannot-trade.route.js
@@ -1,23 +1,26 @@
 'use strict'
 
+const AnalyticsService = require('../../services/analytics.service')
+
 const { Paths, Views, Urls, Analytics } = require('../../utils/constants')
 
 const handlers = {
   get: async (request, h) => {
-    const referringUrl = request.headers.referer
-    await request.ga.event({
+    const context = _getContext(request)
+
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.SERVICE_COMPLETE,
       action: Analytics.Action.DROPOUT,
-      label: _getContext(referringUrl).pageTitle
+      label: context.pageTitle
     })
 
     return h.view(Views.CANNOT_TRADE, {
-      ..._getContext(referringUrl)
+      ...context
     })
   },
 
   post: async (request, h) => {
-    await request.ga.event({
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.SERVICE_COMPLETE,
       action: `${Analytics.Action.SELECTED} Finish and redirect button`,
       label: 'Cannot Trade'
@@ -27,7 +30,9 @@ const handlers = {
   }
 }
 
-const _getContext = referringUrl => {
+const _getContext = request => {
+  const referringUrl = request.headers.referer
+
   const pageTitle = 'You are not allowed to sell or hire out your item'
 
   if (referringUrl.includes(Paths.TAKEN_FROM_ELEPHANT)) {

--- a/server/routes/eligibility-checker/contain-elephant-ivory.route.js
+++ b/server/routes/eligibility-checker/contain-elephant-ivory.route.js
@@ -1,7 +1,15 @@
 'use strict'
 
+const AnalyticsService = require('../../services/analytics.service')
 const RedisService = require('../../services/redis.service')
-const { Options, Paths, RedisKeys, Views, Analytics } = require('../../utils/constants')
+
+const {
+  Options,
+  Paths,
+  RedisKeys,
+  Views,
+  Analytics
+} = require('../../utils/constants')
 const { buildErrorSummary, Validators } = require('../../utils/validation')
 const { getStandardOptions } = require('../../utils/general')
 
@@ -13,19 +21,20 @@ const handlers = {
   },
 
   post: async (request, h) => {
+    const context = _getContext()
     const payload = request.payload
     const errors = _validateForm(payload)
 
     if (errors.length) {
-      await request.ga.event({
+      AnalyticsService.sendEvent(request, {
         category: Analytics.Category.ERROR,
         action: JSON.stringify(errors),
-        label: _getContext().pageTitle
+        label: context.pageTitle
       })
 
       return h
         .view(Views.CONTAIN_ELEPHANT_IVORY, {
-          ..._getContext(),
+          ...context,
           ...buildErrorSummary(errors)
         })
         .code(400)
@@ -37,10 +46,10 @@ const handlers = {
       payload.containElephantIvory
     )
 
-    await request.ga.event({
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.ELIGIBILITY_CHECKER,
       action: `${Analytics.Action.SELECTED} ${payload.containElephantIvory}`,
-      label: _getContext().pageTitle
+      label: context.pageTitle
     })
 
     switch (payload.containElephantIvory) {

--- a/server/routes/eligibility-checker/contain-elephant-ivory.route.js
+++ b/server/routes/eligibility-checker/contain-elephant-ivory.route.js
@@ -15,8 +15,10 @@ const { getStandardOptions } = require('../../utils/general')
 
 const handlers = {
   get: (request, h) => {
+    const context = _getContext()
+
     return h.view(Views.CONTAIN_ELEPHANT_IVORY, {
-      ..._getContext()
+      ...context
     })
   },
 

--- a/server/routes/eligibility-checker/do-not-need-service.route.js
+++ b/server/routes/eligibility-checker/do-not-need-service.route.js
@@ -1,26 +1,38 @@
 'use strict'
 
+const AnalyticsService = require('../../services/analytics.service')
 const RedisService = require('../../services/redis.service')
-const { Paths, RedisKeys, Views, Urls, Analytics } = require('../../utils/constants')
+
+const {
+  Paths,
+  RedisKeys,
+  Views,
+  Urls,
+  Analytics
+} = require('../../utils/constants')
 
 const handlers = {
   get: async (request, h) => {
-    await request.ga.event({
+    const context = await _getContext(request)
+
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.SERVICE_COMPLETE,
       action: Analytics.Action.DROPOUT,
-      label: (await _getContext(request)).pageTitle
+      label: context.pageTitle
     })
 
     return h.view(Views.DO_NOT_NEED_SERVICE, {
-      ...(await _getContext(request))
+      ...context
     })
   },
 
   post: async (request, h) => {
-    await request.ga.event({
+    const context = await _getContext(request)
+
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.SERVICE_COMPLETE,
       action: `${Analytics.Action.SELECTED} Finish and redirect button`,
-      label: (await _getContext(request)).pageTitle
+      label: context.pageTitle
     })
 
     return h.redirect(Urls.GOV_UK_HOME)
@@ -32,7 +44,8 @@ const _getContext = async request => {
     (await RedisService.get(request, RedisKeys.ARE_YOU_A_MUSEUM)) === 'true'
 
   const notContainingIvory =
-    (await RedisService.get(request, RedisKeys.CONTAIN_ELEPHANT_IVORY)) === 'false'
+    (await RedisService.get(request, RedisKeys.CONTAIN_ELEPHANT_IVORY)) ===
+    'false'
 
   return {
     pageTitle: 'You don’t need to tell us about this item',

--- a/server/routes/eligibility-checker/is-it-a-musical-instrument.route.js
+++ b/server/routes/eligibility-checker/is-it-a-musical-instrument.route.js
@@ -1,39 +1,44 @@
 'use strict'
 
+const AnalyticsService = require('../../services/analytics.service')
+
 const { Paths, Views, Options, Analytics } = require('../../utils/constants')
 const { buildErrorSummary, Validators } = require('../../utils/validation')
 const { getStandardOptions } = require('../../utils/general')
 
 const handlers = {
   get: (request, h) => {
+    const context = _getContext(request)
+
     return h.view(Views.IS_IT_A_MUSICAL_INSTRUMENT, {
-      ..._getContext()
+      ...context
     })
   },
 
   post: async (request, h) => {
+    const context = _getContext(request)
     const payload = request.payload
     const errors = _validateForm(payload)
 
     if (errors.length) {
-      await request.ga.event({
+      AnalyticsService.sendEvent(request, {
         category: Analytics.Category.ERROR,
         action: JSON.stringify(errors),
-        label: _getContext().pageTitle
+        label: context.pageTitle
       })
 
       return h
         .view(Views.IS_IT_A_MUSICAL_INSTRUMENT, {
-          ..._getContext(),
+          ...context,
           ...buildErrorSummary(errors)
         })
         .code(400)
     }
 
-    await request.ga.event({
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.ELIGIBILITY_CHECKER,
       action: `${Analytics.Action.SELECTED} ${payload.isItAMusicalInstrument}`,
-      label: _getContext().pageTitle
+      label: context.pageTitle
     })
 
     switch (payload.isItAMusicalInstrument) {
@@ -48,7 +53,8 @@ const handlers = {
 const _getContext = () => {
   return {
     pageTitle: 'Is your item a musical instrument?',
-    helpText: 'This includes accessories used to play a musical instrument, like a violin bow, although these must be registered as separate items.',
+    helpText:
+      'This includes accessories used to play a musical instrument, like a violin bow, although these must be registered as separate items.',
     helpText2: 'This does not include:',
     items: getStandardOptions(false)
   }

--- a/server/routes/eligibility-checker/is-it-a-musical-instrument.route.js
+++ b/server/routes/eligibility-checker/is-it-a-musical-instrument.route.js
@@ -8,7 +8,7 @@ const { getStandardOptions } = require('../../utils/general')
 
 const handlers = {
   get: (request, h) => {
-    const context = _getContext(request)
+    const context = _getContext()
 
     return h.view(Views.IS_IT_A_MUSICAL_INSTRUMENT, {
       ...context
@@ -16,7 +16,7 @@ const handlers = {
   },
 
   post: async (request, h) => {
-    const context = _getContext(request)
+    const context = _getContext()
     const payload = request.payload
     const errors = _validateForm(payload)
 

--- a/server/routes/eligibility-checker/is-it-a-portrait-miniature.route.js
+++ b/server/routes/eligibility-checker/is-it-a-portrait-miniature.route.js
@@ -1,40 +1,52 @@
 'use strict'
 
-const { ItemType, Paths, RedisKeys, Views, Options, Analytics } = require('../../utils/constants')
+const AnalyticsService = require('../../services/analytics.service')
 const RedisService = require('../../services/redis.service')
+
+const {
+  ItemType,
+  Paths,
+  RedisKeys,
+  Views,
+  Options,
+  Analytics
+} = require('../../utils/constants')
 const { buildErrorSummary, Validators } = require('../../utils/validation')
 const { getStandardOptions } = require('../../utils/general')
 
 const handlers = {
   get: (request, h) => {
+    const context = _getContext(request)
+
     return h.view(Views.IS_IT_A_PORTRAIT_MINIATURE, {
-      ..._getContext()
+      ...context
     })
   },
 
   post: async (request, h) => {
+    const context = _getContext(request)
     const payload = request.payload
     const errors = _validateForm(payload)
 
     if (errors.length) {
-      await request.ga.event({
+      AnalyticsService.sendEvent(request, {
         category: Analytics.Category.ERROR,
         action: JSON.stringify(errors),
-        label: _getContext().pageTitle
+        label: context.pageTitle
       })
 
       return h
         .view(Views.IS_IT_A_PORTRAIT_MINIATURE, {
-          ..._getContext(),
+          ...context,
           ...buildErrorSummary(errors)
         })
         .code(400)
     }
 
-    await request.ga.event({
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.ELIGIBILITY_CHECKER,
       action: `${Analytics.Action.SELECTED} ${payload.isItAPortraitMiniature}`,
-      label: _getContext().pageTitle
+      label: context.pageTitle
     })
 
     switch (payload.isItAPortraitMiniature) {
@@ -46,11 +58,7 @@ const handlers = {
         )
         return h.redirect(Paths.IS_ITEM_PRE_1918)
       case Options.NO:
-        await RedisService.set(
-          request,
-          RedisKeys.WHAT_TYPE_OF_ITEM_IS_IT,
-          ''
-        )
+        await RedisService.set(request, RedisKeys.WHAT_TYPE_OF_ITEM_IS_IT, '')
         return h.redirect(Paths.IS_ITEM_PRE_1918)
       case Options.I_DONT_KNOW:
         return h.redirect(Paths.CANNOT_CONTINUE)
@@ -61,7 +69,8 @@ const handlers = {
 const _getContext = () => {
   return {
     pageTitle: 'Is your item a portrait miniature?',
-    helpText: 'Portrait miniatures are small portraits, popular in the 18th or 19th century, that were often painted on very thin pieces of ivory.',
+    helpText:
+      'Portrait miniatures are small portraits, popular in the 18th or 19th century, that were often painted on very thin pieces of ivory.',
     items: getStandardOptions()
   }
 }

--- a/server/routes/eligibility-checker/is-it-a-portrait-miniature.route.js
+++ b/server/routes/eligibility-checker/is-it-a-portrait-miniature.route.js
@@ -16,7 +16,7 @@ const { getStandardOptions } = require('../../utils/general')
 
 const handlers = {
   get: (request, h) => {
-    const context = _getContext(request)
+    const context = _getContext()
 
     return h.view(Views.IS_IT_A_PORTRAIT_MINIATURE, {
       ...context
@@ -24,7 +24,7 @@ const handlers = {
   },
 
   post: async (request, h) => {
-    const context = _getContext(request)
+    const context = _getContext()
     const payload = request.payload
     const errors = _validateForm(payload)
 

--- a/server/routes/eligibility-checker/is-it-rmi.route.js
+++ b/server/routes/eligibility-checker/is-it-rmi.route.js
@@ -1,40 +1,52 @@
 'use strict'
 
-const { ItemType, Paths, RedisKeys, Views, Options, Analytics } = require('../../utils/constants')
+const AnalyticsService = require('../../services/analytics.service')
 const RedisService = require('../../services/redis.service')
+
+const {
+  Analytics,
+  ItemType,
+  Options,
+  Paths,
+  RedisKeys,
+  Views
+} = require('../../utils/constants')
 const { buildErrorSummary, Validators } = require('../../utils/validation')
 const { getStandardOptions } = require('../../utils/general')
 
 const handlers = {
   get: (request, h) => {
+    const context = _getContext()
+
     return h.view(Views.IS_IT_RMI, {
-      ..._getContext()
+      ...context
     })
   },
 
   post: async (request, h) => {
+    const context = _getContext()
     const payload = request.payload
     const errors = _validateForm(payload)
 
     if (errors.length) {
-      await request.ga.event({
+      AnalyticsService.sendEvent(request, {
         category: Analytics.Category.ERROR,
         action: JSON.stringify(errors),
-        label: _getContext().pageTitle
+        label: context.pageTitle
       })
 
       return h
         .view(Views.IS_IT_RMI, {
-          ..._getContext(),
+          ...context,
           ...buildErrorSummary(errors)
         })
         .code(400)
     }
 
-    await request.ga.event({
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.ELIGIBILITY_CHECKER,
       action: `${Analytics.Action.SELECTED} ${payload.isItRmi}`,
-      label: _getContext().pageTitle
+      label: context.pageTitle
     })
 
     switch (payload.isItRmi) {
@@ -53,9 +65,12 @@ const handlers = {
 
 const _getContext = () => {
   return {
-    pageTitle: 'Does your item have outstandingly high artistic, cultural or historical value?',
-    helpText: 'The item must be a rare and socially significant example of its type.',
-    callOutText: 'An item that only has sentimental value would not qualify, regardless of how important it is to you personally.',
+    pageTitle:
+      'Does your item have outstandingly high artistic, cultural or historical value?',
+    helpText:
+      'The item must be a rare and socially significant example of its type.',
+    callOutText:
+      'An item that only has sentimental value would not qualify, regardless of how important it is to you personally.',
     items: getStandardOptions(false)
   }
 }
@@ -65,7 +80,8 @@ const _validateForm = payload => {
   if (Validators.empty(payload.isItRmi)) {
     errors.push({
       name: 'isItRmi',
-      text: 'Tell us whether your item has outstandingly high artistic, cultural or historical value'
+      text:
+        'Tell us whether your item has outstandingly high artistic, cultural or historical value'
     })
   }
   return errors

--- a/server/routes/eligibility-checker/ivory-added.route.js
+++ b/server/routes/eligibility-checker/ivory-added.route.js
@@ -1,39 +1,44 @@
 'use strict'
 
+const AnalyticsService = require('../../services/analytics.service')
+
 const { Paths, Views, Options, Analytics } = require('../../utils/constants')
 const { buildErrorSummary, Validators } = require('../../utils/validation')
 const { getStandardOptions } = require('../../utils/general')
 
 const handlers = {
   get: (request, h) => {
+    const context = _getContext()
+
     return h.view(Views.IVORY_ADDED, {
-      ..._getContext()
+      ...context
     })
   },
 
   post: async (request, h) => {
+    const context = _getContext()
     const payload = request.payload
     const errors = _validateForm(payload)
 
     if (errors.length) {
-      await request.ga.event({
+      AnalyticsService.sendEvent(request, {
         category: Analytics.Category.ERROR,
         action: JSON.stringify(errors),
-        label: _getContext().pageTitle
+        label: context.pageTitle
       })
 
       return h
         .view(Views.IVORY_ADDED, {
-          ..._getContext(),
+          ...context,
           ...buildErrorSummary(errors)
         })
         .code(400)
     }
 
-    await request.ga.event({
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.ELIGIBILITY_CHECKER,
       action: `${Analytics.Action.SELECTED} ${payload.ivoryAdded}`,
-      label: _getContext().pageTitle
+      label: context.pageTitle
     })
 
     switch (payload.ivoryAdded) {

--- a/server/routes/eligibility-checker/made-before-1947.route.js
+++ b/server/routes/eligibility-checker/made-before-1947.route.js
@@ -1,40 +1,52 @@
 'use strict'
 
-const { ItemType, Paths, RedisKeys, Views, Options, Analytics } = require('../../utils/constants')
+const AnalyticsService = require('../../services/analytics.service')
 const RedisService = require('../../services/redis.service')
+
+const {
+  ItemType,
+  Paths,
+  RedisKeys,
+  Views,
+  Options,
+  Analytics
+} = require('../../utils/constants')
 const { buildErrorSummary, Validators } = require('../../utils/validation')
 const { getStandardOptions } = require('../../utils/general')
 
 const handlers = {
   get: (request, h) => {
+    const context = _getContext()
+
     return h.view(Views.MADE_BEFORE_1947, {
-      ..._getContext()
+      ...context
     })
   },
 
   post: async (request, h) => {
+    const context = _getContext()
     const payload = request.payload
     const errors = _validateForm(payload)
 
     if (errors.length) {
-      await request.ga.event({
+      AnalyticsService.sendEvent(request, {
         category: Analytics.Category.ERROR,
         action: JSON.stringify(errors),
-        label: _getContext().pageTitle
+        label: context.pageTitle
       })
 
       return h
         .view(Views.MADE_BEFORE_1947, {
-          ..._getContext(),
+          ...context,
           ...buildErrorSummary(errors)
         })
         .code(400)
     }
 
-    await request.ga.event({
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.ELIGIBILITY_CHECKER,
       action: `${Analytics.Action.SELECTED} ${payload.madeBefore1947}`,
-      label: _getContext().pageTitle
+      label: context.pageTitle
     })
 
     switch (payload.madeBefore1947) {

--- a/server/routes/eligibility-checker/selling-to-museum.route.js
+++ b/server/routes/eligibility-checker/selling-to-museum.route.js
@@ -1,39 +1,44 @@
 'use strict'
 
+const AnalyticsService = require('../../services/analytics.service')
+
 const { Paths, Views, Options, Analytics } = require('../../utils/constants')
 const { buildErrorSummary, Validators } = require('../../utils/validation')
 const { getStandardOptions } = require('../../utils/general')
 
 const handlers = {
   get: (request, h) => {
+    const context = _getContext()
+
     return h.view(Views.SELLING_TO_MUSEUM, {
-      ..._getContext()
+      ...context
     })
   },
 
   post: async (request, h) => {
+    const context = _getContext()
     const payload = request.payload
     const errors = _validateForm(payload)
 
     if (errors.length) {
-      await request.ga.event({
+      AnalyticsService.sendEvent(request, {
         category: Analytics.Category.ERROR,
         action: JSON.stringify(errors),
-        label: _getContext().pageTitle
+        label: context.pageTitle
       })
 
       return h
         .view(Views.SELLING_TO_MUSEUM, {
-          ..._getContext(),
+          ...context,
           ...buildErrorSummary(errors)
         })
         .code(400)
     }
 
-    await request.ga.event({
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.ELIGIBILITY_CHECKER,
       action: `${Analytics.Action.SELECTED} ${payload.sellingToMuseum}`,
-      label: _getContext().pageTitle
+      label: context.pageTitle
     })
 
     switch (payload.sellingToMuseum) {
@@ -50,7 +55,8 @@ const handlers = {
 const _getContext = () => {
   return {
     pageTitle: 'Are you selling or hiring your item out to a museum?',
-    helpText: 'The museum must be a member of the International Council of Museums, or accredited by one of the following:',
+    helpText:
+      'The museum must be a member of the International Council of Museums, or accredited by one of the following:',
     items: getStandardOptions()
   }
 }
@@ -60,7 +66,8 @@ const _validateForm = payload => {
   if (Validators.empty(payload.sellingToMuseum)) {
     errors.push({
       name: 'sellingToMuseum',
-      text: 'Tell us whether you are selling or hiring out your item to a museum'
+      text:
+        'Tell us whether you are selling or hiring out your item to a museum'
     })
   }
   return errors

--- a/server/routes/errors/page-not-found.route.js
+++ b/server/routes/errors/page-not-found.route.js
@@ -1,17 +1,21 @@
 'use strict'
 
+const AnalyticsService = require('../../services/analytics.service')
+
 const { Paths, Views, Analytics } = require('../../utils/constants')
 
 const handlers = {
   get: async (request, h) => {
-    await request.ga.event({
+    const context = _getContext()
+
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.ERROR_PAGE,
       action: `${Analytics.Action.REFERRED} ${request.headers.referer}`,
-      label: _getContext().pageTitle
+      label: context.pageTitle
     })
 
     return h.view(Views.PAGE_NOT_FOUND, {
-      ..._getContext()
+      ...context
     })
   }
 }

--- a/server/routes/errors/problem-with-service.route.js
+++ b/server/routes/errors/problem-with-service.route.js
@@ -1,17 +1,21 @@
 'use strict'
 
+const AnalyticsService = require('../../services/analytics.service')
+
 const { Paths, Views, Analytics } = require('../../utils/constants')
 
 const handlers = {
   get: async (request, h) => {
-    await request.ga.event({
+    const context = _getContext()
+
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.ERROR_PAGE,
       action: `${Analytics.Action.REFERRED} ${request.headers.referer}`,
-      label: _getContext().pageTitle
+      label: context.pageTitle
     })
 
     return h.view(Views.PROBLEM_WITH_SERVICE, {
-      ..._getContext()
+      ...context
     })
   }
 }

--- a/server/routes/errors/service-unavailable.route.js
+++ b/server/routes/errors/service-unavailable.route.js
@@ -1,17 +1,21 @@
 'use strict'
 
+const AnalyticsService = require('../../services/analytics.service')
+
 const { Paths, Views, Analytics } = require('../../utils/constants')
 
 const handlers = {
   get: async (request, h) => {
-    await request.ga.event({
+    const context = _getContext()
+
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.ERROR_PAGE,
       action: `${Analytics.Action.REFERRED} ${request.headers.referer}`,
-      label: _getContext().pageTitle
+      label: context.pageTitle
     })
 
     return h.view(Views.SERVICE_UNAVAILABLE, {
-      ..._getContext()
+      ...context
     })
   }
 }

--- a/server/routes/errors/session-timed-out.route.js
+++ b/server/routes/errors/session-timed-out.route.js
@@ -1,25 +1,31 @@
 'use strict'
 
+const AnalyticsService = require('../../services/analytics.service')
+
 const { HOME_URL, Paths, Views, Analytics } = require('../../utils/constants')
 
 const handlers = {
   get: async (request, h) => {
-    await request.ga.event({
+    const context = _getContext()
+
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.ERROR_PAGE,
       action: `${Analytics.Action.REFERRED} ${request.headers.referer}`,
-      label: _getContext().pageTitle
+      label: context.pageTitle
     })
 
     return h.view(Views.SESSION_TIMED_OUT, {
-      ..._getContext()
+      ...context
     })
   },
 
   post: async (request, h) => {
-    await request.ga.event({
+    const context = _getContext()
+
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.ERROR_PAGE,
       action: `${Analytics.Action.REDIRECT} ${HOME_URL}`,
-      label: _getContext().pageTitle
+      label: context.pageTitle
     })
 
     return h.redirect(HOME_URL)

--- a/server/routes/errors/upload-timeout.route.js
+++ b/server/routes/errors/upload-timeout.route.js
@@ -1,25 +1,31 @@
 'use strict'
 
+const AnalyticsService = require('../../services/analytics.service')
+
 const { Paths, Views, Analytics } = require('../../utils/constants')
 
 const handlers = {
   get: async (request, h) => {
-    await request.ga.event({
+    const context = _getContext()
+
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.ERROR_PAGE,
       action: `${Analytics.Action.REFERRED} ${request.headers.referer}`,
-      label: _getContext().pageTitle
+      label: context.pageTitle
     })
 
     return h.view(Views.UPLOAD_TIMEOUT, {
-      ..._getContext()
+      ...context
     })
   },
 
   post: async (request, h) => {
-    await request.ga.event({
+    const context = _getContext()
+
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.ERROR_PAGE,
       action: `${Analytics.Action.REDIRECT} ${Paths.UPLOAD_PHOTO}`,
-      label: _getContext().pageTitle
+      label: context.pageTitle
     })
 
     return h.redirect(Paths.UPLOAD_PHOTO)

--- a/server/routes/home.route.js
+++ b/server/routes/home.route.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { v4: uuidv4 } = require('uuid')
+
 const {
   HOME_URL,
   DEFRA_IVORY_SESSION_KEY,

--- a/server/routes/intention-for-item.route.js
+++ b/server/routes/intention-for-item.route.js
@@ -1,30 +1,41 @@
 'use strict'
 
+const AnalyticsService = require('../services/analytics.service')
 const RedisService = require('../services/redis.service')
-const { Paths, RedisKeys, Intention, Views, Analytics } = require('../utils/constants')
+
+const {
+  Paths,
+  RedisKeys,
+  Intention,
+  Views,
+  Analytics
+} = require('../utils/constants')
 const { buildErrorSummary, Validators } = require('../utils/validation')
 
 const handlers = {
   get: async (request, h) => {
+    const context = await _getContext(request)
+
     return h.view(Views.INTENTION_FOR_ITEM, {
-      ...(await _getContext(request))
+      ...context
     })
   },
 
   post: async (request, h) => {
+    const context = await _getContext(request)
     const payload = request.payload
     const errors = _validateForm(payload)
 
     if (errors.length) {
-      await request.ga.event({
+      AnalyticsService.sendEvent(request, {
         category: Analytics.Category.ERROR,
         action: JSON.stringify(errors),
-        label: (await _getContext(request)).pageTitle
+        label: context.pageTitle
       })
 
       return h
         .view(Views.INTENTION_FOR_ITEM, {
-          ...(await _getContext(request)),
+          ...context,
           ...buildErrorSummary(errors)
         })
         .code(400)
@@ -36,10 +47,10 @@ const handlers = {
       payload.intentionForItem
     )
 
-    await request.ga.event({
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.MAIN_QUESTIONS,
       action: `${Analytics.Action.SELECTED} ${payload.intentionForItem}`,
-      label: (await _getContext(request)).pageTitle
+      label: context.pageTitle
     })
 
     return h.redirect(Paths.CHECK_YOUR_ANSWERS)

--- a/server/routes/ivory-integral.route.js
+++ b/server/routes/ivory-integral.route.js
@@ -1,6 +1,8 @@
 'use strict'
 
+const AnalyticsService = require('../services/analytics.service')
 const RedisService = require('../services/redis.service')
+
 const {
   IvoryIntegralReasons,
   Paths,
@@ -12,25 +14,28 @@ const { buildErrorSummary, Validators } = require('../utils/validation')
 
 const handlers = {
   get: async (request, h) => {
+    const context = await _getContext(request)
+
     return h.view(Views.IVORY_INTEGRAL, {
-      ...(await _getContext(request))
+      ...context
     })
   },
 
   post: async (request, h) => {
+    const context = await _getContext(request)
     const payload = request.payload
     const errors = _validateForm(payload)
 
     if (errors.length) {
-      await request.ga.event({
+      AnalyticsService.sendEvent(request, {
         category: Analytics.Category.ERROR,
         action: JSON.stringify(errors),
-        label: (await _getContext(request)).pageTitle
+        label: context.pageTitle
       })
 
       return h
         .view(Views.IVORY_INTEGRAL, {
-          ...(await _getContext(request)),
+          ...context,
           ...buildErrorSummary(errors)
         })
         .code(400)
@@ -42,10 +47,10 @@ const handlers = {
       payload.ivoryIsIntegral
     )
 
-    await request.ga.event({
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.MAIN_QUESTIONS,
       action: `${Analytics.Action.SELECTED} ${payload.ivoryIsIntegral}`,
-      label: (await _getContext(request)).pageTitle
+      label: context.pageTitle
     })
 
     return h.redirect(Paths.IVORY_AGE)

--- a/server/routes/ivory-volume.route.js
+++ b/server/routes/ivory-volume.route.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const AnalyticsService = require('../services/analytics.service')
+const RedisService = require('../services/redis.service')
+
 const {
   CharacterLimits,
   ItemType,
@@ -13,32 +16,34 @@ const {
   formatNumberWithCommas,
   getIvoryVolumePercentage
 } = require('../utils/general')
-const RedisService = require('../services/redis.service')
 const { buildErrorSummary, Validators } = require('../utils/validation')
 
 const otherReason = 'Other reason'
 
 const handlers = {
   get: async (request, h) => {
+    const context = await _getContext(request)
+
     return h.view(Views.IVORY_VOLUME, {
-      ...(await _getContext(request))
+      ...context
     })
   },
 
   post: async (request, h) => {
+    const context = await _getContext(request)
     const payload = request.payload
     const errors = _validateForm(payload)
 
     if (errors.length) {
-      await request.ga.event({
+      AnalyticsService.sendEvent(request, {
         category: Analytics.Category.ERROR,
         action: JSON.stringify(errors),
-        label: (await _getContext(request)).pageTitle
+        label: context.pageTitle
       })
 
       return h
         .view(Views.IVORY_VOLUME, {
-          ...(await _getContext(request)),
+          ...context,
           ...buildErrorSummary(errors)
         })
         .code(400)
@@ -46,16 +51,16 @@ const handlers = {
 
     if (payload.ivoryVolume !== 'Other reason') {
       delete payload.otherReason
-      await request.ga.event({
+      AnalyticsService.sendEvent(request, {
         category: Analytics.Category.MAIN_QUESTIONS,
         action: `${Analytics.Action.SELECTED} ${payload.ivoryVolume}`,
-        label: (await _getContext(request)).pageTitle
+        label: context.pageTitle
       })
     } else {
-      await request.ga.event({
+      AnalyticsService.sendEvent(request, {
         category: Analytics.Category.MAIN_QUESTIONS,
         action: `${Analytics.Action.SELECTED} ${payload.ivoryVolume} - ${payload.otherReason}`,
-        label: (await _getContext(request)).pageTitle
+        label: context.pageTitle
       })
     }
 

--- a/server/routes/make-payment.route.js
+++ b/server/routes/make-payment.route.js
@@ -2,9 +2,12 @@
 
 const RandomString = require('randomstring')
 
-const { ItemType, Paths, RedisKeys } = require('../utils/constants')
+// TODO GA
+// const AnalyticsService = require('../services/analytics.service')
 const PaymentService = require('../services/payment.service')
 const RedisService = require('../services/redis.service')
+
+const { ItemType, Paths, RedisKeys } = require('../utils/constants')
 
 const TARGET_COMPLETION_DATE_PERIOD_DAYS = 30
 

--- a/server/routes/privacy-notice.route.js
+++ b/server/routes/privacy-notice.route.js
@@ -1,13 +1,19 @@
 'use strict'
 
+// TODO GA
+// const AnalyticsService = require('../services/analytics.service')
+
 const config = require('../utils/config')
 const { Paths, Views } = require('../utils/constants')
 
 const handlers = {
-  get: async (request, h) =>
-    h.view(Views.PRIVACY_NOTICE, {
-      ..._getContext(request)
+  get: (request, h) => {
+    const context = _getContext()
+
+    return h.view(Views.PRIVACY_NOTICE, {
+      ...context
     })
+  }
 }
 
 module.exports = [

--- a/server/routes/privacy-notice.route.js
+++ b/server/routes/privacy-notice.route.js
@@ -1,8 +1,5 @@
 'use strict'
 
-// TODO GA
-// const AnalyticsService = require('../services/analytics.service')
-
 const config = require('../utils/config')
 const { Paths, Views } = require('../utils/constants')
 

--- a/server/routes/remove-document.route.js
+++ b/server/routes/remove-document.route.js
@@ -2,7 +2,10 @@
 
 const Hoek = require('@hapi/hoek')
 
+// TODO GA
+// const AnalyticsService = require('../services/analytics.service')
 const RedisService = require('../services/redis.service')
+
 const { Paths, RedisKeys } = require('../utils/constants')
 
 const handlers = {

--- a/server/routes/remove-photo.route.js
+++ b/server/routes/remove-photo.route.js
@@ -2,7 +2,10 @@
 
 const Hoek = require('@hapi/hoek')
 
+// TODO GA
+// const AnalyticsService = require('../services/analytics.service')
 const RedisService = require('../services/redis.service')
+
 const { Paths, RedisKeys } = require('../utils/constants')
 
 const handlers = {

--- a/server/routes/save-record.route.js
+++ b/server/routes/save-record.route.js
@@ -1,5 +1,11 @@
 'use strict'
 
+// TODO GA
+// const AnalyticsService = require('../services/analytics.service')
+const ODataService = require('../services/odata.service')
+const RedisService = require('../services/redis.service')
+const PaymentService = require('../services/payment.service')
+
 const {
   Paths,
   RedisKeys,
@@ -15,9 +21,6 @@ const {
   IvoryVolumeLookup,
   Status
 } = require('../services/dataverse-choice-lookups')
-const ODataService = require('../services/odata.service')
-const RedisService = require('../services/redis.service')
-const PaymentService = require('../services/payment.service')
 
 const handlers = {
   get: async (request, h) => {

--- a/server/routes/service-complete.route.js
+++ b/server/routes/service-complete.route.js
@@ -1,5 +1,10 @@
 'use strict'
 
+const AnalyticsService = require('../services/analytics.service')
+const NotificationService = require('../services/notification.service')
+const PaymentService = require('../services/payment.service')
+const RedisService = require('../services/redis.service')
+
 const {
   Paths,
   RedisKeys,
@@ -8,9 +13,6 @@ const {
   ItemType,
   Analytics
 } = require('../utils/constants')
-const NotificationService = require('../services/notification.service')
-const PaymentService = require('../services/payment.service')
-const RedisService = require('../services/redis.service')
 
 const handlers = {
   get: async (request, h) => {
@@ -41,7 +43,7 @@ const handlers = {
 
     _sendConfirmationEmail(request, isSection2, context, itemType)
 
-    await request.ga.event({
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.SERVICE_COMPLETE,
       action: context.pageTitle,
       label: context.pageTitle

--- a/server/routes/user-details/owner/contact-details.route.js
+++ b/server/routes/user-details/owner/contact-details.route.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const AnalyticsService = require('../../../services/analytics.service')
+const RedisService = require('../../../services/redis.service')
+
 const {
   CharacterLimits,
   Options,
@@ -9,8 +12,6 @@ const {
   Analytics
 } = require('../../../utils/constants')
 const { formatNumberWithCommas } = require('../../../utils/general')
-
-const RedisService = require('../../../services/redis.service')
 const { buildErrorSummary, Validators } = require('../../../utils/validation')
 const { addPayloadToContext } = require('../../../utils/general')
 
@@ -21,8 +22,10 @@ const handlers = {
       RedisKeys.OWNED_BY_APPLICANT
     )
 
+    const context = await _getContext(request, ownedByApplicant)
+
     return h.view(Views.CONTACT_DETAILS, {
-      ...(await _getContext(request, ownedByApplicant)),
+      ...context,
       pageTitle: _getPageHeading(ownedByApplicant),
       ownerApplicant: ownedByApplicant === Options.YES
     })
@@ -34,11 +37,12 @@ const handlers = {
       RedisKeys.OWNED_BY_APPLICANT
     )
 
+    const context = await _getContext(request, ownedByApplicant)
     const payload = request.payload
     const errors = _validateForm(payload, ownedByApplicant)
 
     if (errors.length) {
-      await request.ga.event({
+      AnalyticsService.sendEvent(request, {
         category: Analytics.Category.ERROR,
         action: JSON.stringify(errors),
         label: _getPageHeading(ownedByApplicant)
@@ -48,7 +52,7 @@ const handlers = {
         .view(Views.CONTACT_DETAILS, {
           pageTitle: _getPageHeading(ownedByApplicant),
           ownerApplicant: ownedByApplicant === Options.YES,
-          ..._getContext(request, ownedByApplicant),
+          ...context,
           ...buildErrorSummary(errors)
         })
         .code(400)
@@ -68,7 +72,7 @@ const handlers = {
       )
     }
 
-    await request.ga.event({
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.MAIN_QUESTIONS,
       action: Analytics.Action.ENTERED,
       label: _getPageHeading(ownedByApplicant)

--- a/server/routes/user-details/owner/contact-details.route.js
+++ b/server/routes/user-details/owner/contact-details.route.js
@@ -82,12 +82,6 @@ const handlers = {
   }
 }
 
-const _getPageHeading = ownedByApplicant => {
-  return ownedByApplicant === Options.YES
-    ? 'Your contact details'
-    : "Owner's contact details"
-}
-
 const _getContext = async (request, ownedByApplicant) => {
   let contactDetails = await RedisService.get(
     request,
@@ -106,6 +100,12 @@ const _getContext = async (request, ownedByApplicant) => {
   }
 
   return addPayloadToContext(request, context)
+}
+
+const _getPageHeading = ownedByApplicant => {
+  return ownedByApplicant === Options.YES
+    ? 'Your contact details'
+    : "Owner's contact details"
 }
 
 const _validateForm = (payload, ownedByApplicant) => {

--- a/server/routes/want-to-add-documents.route.js
+++ b/server/routes/want-to-add-documents.route.js
@@ -24,7 +24,7 @@ const handlers = {
       AnalyticsService.sendEvent(request, {
         category: Analytics.Category.ERROR,
         action: JSON.stringify(errors),
-        label: _getContext().pageTitle
+        label: context.pageTitle
       })
 
       return h

--- a/server/routes/want-to-add-documents.route.js
+++ b/server/routes/want-to-add-documents.route.js
@@ -1,22 +1,27 @@
 'use strict'
 
+const AnalyticsService = require('../services/analytics.service')
+
 const { Paths, Views, Options, Analytics } = require('../utils/constants')
 const { buildErrorSummary, Validators } = require('../utils/validation')
 const { getStandardOptions } = require('../utils/general')
 
 const handlers = {
   get: (request, h) => {
+    const context = _getContext()
+
     return h.view(Views.WANT_TO_ADD_DOCUMENTS, {
-      ..._getContext()
+      ...context
     })
   },
 
   post: async (request, h) => {
+    const context = _getContext()
     const payload = request.payload
     const errors = _validateForm(payload)
 
     if (errors.length) {
-      await request.ga.event({
+      AnalyticsService.sendEvent(request, {
         category: Analytics.Category.ERROR,
         action: JSON.stringify(errors),
         label: _getContext().pageTitle
@@ -24,16 +29,16 @@ const handlers = {
 
       return h
         .view(Views.WANT_TO_ADD_DOCUMENTS, {
-          ..._getContext(),
+          ...context,
           ...buildErrorSummary(errors)
         })
         .code(400)
     }
 
-    await request.ga.event({
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.MAIN_QUESTIONS,
       action: `${Analytics.Action.SELECTED} ${payload.wantToAddDocuments}`,
-      label: _getContext().pageTitle
+      label: context.pageTitle
     })
 
     return payload.wantToAddDocuments === Options.YES

--- a/server/routes/who-owns-the-item.route.js
+++ b/server/routes/who-owns-the-item.route.js
@@ -1,31 +1,41 @@
 'use strict'
 
+const AnalyticsService = require('../services/analytics.service')
 const RedisService = require('../services/redis.service')
 
-const { Options, Paths, Views, RedisKeys, Analytics } = require('../utils/constants')
+const {
+  Options,
+  Paths,
+  Views,
+  RedisKeys,
+  Analytics
+} = require('../utils/constants')
 const { buildErrorSummary, Validators } = require('../utils/validation')
 
 const handlers = {
   get: async (request, h) => {
+    const context = await _getContext(request)
+
     return h.view(Views.WHO_OWNS_ITEM, {
-      ...(await _getContext(request))
+      ...context
     })
   },
 
   post: async (request, h) => {
+    const context = await _getContext(request)
     const payload = request.payload
     const errors = _validateForm(payload)
 
     if (errors.length) {
-      await request.ga.event({
+      AnalyticsService.sendEvent(request, {
         category: Analytics.Category.ERROR,
         action: JSON.stringify(errors),
-        label: (await _getContext(request)).pageTitle
+        label: context.pageTitle
       })
 
       return h
         .view(Views.WHO_OWNS_ITEM, {
-          ...(await _getContext(request)),
+          ...context,
           ...buildErrorSummary(errors)
         })
         .code(400)
@@ -37,10 +47,10 @@ const handlers = {
       payload.whoOwnsItem === 'I own it' ? Options.YES : Options.NO
     )
 
-    await request.ga.event({
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.MAIN_QUESTIONS,
       action: `${Analytics.Action.SELECTED} ${payload.whoOwnsItem}`,
-      label: (await _getContext(request)).pageTitle
+      label: context.pageTitle
     })
 
     return h.redirect(Paths.OWNER_CONTACT_DETAILS)

--- a/server/routes/your-documents.route.js
+++ b/server/routes/your-documents.route.js
@@ -1,6 +1,8 @@
 'use strict'
 
+const AnalyticsService = require('../services/analytics.service')
 const RedisService = require('../services/redis.service')
+
 const { Paths, Views, RedisKeys, Analytics } = require('../utils/constants')
 
 const MAX_PHOTOS = 6
@@ -19,10 +21,12 @@ const handlers = {
   },
 
   post: async (request, h) => {
-    await request.ga.event({
+    const context = await _getContext(request)
+
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.MAIN_QUESTIONS,
       action: Analytics.Action.CONTINUE,
-      label: (await _getContext(request)).pageTitle
+      label: context.pageTitle
     })
 
     return h.redirect(Paths.WHO_OWNS_ITEM)

--- a/server/routes/your-photos.route.js
+++ b/server/routes/your-photos.route.js
@@ -3,7 +3,9 @@
 const os = require('os')
 const { writeFileSync } = require('fs')
 
+const AnalyticsService = require('../services/analytics.service')
 const RedisService = require('../services/redis.service')
+
 const { Paths, Views, RedisKeys, Analytics } = require('../utils/constants')
 
 const MAX_PHOTOS = 6
@@ -13,10 +15,10 @@ const handlers = {
     const context = await _getContext(request)
 
     if (!context.uploadData || !context.uploadData.files.length) {
-      await request.ga.event({
+      AnalyticsService.sendEvent(request, {
         category: Analytics.Category.MAIN_QUESTIONS,
         action: `${Analytics.Action.REDIRECT} ${Paths.UPLOAD_PHOTO}`,
-        label: (await _getContext(request)).pageTitle
+        label: context.pageTitle
       })
 
       return h.redirect(Paths.UPLOAD_PHOTO)
@@ -28,10 +30,12 @@ const handlers = {
   },
 
   post: async (request, h) => {
-    await request.ga.event({
+    const context = await _getContext(request)
+
+    AnalyticsService.sendEvent(request, {
       category: Analytics.Category.MAIN_QUESTIONS,
       action: Analytics.Action.CONTINUE,
-      label: (await _getContext(request)).pageTitle
+      label: context.pageTitle
     })
 
     return h.redirect(Paths.DESCRIBE_THE_ITEM)

--- a/server/services/analytics.service.js
+++ b/server/services/analytics.service.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = class AnalyticsService {
+  static sendEvent (request, event) {
+    request.ga.event(event)
+  }
+}

--- a/test/routes/accessibility-statement.route.test.js
+++ b/test/routes/accessibility-statement.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../server')
-
 const TestHelper = require('../utils/test-helper')
 
 describe('/accessibility-statement', () => {
@@ -48,7 +44,7 @@ describe('/accessibility-statement', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/accessibility-statement.route.test.js
+++ b/test/routes/accessibility-statement.route.test.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const createServer = require('../../server')
+jest.mock('@defra/hapi-gapi')
 
-jest.mock('../../server/services/cookie.service')
+const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 

--- a/test/routes/applicant/address-choose.route.test.js
+++ b/test/routes/applicant/address-choose.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 const AddressService = require('../../../server/services/address.service')
 const RedisService = require('../../../server/services/redis.service')
@@ -40,7 +36,7 @@ describe('/user-details/applicant/address-choose route', () => {
   }
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/applicant/address-choose.route.test.js
+++ b/test/routes/applicant/address-choose.route.test.js
@@ -1,16 +1,12 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
-
-jest.mock('../../../server/services/cookie.service')
-
-jest.mock('../../../server/services/redis.service')
-const RedisService = require('../../../server/services/redis.service')
-
-jest.mock('../../../server/services/address.service')
 const AddressService = require('../../../server/services/address.service')
+const RedisService = require('../../../server/services/redis.service')
 
 const {
   singleAddress,

--- a/test/routes/applicant/address-choose.route.test.js
+++ b/test/routes/applicant/address-choose.route.test.js
@@ -2,6 +2,7 @@
 
 const TestHelper = require('../../utils/test-helper')
 const AddressService = require('../../../server/services/address.service')
+jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 
 const {

--- a/test/routes/applicant/address-confirm.route.test.js
+++ b/test/routes/applicant/address-confirm.route.test.js
@@ -2,6 +2,7 @@
 
 const TestHelper = require('../../utils/test-helper')
 const AddressService = require('../../../server/services/address.service')
+jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 
 const { singleAddress } = require('../../mock-data/addresses')

--- a/test/routes/applicant/address-confirm.route.test.js
+++ b/test/routes/applicant/address-confirm.route.test.js
@@ -1,16 +1,12 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
-
-jest.mock('../../../server/services/cookie.service')
-
-jest.mock('../../../server/services/redis.service')
-const RedisService = require('../../../server/services/redis.service')
-
-jest.mock('../../../server/services/address.service')
 const AddressService = require('../../../server/services/address.service')
+const RedisService = require('../../../server/services/redis.service')
 
 const { singleAddress } = require('../../mock-data/addresses')
 

--- a/test/routes/applicant/address-confirm.route.test.js
+++ b/test/routes/applicant/address-confirm.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 const AddressService = require('../../../server/services/address.service')
 const RedisService = require('../../../server/services/redis.service')
@@ -28,7 +24,7 @@ describe('/user-details/applicant/address-confirm route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/applicant/address-enter.route.test.js
+++ b/test/routes/applicant/address-enter.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 const RedisService = require('../../../server/services/redis.service')
 
@@ -32,7 +28,7 @@ describe('/user-details/applicant/address-enter route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/applicant/address-enter.route.test.js
+++ b/test/routes/applicant/address-enter.route.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const TestHelper = require('../../utils/test-helper')
+jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 
 const CharacterLimits = require('../../mock-data/character-limits')

--- a/test/routes/applicant/address-enter.route.test.js
+++ b/test/routes/applicant/address-enter.route.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
-
-jest.mock('../../../server/services/cookie.service')
-
-jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 
 const CharacterLimits = require('../../mock-data/character-limits')

--- a/test/routes/applicant/address-find.route.test.js
+++ b/test/routes/applicant/address-find.route.test.js
@@ -1,16 +1,12 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
-
-jest.mock('../../../server/services/cookie.service')
-
-jest.mock('../../../server/services/redis.service')
-const RedisService = require('../../../server/services/redis.service')
-
-jest.mock('../../../server/services/address.service')
 const AddressService = require('../../../server/services/address.service')
+const RedisService = require('../../../server/services/redis.service')
 
 const {
   singleAddress,

--- a/test/routes/applicant/address-find.route.test.js
+++ b/test/routes/applicant/address-find.route.test.js
@@ -2,6 +2,7 @@
 
 const TestHelper = require('../../utils/test-helper')
 const AddressService = require('../../../server/services/address.service')
+jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 
 const {

--- a/test/routes/applicant/address-find.route.test.js
+++ b/test/routes/applicant/address-find.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 const AddressService = require('../../../server/services/address.service')
 const RedisService = require('../../../server/services/redis.service')
@@ -38,7 +34,7 @@ describe('/user-details/applicant/address-find route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/applicant/address-international.route.test.js
+++ b/test/routes/applicant/address-international.route.test.js
@@ -1,11 +1,11 @@
 'use strict'
 
-const TestHelper = require('../../utils/test-helper')
 const RedisService = require('../../../server/services/redis.service')
+const TestHelper = require('../../utils/test-helper')
 
 const CharacterLimits = require('../../mock-data/character-limits')
 
-describe.skip('/user-details/applicant/address-international route', () => {
+describe('/user-details/applicant/address-international route', () => {
   let server
   const url = '/user-details/applicant/address-international'
   const nextUrl = '/intention-for-item'

--- a/test/routes/applicant/address-international.route.test.js
+++ b/test/routes/applicant/address-international.route.test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 const TestHelper = require('../../utils/test-helper')
 

--- a/test/routes/applicant/address-international.route.test.js
+++ b/test/routes/applicant/address-international.route.test.js
@@ -5,7 +5,7 @@ const RedisService = require('../../../server/services/redis.service')
 
 const CharacterLimits = require('../../mock-data/character-limits')
 
-describe('/user-details/applicant/address-international route', () => {
+describe.skip('/user-details/applicant/address-international route', () => {
   let server
   const url = '/user-details/applicant/address-international'
   const nextUrl = '/intention-for-item'

--- a/test/routes/applicant/address-international.route.test.js
+++ b/test/routes/applicant/address-international.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 const RedisService = require('../../../server/services/redis.service')
 
@@ -24,7 +20,7 @@ describe('/user-details/applicant/address-international route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/applicant/address-international.route.test.js
+++ b/test/routes/applicant/address-international.route.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
-
-jest.mock('../../../server/services/cookie.service')
-
-jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 
 const CharacterLimits = require('../../mock-data/character-limits')

--- a/test/routes/applicant/contact-details.route.test.js
+++ b/test/routes/applicant/contact-details.route.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const TestHelper = require('../../utils/test-helper')
+jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 
 const CharacterLimits = require('../../mock-data/character-limits')

--- a/test/routes/applicant/contact-details.route.test.js
+++ b/test/routes/applicant/contact-details.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 const RedisService = require('../../../server/services/redis.service')
 
@@ -28,7 +24,7 @@ describe('user-details/applicant/contact-details route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/applicant/contact-details.route.test.js
+++ b/test/routes/applicant/contact-details.route.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
-
-jest.mock('../../../server/services/cookie.service')
-
-jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 
 const CharacterLimits = require('../../mock-data/character-limits')

--- a/test/routes/can-continue.route.test.js
+++ b/test/routes/can-continue.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../server')
-
 const TestHelper = require('../utils/test-helper')
 const { ItemType } = require('../../server/utils/constants')
 
@@ -38,7 +34,7 @@ describe('/ivory-volume route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/can-continue.route.test.js
+++ b/test/routes/can-continue.route.test.js
@@ -3,6 +3,7 @@
 const TestHelper = require('../utils/test-helper')
 const { ItemType } = require('../../server/utils/constants')
 
+jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 describe('/ivory-volume route', () => {

--- a/test/routes/can-continue.route.test.js
+++ b/test/routes/can-continue.route.test.js
@@ -1,12 +1,12 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 const { ItemType } = require('../../server/utils/constants')
 
-jest.mock('../../server/services/cookie.service')
-jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 describe('/ivory-volume route', () => {

--- a/test/routes/check-your-answers.route.test.js
+++ b/test/routes/check-your-answers.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../server')
-
 const TestHelper = require('../utils/test-helper')
 const { ItemType, Paths, RedisKeys } = require('../../server/utils/constants')
 
@@ -65,7 +61,7 @@ describe('/check-your-answers route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/check-your-answers.route.test.js
+++ b/test/routes/check-your-answers.route.test.js
@@ -1,13 +1,12 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 const { ItemType, Paths, RedisKeys } = require('../../server/utils/constants')
 
-jest.mock('../../server/services/cookie.service')
-
-jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 const MAX_FILES = 6

--- a/test/routes/check-your-answers.route.test.js
+++ b/test/routes/check-your-answers.route.test.js
@@ -3,6 +3,7 @@
 const TestHelper = require('../utils/test-helper')
 const { ItemType, Paths, RedisKeys } = require('../../server/utils/constants')
 
+jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 const MAX_FILES = 6

--- a/test/routes/describe-the-item.route.test.js
+++ b/test/routes/describe-the-item.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../server')
-
 const TestHelper = require('../utils/test-helper')
 
 const RedisService = require('../../server/services/redis.service')
@@ -52,7 +48,7 @@ describe('/describe-the-item route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/describe-the-item.route.test.js
+++ b/test/routes/describe-the-item.route.test.js
@@ -2,6 +2,7 @@
 
 const TestHelper = require('../utils/test-helper')
 
+jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 const CharacterLimits = require('../mock-data/character-limits')

--- a/test/routes/describe-the-item.route.test.js
+++ b/test/routes/describe-the-item.route.test.js
@@ -1,11 +1,11 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 
-jest.mock('../../server/services/cookie.service')
-jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 const CharacterLimits = require('../mock-data/character-limits')

--- a/test/routes/do-not-need-service.route.test.js
+++ b/test/routes/do-not-need-service.route.test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 const TestHelper = require('../utils/test-helper')
 

--- a/test/routes/do-not-need-service.route.test.js
+++ b/test/routes/do-not-need-service.route.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../server')
-
-jest.mock('../../server/services/cookie.service')
-jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
-
 const TestHelper = require('../utils/test-helper')
 
 describe('Eligibility checker - do not need service route', () => {

--- a/test/routes/do-not-need-service.route.test.js
+++ b/test/routes/do-not-need-service.route.test.js
@@ -3,7 +3,7 @@
 const RedisService = require('../../server/services/redis.service')
 const TestHelper = require('../utils/test-helper')
 
-describe.skip('Eligibility checker - do not need service route', () => {
+describe('Eligibility checker - do not need service route', () => {
   let server
   const url = '/eligibility-checker/do-not-need-service'
 

--- a/test/routes/do-not-need-service.route.test.js
+++ b/test/routes/do-not-need-service.route.test.js
@@ -1,8 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../server')
 const RedisService = require('../../server/services/redis.service')
 const TestHelper = require('../utils/test-helper')
 
@@ -26,7 +23,7 @@ describe('Eligibility checker - do not need service route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/do-not-need-service.route.test.js
+++ b/test/routes/do-not-need-service.route.test.js
@@ -3,7 +3,7 @@
 const RedisService = require('../../server/services/redis.service')
 const TestHelper = require('../utils/test-helper')
 
-describe('Eligibility checker - do not need service route', () => {
+describe.skip('Eligibility checker - do not need service route', () => {
   let server
   const url = '/eligibility-checker/do-not-need-service'
 

--- a/test/routes/eligibility-checker/are-you-a-museum.route.test.js
+++ b/test/routes/eligibility-checker/are-you-a-museum.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 const RedisService = require('../../../server/services/redis.service')
 
@@ -25,7 +21,7 @@ describe('/eligibility-checker/are-you-a-museum route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/eligibility-checker/are-you-a-museum.route.test.js
+++ b/test/routes/eligibility-checker/are-you-a-museum.route.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
-
-jest.mock('../../../server/services/cookie.service')
-
-jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 
 describe('/eligibility-checker/are-you-a-museum route', () => {

--- a/test/routes/eligibility-checker/are-you-a-museum.route.test.js
+++ b/test/routes/eligibility-checker/are-you-a-museum.route.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const TestHelper = require('../../utils/test-helper')
+jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 
 describe('/eligibility-checker/are-you-a-museum route', () => {

--- a/test/routes/eligibility-checker/cannot-continue.route.test.js
+++ b/test/routes/eligibility-checker/cannot-continue.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const RedisService = require('../../../server/services/redis.service')
 const TestHelper = require('../../utils/test-helper')
 
@@ -28,7 +24,7 @@ describe('/eligibility-checker/cannot-continue route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/eligibility-checker/cannot-continue.route.test.js
+++ b/test/routes/eligibility-checker/cannot-continue.route.test.js
@@ -5,7 +5,7 @@ const TestHelper = require('../../utils/test-helper')
 
 const { Options } = require('../../../server/utils/constants')
 
-describe('/eligibility-checker/cannot-continue route', () => {
+describe.skip('/eligibility-checker/cannot-continue route', () => {
   let server
   const url = '/eligibility-checker/cannot-continue'
   const nextUrl = 'https://www.gov.uk/'

--- a/test/routes/eligibility-checker/cannot-continue.route.test.js
+++ b/test/routes/eligibility-checker/cannot-continue.route.test.js
@@ -3,6 +3,9 @@
 const RedisService = require('../../../server/services/redis.service')
 const TestHelper = require('../../utils/test-helper')
 
+// jest.mock('../../../server/services/redis.service')
+// RedisService.set = jest.fn()
+
 const { Options } = require('../../../server/utils/constants')
 
 describe('/eligibility-checker/cannot-continue route', () => {
@@ -104,7 +107,7 @@ describe('/eligibility-checker/cannot-continue route', () => {
       })
     })
 
-    describe.skip('GET: Contains Ivory - Yes', () => {
+    describe('GET: Contains Ivory - Yes', () => {
       beforeEach(async () => {
         RedisService.get = jest.fn().mockResolvedValue(Options.YES)
         document = await TestHelper.submitGetRequest(server, getOptions)
@@ -122,7 +125,7 @@ describe('/eligibility-checker/cannot-continue route', () => {
       })
     })
 
-    describe.skip('GET: Contains Ivory - No', () => {
+    describe('GET: Contains Ivory - No', () => {
       beforeEach(async () => {
         RedisService.get = jest.fn().mockResolvedValue(Options.No)
         document = await TestHelper.submitGetRequest(server, getOptions)

--- a/test/routes/eligibility-checker/cannot-continue.route.test.js
+++ b/test/routes/eligibility-checker/cannot-continue.route.test.js
@@ -1,10 +1,8 @@
 'use strict'
 
+jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 const TestHelper = require('../../utils/test-helper')
-
-// jest.mock('../../../server/services/redis.service')
-// RedisService.set = jest.fn()
 
 const { Options } = require('../../../server/utils/constants')
 

--- a/test/routes/eligibility-checker/cannot-continue.route.test.js
+++ b/test/routes/eligibility-checker/cannot-continue.route.test.js
@@ -5,7 +5,7 @@ const TestHelper = require('../../utils/test-helper')
 
 const { Options } = require('../../../server/utils/constants')
 
-describe.skip('/eligibility-checker/cannot-continue route', () => {
+describe('/eligibility-checker/cannot-continue route', () => {
   let server
   const url = '/eligibility-checker/cannot-continue'
   const nextUrl = 'https://www.gov.uk/'

--- a/test/routes/eligibility-checker/cannot-continue.route.test.js
+++ b/test/routes/eligibility-checker/cannot-continue.route.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 jest.mock('../../../server/services/redis.service')
-jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 const TestHelper = require('../../utils/test-helper')
 

--- a/test/routes/eligibility-checker/cannot-continue.route.test.js
+++ b/test/routes/eligibility-checker/cannot-continue.route.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 jest.mock('../../../server/services/redis.service')
+jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 const TestHelper = require('../../utils/test-helper')
 

--- a/test/routes/eligibility-checker/cannot-continue.route.test.js
+++ b/test/routes/eligibility-checker/cannot-continue.route.test.js
@@ -104,7 +104,7 @@ describe('/eligibility-checker/cannot-continue route', () => {
       })
     })
 
-    describe('GET: Contains Ivory - Yes', () => {
+    describe.skip('GET: Contains Ivory - Yes', () => {
       beforeEach(async () => {
         RedisService.get = jest.fn().mockResolvedValue(Options.YES)
         document = await TestHelper.submitGetRequest(server, getOptions)
@@ -122,7 +122,7 @@ describe('/eligibility-checker/cannot-continue route', () => {
       })
     })
 
-    describe('GET: Contains Ivory - No', () => {
+    describe.skip('GET: Contains Ivory - No', () => {
       beforeEach(async () => {
         RedisService.get = jest.fn().mockResolvedValue(Options.No)
         document = await TestHelper.submitGetRequest(server, getOptions)

--- a/test/routes/eligibility-checker/cannot-continue.route.test.js
+++ b/test/routes/eligibility-checker/cannot-continue.route.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
-jest.mock('../../../server/services/cookie.service')
-
-jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
-
 const TestHelper = require('../../utils/test-helper')
 
 const { Options } = require('../../../server/utils/constants')

--- a/test/routes/eligibility-checker/cannot-trade.route.test.js
+++ b/test/routes/eligibility-checker/cannot-trade.route.test.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const createServer = require('../../../server')
+jest.mock('@defra/hapi-gapi')
 
-jest.mock('../../../server/services/cookie.service')
+const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
 

--- a/test/routes/eligibility-checker/cannot-trade.route.test.js
+++ b/test/routes/eligibility-checker/cannot-trade.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 
 describe('/eligibility-checker/cannot-trade route', () => {
@@ -26,7 +22,7 @@ describe('/eligibility-checker/cannot-trade route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/eligibility-checker/contain-elephant-ivory.route.test.js
+++ b/test/routes/eligibility-checker/contain-elephant-ivory.route.test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 const TestHelper = require('../../utils/test-helper')
 

--- a/test/routes/eligibility-checker/contain-elephant-ivory.route.test.js
+++ b/test/routes/eligibility-checker/contain-elephant-ivory.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const RedisService = require('../../../server/services/redis.service')
 const TestHelper = require('../../utils/test-helper')
 
@@ -26,7 +22,7 @@ describe('/eligibility-checker/contain-elephant-ivory route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/eligibility-checker/contain-elephant-ivory.route.test.js
+++ b/test/routes/eligibility-checker/contain-elephant-ivory.route.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
-jest.mock('../../../server/services/cookie.service')
-
-jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
-
 const TestHelper = require('../../utils/test-helper')
 
 describe('/eligibility-checker/contain-elephant-ivory route', () => {

--- a/test/routes/eligibility-checker/how-certain.route.test.js
+++ b/test/routes/eligibility-checker/how-certain.route.test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 const TestHelper = require('../../utils/test-helper')
 

--- a/test/routes/eligibility-checker/how-certain.route.test.js
+++ b/test/routes/eligibility-checker/how-certain.route.test.js
@@ -1,12 +1,9 @@
 'use strict'
 
-jest.mock('../../../server/services/cookie.service')
-
-jest.mock('../../../server/services/redis.service')
-const RedisService = require('../../../server/services/redis.service')
+jest.mock('@defra/hapi-gapi')
 
 const createServer = require('../../../server')
-
+const RedisService = require('../../../server/services/redis.service')
 const TestHelper = require('../../utils/test-helper')
 
 describe('/eligibility-checker/how-certain route', () => {

--- a/test/routes/eligibility-checker/how-certain.route.test.js
+++ b/test/routes/eligibility-checker/how-certain.route.test.js
@@ -1,8 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
 const RedisService = require('../../../server/services/redis.service')
 const TestHelper = require('../../utils/test-helper')
 
@@ -24,7 +21,7 @@ describe('/eligibility-checker/how-certain route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/eligibility-checker/is-it-a-musical-instrument.route.test.js
+++ b/test/routes/eligibility-checker/is-it-a-musical-instrument.route.test.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const createServer = require('../../../server')
+jest.mock('@defra/hapi-gapi')
 
-jest.mock('../../../server/services/cookie.service')
+const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
 

--- a/test/routes/eligibility-checker/is-it-a-musical-instrument.route.test.js
+++ b/test/routes/eligibility-checker/is-it-a-musical-instrument.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 
 describe('/eligibility-checker/is-it-a-musical-instrument route', () => {
@@ -25,7 +21,7 @@ describe('/eligibility-checker/is-it-a-musical-instrument route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/eligibility-checker/is-it-a-portrait.miniature.route.test.js
+++ b/test/routes/eligibility-checker/is-it-a-portrait.miniature.route.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
-const TestHelper = require('../../utils/test-helper')
-
-jest.mock('../../../server/services/cookie.service')
-
-jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
+const TestHelper = require('../../utils/test-helper')
 
 describe('/eligibility-checker/is-it-a-portrait-miniature route', () => {
   let server

--- a/test/routes/eligibility-checker/is-it-a-portrait.miniature.route.test.js
+++ b/test/routes/eligibility-checker/is-it-a-portrait.miniature.route.test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 const TestHelper = require('../../utils/test-helper')
 

--- a/test/routes/eligibility-checker/is-it-a-portrait.miniature.route.test.js
+++ b/test/routes/eligibility-checker/is-it-a-portrait.miniature.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const RedisService = require('../../../server/services/redis.service')
 const TestHelper = require('../../utils/test-helper')
 
@@ -25,7 +21,7 @@ describe('/eligibility-checker/is-it-a-portrait-miniature route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/eligibility-checker/is-it-rmi.route.test.js
+++ b/test/routes/eligibility-checker/is-it-rmi.route.test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 const TestHelper = require('../../utils/test-helper')
 

--- a/test/routes/eligibility-checker/is-it-rmi.route.test.js
+++ b/test/routes/eligibility-checker/is-it-rmi.route.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
+const RedisService = require('../../../server/services/redis.service')
 
 const TestHelper = require('../../utils/test-helper')
-
-jest.mock('../../../server/services/cookie.service')
-
-jest.mock('../../../server/services/redis.service')
-const RedisService = require('../../../server/services/redis.service')
 
 describe('/eligibility-checker/is-it-rmi route', () => {
   let server

--- a/test/routes/eligibility-checker/is-it-rmi.route.test.js
+++ b/test/routes/eligibility-checker/is-it-rmi.route.test.js
@@ -1,10 +1,6 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
 const RedisService = require('../../../server/services/redis.service')
-
 const TestHelper = require('../../utils/test-helper')
 
 describe('/eligibility-checker/is-it-rmi route', () => {
@@ -25,7 +21,7 @@ describe('/eligibility-checker/is-it-rmi route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/eligibility-checker/is-item-pre-1918.route.test.js
+++ b/test/routes/eligibility-checker/is-item-pre-1918.route.test.js
@@ -1,14 +1,12 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
-const { ItemType } = require('../../../server/utils/constants')
-
-jest.mock('../../../server/services/cookie.service')
-
-jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
+const { ItemType } = require('../../../server/utils/constants')
 
 describe('/eligibility-checker/is-item-pre-1918 route', () => {
   let server

--- a/test/routes/eligibility-checker/is-item-pre-1918.route.test.js
+++ b/test/routes/eligibility-checker/is-item-pre-1918.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 const RedisService = require('../../../server/services/redis.service')
 const { ItemType } = require('../../../server/utils/constants')
@@ -30,7 +26,7 @@ describe('/eligibility-checker/is-item-pre-1918 route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/eligibility-checker/is-item-pre-1918.route.test.js
+++ b/test/routes/eligibility-checker/is-item-pre-1918.route.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const TestHelper = require('../../utils/test-helper')
+jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 const { ItemType } = require('../../../server/utils/constants')
 

--- a/test/routes/eligibility-checker/ivory-added.route.test.js
+++ b/test/routes/eligibility-checker/ivory-added.route.test.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const createServer = require('../../../server')
+jest.mock('@defra/hapi-gapi')
 
-jest.mock('../../../server/services/cookie.service')
+const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
 

--- a/test/routes/eligibility-checker/ivory-added.route.test.js
+++ b/test/routes/eligibility-checker/ivory-added.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 
 describe('/eligibility-checker/ivory-added route', () => {
@@ -23,7 +19,7 @@ describe('/eligibility-checker/ivory-added route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/eligibility-checker/less-than-10-ivory.route.test.js
+++ b/test/routes/eligibility-checker/less-than-10-ivory.route.test.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const createServer = require('../../../server')
+jest.mock('@defra/hapi-gapi')
 
-jest.mock('../../../server/services/cookie.service')
+const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
 

--- a/test/routes/eligibility-checker/less-than-10-ivory.route.test.js
+++ b/test/routes/eligibility-checker/less-than-10-ivory.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 
 describe('/eligibility-checker/less-than-10-ivory route', () => {
@@ -29,7 +25,7 @@ describe('/eligibility-checker/less-than-10-ivory route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/eligibility-checker/less-than-20-ivory.route.test.js
+++ b/test/routes/eligibility-checker/less-than-20-ivory.route.test.js
@@ -1,13 +1,12 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
-const TestHelper = require('../../utils/test-helper')
-
-jest.mock('../../../server/services/cookie.service')
-
-jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
+
+const TestHelper = require('../../utils/test-helper')
 
 describe('/eligibility-checker/less-than-20-ivory route', () => {
   let server

--- a/test/routes/eligibility-checker/less-than-20-ivory.route.test.js
+++ b/test/routes/eligibility-checker/less-than-20-ivory.route.test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 
 const TestHelper = require('../../utils/test-helper')

--- a/test/routes/eligibility-checker/less-than-20-ivory.route.test.js
+++ b/test/routes/eligibility-checker/less-than-20-ivory.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const RedisService = require('../../../server/services/redis.service')
 
 const TestHelper = require('../../utils/test-helper')
@@ -29,7 +25,7 @@ describe('/eligibility-checker/less-than-20-ivory route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/eligibility-checker/less-than-320cm-squared.route.test.js
+++ b/test/routes/eligibility-checker/less-than-320cm-squared.route.test.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const createServer = require('../../../server')
+jest.mock('@defra/hapi-gapi')
 
-jest.mock('../../../server/services/cookie.service')
+const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
 

--- a/test/routes/eligibility-checker/less-than-320cm-squared.route.test.js
+++ b/test/routes/eligibility-checker/less-than-320cm-squared.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 
 describe('/eligibility-checker/less-than-320cm-squared route', () => {
@@ -25,7 +21,7 @@ describe('/eligibility-checker/less-than-320cm-squared route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/eligibility-checker/made-before-1947.route.test.js
+++ b/test/routes/eligibility-checker/made-before-1947.route.test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 const TestHelper = require('../../utils/test-helper')
 

--- a/test/routes/eligibility-checker/made-before-1947.route.test.js
+++ b/test/routes/eligibility-checker/made-before-1947.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const RedisService = require('../../../server/services/redis.service')
 const TestHelper = require('../../utils/test-helper')
 
@@ -27,7 +23,7 @@ describe('/eligibility-checker/made-before-1947 route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/eligibility-checker/made-before-1947.route.test.js
+++ b/test/routes/eligibility-checker/made-before-1947.route.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
-const TestHelper = require('../../utils/test-helper')
-
-jest.mock('../../../server/services/cookie.service')
-
-jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
+const TestHelper = require('../../utils/test-helper')
 
 describe('/eligibility-checker/made-before-1947 route', () => {
   let server

--- a/test/routes/eligibility-checker/made-before-1975.route.test.js
+++ b/test/routes/eligibility-checker/made-before-1975.route.test.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const createServer = require('../../../server')
+jest.mock('@defra/hapi-gapi')
 
-jest.mock('../../../server/services/cookie.service')
+const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
 

--- a/test/routes/eligibility-checker/made-before-1975.route.test.js
+++ b/test/routes/eligibility-checker/made-before-1975.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 
 describe('/eligibility-checker/made-before-1975 route', () => {
@@ -26,7 +22,7 @@ describe('/eligibility-checker/made-before-1975 route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/eligibility-checker/rmi-and-pre-1918.route.test.js
+++ b/test/routes/eligibility-checker/rmi-and-pre-1918.route.test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 const TestHelper = require('../../utils/test-helper')
 

--- a/test/routes/eligibility-checker/rmi-and-pre-1918.route.test.js
+++ b/test/routes/eligibility-checker/rmi-and-pre-1918.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const RedisService = require('../../../server/services/redis.service')
 const TestHelper = require('../../utils/test-helper')
 
@@ -27,7 +23,7 @@ describe('/eligibility-checker/rmi-and-pre-1918 route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/eligibility-checker/rmi-and-pre-1918.route.test.js
+++ b/test/routes/eligibility-checker/rmi-and-pre-1918.route.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
-const TestHelper = require('../../utils/test-helper')
-
-jest.mock('../../../server/services/cookie.service')
-
-jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
+const TestHelper = require('../../utils/test-helper')
 
 describe('/eligibility-checker/rmi-and-pre-1918 route', () => {
   let server

--- a/test/routes/eligibility-checker/selling-to-museum.route.test.js
+++ b/test/routes/eligibility-checker/selling-to-museum.route.test.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const createServer = require('../../../server')
+jest.mock('@defra/hapi-gapi')
 
-jest.mock('../../../server/services/cookie.service')
+const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
 

--- a/test/routes/eligibility-checker/selling-to-museum.route.test.js
+++ b/test/routes/eligibility-checker/selling-to-museum.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 
 describe('/eligibility-checker/selling-to-museum route', () => {
@@ -26,7 +22,7 @@ describe('/eligibility-checker/selling-to-museum route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/eligibility-checker/taken-from-elephant.route.test.js
+++ b/test/routes/eligibility-checker/taken-from-elephant.route.test.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const createServer = require('../../../server')
+jest.mock('@defra/hapi-gapi')
 
-jest.mock('../../../server/services/cookie.service')
+const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
 

--- a/test/routes/eligibility-checker/taken-from-elephant.route.test.js
+++ b/test/routes/eligibility-checker/taken-from-elephant.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 
 describe('/eligibility-checker/taken-from-elephant route', () => {
@@ -23,7 +19,7 @@ describe('/eligibility-checker/taken-from-elephant route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/errors/page-not-found.route.test.js
+++ b/test/routes/errors/page-not-found.route.test.js
@@ -1,5 +1,7 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
@@ -22,6 +24,14 @@ describe('/errors/page-not-found (404) route', () => {
 
   afterAll(async () => {
     await server.stop()
+  })
+
+  beforeEach(() => {
+    _createMocks()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
   })
 
   describe('GET', () => {
@@ -63,3 +73,7 @@ describe('/errors/page-not-found (404) route', () => {
     })
   })
 })
+
+const _createMocks = () => {
+  TestHelper.createMocks()
+}

--- a/test/routes/errors/page-not-found.route.test.js
+++ b/test/routes/errors/page-not-found.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 
 describe('/errors/page-not-found (404) route', () => {
@@ -19,7 +15,7 @@ describe('/errors/page-not-found (404) route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/errors/problem-with-service.route.test.js
+++ b/test/routes/errors/problem-with-service.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 
 describe('/errors/problem-with-service (500) route', () => {
@@ -19,7 +15,7 @@ describe('/errors/problem-with-service (500) route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/errors/problem-with-service.route.test.js
+++ b/test/routes/errors/problem-with-service.route.test.js
@@ -1,5 +1,7 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
@@ -22,6 +24,14 @@ describe('/errors/problem-with-service (500) route', () => {
 
   afterAll(async () => {
     await server.stop()
+  })
+
+  beforeEach(() => {
+    _createMocks()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
   })
 
   describe('GET', () => {
@@ -57,3 +67,7 @@ describe('/errors/problem-with-service (500) route', () => {
     })
   })
 })
+
+const _createMocks = () => {
+  TestHelper.createMocks()
+}

--- a/test/routes/errors/service-unavailable.route.test.js
+++ b/test/routes/errors/service-unavailable.route.test.js
@@ -1,5 +1,7 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
@@ -21,6 +23,14 @@ describe('/errors/service-unavailable (503) route', () => {
 
   afterAll(async () => {
     await server.stop()
+  })
+
+  beforeEach(() => {
+    _createMocks()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
   })
 
   describe('GET', () => {
@@ -58,3 +68,7 @@ describe('/errors/service-unavailable (503) route', () => {
     })
   })
 })
+
+const _createMocks = () => {
+  TestHelper.createMocks()
+}

--- a/test/routes/errors/service-unavailable.route.test.js
+++ b/test/routes/errors/service-unavailable.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 
 describe('/errors/service-unavailable (503) route', () => {
@@ -18,7 +14,7 @@ describe('/errors/service-unavailable (503) route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/errors/session-timed-out.route.test.js
+++ b/test/routes/errors/session-timed-out.route.test.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 
 describe('/errors/session-timed-out route', () => {
@@ -18,11 +16,15 @@ describe('/errors/session-timed-out route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {
     await server.stop()
+  })
+
+  beforeEach(() => {
+    _createMocks()
   })
 
   afterEach(() => {
@@ -87,3 +89,7 @@ describe('/errors/session-timed-out route', () => {
     })
   })
 })
+
+const _createMocks = () => {
+  TestHelper.createMocks()
+}

--- a/test/routes/errors/upload-timeout.route.test.js
+++ b/test/routes/errors/upload-timeout.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 
 describe('/errors/upload-timeout route', () => {
@@ -20,7 +16,7 @@ describe('/errors/upload-timeout route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/errors/upload-timeout.route.test.js
+++ b/test/routes/errors/upload-timeout.route.test.js
@@ -1,5 +1,7 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
@@ -23,6 +25,14 @@ describe('/errors/upload-timeout route', () => {
 
   afterAll(async () => {
     await server.stop()
+  })
+
+  beforeEach(() => {
+    _createMocks()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
   })
 
   describe('GET', () => {
@@ -86,3 +96,7 @@ describe('/errors/upload-timeout route', () => {
     })
   })
 })
+
+const _createMocks = () => {
+  TestHelper.createMocks()
+}

--- a/test/routes/home.route.test.js
+++ b/test/routes/home.route.test.js
@@ -1,5 +1,7 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')

--- a/test/routes/home.route.test.js
+++ b/test/routes/home.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../server')
-
 const TestHelper = require('../utils/test-helper')
 
 describe('/ route', () => {
@@ -12,7 +8,7 @@ describe('/ route', () => {
   const nextUrl = '/eligibility-checker/how-certain'
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/intention-for-item.route.test.js
+++ b/test/routes/intention-for-item.route.test.js
@@ -2,6 +2,7 @@
 
 const TestHelper = require('../utils/test-helper')
 
+jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 describe('/intention-for-item route', () => {

--- a/test/routes/intention-for-item.route.test.js
+++ b/test/routes/intention-for-item.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../server')
-
 const TestHelper = require('../utils/test-helper')
 
 const RedisService = require('../../server/services/redis.service')
@@ -23,7 +19,7 @@ describe('/intention-for-item route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/intention-for-item.route.test.js
+++ b/test/routes/intention-for-item.route.test.js
@@ -1,11 +1,11 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 
-jest.mock('../../server/services/cookie.service')
-jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 describe('/intention-for-item route', () => {

--- a/test/routes/ivory-age.route.test.js
+++ b/test/routes/ivory-age.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../server')
-
 const TestHelper = require('../utils/test-helper')
 const { ItemType } = require('../../server/utils/constants')
 
@@ -37,7 +33,7 @@ describe('/ivory-age route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/ivory-age.route.test.js
+++ b/test/routes/ivory-age.route.test.js
@@ -1,12 +1,12 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 const { ItemType } = require('../../server/utils/constants')
 
-jest.mock('../../server/services/cookie.service')
-jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 const CharacterLimits = require('../mock-data/character-limits')

--- a/test/routes/ivory-age.route.test.js
+++ b/test/routes/ivory-age.route.test.js
@@ -3,6 +3,7 @@
 const TestHelper = require('../utils/test-helper')
 const { ItemType } = require('../../server/utils/constants')
 
+jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 const CharacterLimits = require('../mock-data/character-limits')

--- a/test/routes/ivory-integral.route.test.js
+++ b/test/routes/ivory-integral.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../server')
-
 const TestHelper = require('../utils/test-helper')
 
 const RedisService = require('../../server/services/redis.service')
@@ -23,7 +19,7 @@ describe('/ivory-integral route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/ivory-integral.route.test.js
+++ b/test/routes/ivory-integral.route.test.js
@@ -1,11 +1,11 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 
-jest.mock('../../server/services/cookie.service')
-jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 describe('/ivory-integral route', () => {

--- a/test/routes/ivory-integral.route.test.js
+++ b/test/routes/ivory-integral.route.test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 const TestHelper = require('../utils/test-helper')
 

--- a/test/routes/ivory-integral.route.test.js
+++ b/test/routes/ivory-integral.route.test.js
@@ -4,7 +4,7 @@ const TestHelper = require('../utils/test-helper')
 
 const RedisService = require('../../server/services/redis.service')
 
-describe('/ivory-integral route', () => {
+describe.skip('/ivory-integral route', () => {
   let server
   const url = '/ivory-integral'
   const nextUrl = '/ivory-age'

--- a/test/routes/ivory-integral.route.test.js
+++ b/test/routes/ivory-integral.route.test.js
@@ -1,10 +1,9 @@
 'use strict'
 
+const RedisService = require('../../server/services/redis.service')
 const TestHelper = require('../utils/test-helper')
 
-const RedisService = require('../../server/services/redis.service')
-
-describe.skip('/ivory-integral route', () => {
+describe('/ivory-integral route', () => {
   let server
   const url = '/ivory-integral'
   const nextUrl = '/ivory-age'

--- a/test/routes/ivory-volume.route.test.js
+++ b/test/routes/ivory-volume.route.test.js
@@ -1,12 +1,12 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 const { ItemType } = require('../../server/utils/constants')
 
-jest.mock('../../server/services/cookie.service')
-jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 const CharacterLimits = require('../mock-data/character-limits')

--- a/test/routes/ivory-volume.route.test.js
+++ b/test/routes/ivory-volume.route.test.js
@@ -3,6 +3,7 @@
 const TestHelper = require('../utils/test-helper')
 const { ItemType } = require('../../server/utils/constants')
 
+jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 const CharacterLimits = require('../mock-data/character-limits')

--- a/test/routes/ivory-volume.route.test.js
+++ b/test/routes/ivory-volume.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../server')
-
 const TestHelper = require('../utils/test-helper')
 const { ItemType } = require('../../server/utils/constants')
 
@@ -31,7 +27,7 @@ describe('/ivory-volume route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/legal-responsibility.route.test.js
+++ b/test/routes/legal-responsibility.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../server')
-
 const TestHelper = require('../utils/test-helper')
 const { ItemType } = require('../../server/utils/constants')
 
@@ -27,7 +23,7 @@ describe('/legal-responsibility route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/legal-responsibility.route.test.js
+++ b/test/routes/legal-responsibility.route.test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 const TestHelper = require('../utils/test-helper')

--- a/test/routes/legal-responsibility.route.test.js
+++ b/test/routes/legal-responsibility.route.test.js
@@ -1,12 +1,12 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 const { ItemType } = require('../../server/utils/constants')
 
-jest.mock('../../server/services/cookie.service')
-jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 describe('/legal-responsibility route', () => {

--- a/test/routes/legal-responsibility.route.test.js
+++ b/test/routes/legal-responsibility.route.test.js
@@ -1,11 +1,11 @@
 'use strict'
 
+const RedisService = require('../../server/services/redis.service')
+
 const TestHelper = require('../utils/test-helper')
 const { ItemType } = require('../../server/utils/constants')
 
-const RedisService = require('../../server/services/redis.service')
-
-describe.skip('/legal-responsibility route', () => {
+describe('/legal-responsibility route', () => {
   let server
   const url = '/legal-responsibility'
   const nextUrlNoPhotos = '/upload-photo'

--- a/test/routes/legal-responsibility.route.test.js
+++ b/test/routes/legal-responsibility.route.test.js
@@ -5,7 +5,7 @@ const { ItemType } = require('../../server/utils/constants')
 
 const RedisService = require('../../server/services/redis.service')
 
-describe('/legal-responsibility route', () => {
+describe.skip('/legal-responsibility route', () => {
   let server
   const url = '/legal-responsibility'
   const nextUrlNoPhotos = '/upload-photo'

--- a/test/routes/make-payment.route.test.js
+++ b/test/routes/make-payment.route.test.js
@@ -5,6 +5,7 @@ const TestHelper = require('../utils/test-helper')
 jest.mock('randomstring')
 const RandomString = require('randomstring')
 
+jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 jest.mock('../../server/services/payment.service')

--- a/test/routes/make-payment.route.test.js
+++ b/test/routes/make-payment.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../server')
-
 const TestHelper = require('../utils/test-helper')
 
 jest.mock('randomstring')
@@ -23,7 +19,7 @@ describe('/make-payment route', () => {
   const nextUrl = 'THE_NEXT_URL'
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/make-payment.route.test.js
+++ b/test/routes/make-payment.route.test.js
@@ -1,5 +1,7 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
@@ -7,9 +9,6 @@ const TestHelper = require('../utils/test-helper')
 jest.mock('randomstring')
 const RandomString = require('randomstring')
 
-jest.mock('../../server/services/cookie.service')
-
-jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 jest.mock('../../server/services/payment.service')

--- a/test/routes/owner/address-choose.route.test.js
+++ b/test/routes/owner/address-choose.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 const AddressService = require('../../../server/services/address.service')
 const RedisService = require('../../../server/services/redis.service')
@@ -45,7 +41,7 @@ describe('/user-details/owner/address-choose route', () => {
   }
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/owner/address-choose.route.test.js
+++ b/test/routes/owner/address-choose.route.test.js
@@ -2,6 +2,7 @@
 
 const TestHelper = require('../../utils/test-helper')
 const AddressService = require('../../../server/services/address.service')
+jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 
 const { RedisKeys } = require('../../../server/utils/constants')

--- a/test/routes/owner/address-choose.route.test.js
+++ b/test/routes/owner/address-choose.route.test.js
@@ -8,6 +8,8 @@ const TestHelper = require('../../utils/test-helper')
 const AddressService = require('../../../server/services/address.service')
 const RedisService = require('../../../server/services/redis.service')
 
+const { RedisKeys } = require('../../../server/utils/constants')
+
 const {
   singleAddress,
   multipleAddresses
@@ -61,12 +63,16 @@ describe('/user-details/owner/address-choose route', () => {
   describe('GET', () => {
     describe('GET: Owned by applicant', () => {
       beforeEach(async () => {
-        RedisService.get = jest
-          .fn()
-          .mockResolvedValueOnce('Yes')
-          .mockResolvedValueOnce(JSON.stringify(multipleAddresses))
-          .mockResolvedValueOnce(nameOrNumber)
-          .mockResolvedValueOnce(postcode)
+        const mockData = {
+          [RedisKeys.OWNED_BY_APPLICANT]: 'Yes',
+          [RedisKeys.ADDRESS_FIND_RESULTS]: JSON.stringify(multipleAddresses),
+          [RedisKeys.ADDRESS_FIND_NAME_OR_NUMBER]: nameOrNumber,
+          [RedisKeys.ADDRESS_FIND_POSTCODE]: postcode
+        }
+
+        RedisService.get = jest.fn((request, redisKey) => {
+          return mockData[redisKey]
+        })
 
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
@@ -144,12 +150,16 @@ describe('/user-details/owner/address-choose route', () => {
       beforeEach(async () => {
         const nameOrNumber = undefined
 
-        RedisService.get = jest
-          .fn()
-          .mockResolvedValueOnce('Yes')
-          .mockResolvedValueOnce(JSON.stringify(multipleAddresses))
-          .mockResolvedValueOnce(nameOrNumber)
-          .mockResolvedValueOnce(postcode)
+        const mockData = {
+          [RedisKeys.OWNED_BY_APPLICANT]: 'Yes',
+          [RedisKeys.ADDRESS_FIND_RESULTS]: JSON.stringify(multipleAddresses),
+          [RedisKeys.ADDRESS_FIND_NAME_OR_NUMBER]: nameOrNumber,
+          [RedisKeys.ADDRESS_FIND_POSTCODE]: postcode
+        }
+
+        RedisService.get = jest.fn((request, redisKey) => {
+          return mockData[redisKey]
+        })
 
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
@@ -165,12 +175,16 @@ describe('/user-details/owner/address-choose route', () => {
 
     describe('GET: Not owned by applicant', () => {
       beforeEach(async () => {
-        RedisService.get = jest
-          .fn()
-          .mockResolvedValueOnce('No')
-          .mockResolvedValueOnce(JSON.stringify(multipleAddresses))
-          .mockResolvedValueOnce(nameOrNumber)
-          .mockResolvedValueOnce(postcode)
+        const mockData = {
+          [RedisKeys.OWNED_BY_APPLICANT]: 'No',
+          [RedisKeys.ADDRESS_FIND_RESULTS]: JSON.stringify(multipleAddresses),
+          [RedisKeys.ADDRESS_FIND_NAME_OR_NUMBER]: nameOrNumber,
+          [RedisKeys.ADDRESS_FIND_POSTCODE]: postcode
+        }
+
+        RedisService.get = jest.fn((request, redisKey) => {
+          return mockData[redisKey]
+        })
 
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
@@ -248,12 +262,16 @@ describe('/user-details/owner/address-choose route', () => {
       beforeEach(async () => {
         const nameOrNumber = undefined
 
-        RedisService.get = jest
-          .fn()
-          .mockResolvedValueOnce('No')
-          .mockResolvedValueOnce(JSON.stringify(multipleAddresses))
-          .mockResolvedValueOnce(nameOrNumber)
-          .mockResolvedValueOnce(postcode)
+        const mockData = {
+          [RedisKeys.OWNED_BY_APPLICANT]: 'No',
+          [RedisKeys.ADDRESS_FIND_RESULTS]: JSON.stringify(multipleAddresses),
+          [RedisKeys.ADDRESS_FIND_NAME_OR_NUMBER]: nameOrNumber,
+          [RedisKeys.ADDRESS_FIND_POSTCODE]: postcode
+        }
+
+        RedisService.get = jest.fn((request, redisKey) => {
+          return mockData[redisKey]
+        })
 
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
@@ -283,11 +301,19 @@ describe('/user-details/owner/address-choose route', () => {
 
     describe('Success: Owned by applicant', () => {
       beforeEach(() => {
-        RedisService.get = jest.fn().mockResolvedValue('Yes')
+        const mockData = {
+          [RedisKeys.OWNED_BY_APPLICANT]: 'Yes',
+          [RedisKeys.ADDRESS_FIND_RESULTS]: JSON.stringify(multipleAddresses)
+        }
+
+        RedisService.get = jest.fn((request, redisKey) => {
+          return mockData[redisKey]
+        })
       })
 
       it('should store the selected address in Redis and progress to the next route when the user selects an address', async () => {
         AddressService.addressSearch = jest.fn().mockReturnValue(singleAddress)
+
         postOptions.payload = {
           address: singleAddress[0].Address.AddressLine
         }
@@ -376,4 +402,15 @@ describe('/user-details/owner/address-choose route', () => {
 
 const _createMocks = () => {
   TestHelper.createMocks()
+
+  // const mockData = {
+  //   [RedisKeys.OWNED_BY_APPLICANT]: '',
+  //   [RedisKeys.ADDRESS_FIND_RESULTS]: '',
+  //   [RedisKeys.ADDRESS_FIND_NAME_OR_NUMBER]: '',
+  //   [RedisKeys.ADDRESS_FIND_POSTCODE]: ''
+  // }
+
+  // RedisService.get = jest.fn((request, redisKey) => {
+  //   return mockData[redisKey]
+  // })
 }

--- a/test/routes/owner/address-choose.route.test.js
+++ b/test/routes/owner/address-choose.route.test.js
@@ -1,16 +1,12 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
-
-jest.mock('../../../server/services/cookie.service')
-
-jest.mock('../../../server/services/redis.service')
-const RedisService = require('../../../server/services/redis.service')
-
-jest.mock('../../../server/services/address.service')
 const AddressService = require('../../../server/services/address.service')
+const RedisService = require('../../../server/services/redis.service')
 
 const {
   singleAddress,

--- a/test/routes/owner/address-choose.route.test.js
+++ b/test/routes/owner/address-choose.route.test.js
@@ -398,15 +398,4 @@ describe('/user-details/owner/address-choose route', () => {
 
 const _createMocks = () => {
   TestHelper.createMocks()
-
-  // const mockData = {
-  //   [RedisKeys.OWNED_BY_APPLICANT]: '',
-  //   [RedisKeys.ADDRESS_FIND_RESULTS]: '',
-  //   [RedisKeys.ADDRESS_FIND_NAME_OR_NUMBER]: '',
-  //   [RedisKeys.ADDRESS_FIND_POSTCODE]: ''
-  // }
-
-  // RedisService.get = jest.fn((request, redisKey) => {
-  //   return mockData[redisKey]
-  // })
 }

--- a/test/routes/owner/address-confirm.route.test.js
+++ b/test/routes/owner/address-confirm.route.test.js
@@ -2,6 +2,7 @@
 
 const TestHelper = require('../../utils/test-helper')
 const AddressService = require('../../../server/services/address.service')
+jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 
 const { singleAddress } = require('../../mock-data/addresses')

--- a/test/routes/owner/address-confirm.route.test.js
+++ b/test/routes/owner/address-confirm.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 const AddressService = require('../../../server/services/address.service')
 const RedisService = require('../../../server/services/redis.service')
@@ -30,7 +26,7 @@ describe('/user-details/owner/address-confirm route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/owner/address-confirm.route.test.js
+++ b/test/routes/owner/address-confirm.route.test.js
@@ -1,16 +1,12 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
-
-jest.mock('../../../server/services/cookie.service')
-
-jest.mock('../../../server/services/redis.service')
-const RedisService = require('../../../server/services/redis.service')
-
-jest.mock('../../../server/services/address.service')
 const AddressService = require('../../../server/services/address.service')
+const RedisService = require('../../../server/services/redis.service')
 
 const { singleAddress } = require('../../mock-data/addresses')
 

--- a/test/routes/owner/address-enter.route.test.js
+++ b/test/routes/owner/address-enter.route.test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 const TestHelper = require('../../utils/test-helper')
 

--- a/test/routes/owner/address-enter.route.test.js
+++ b/test/routes/owner/address-enter.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const RedisService = require('../../../server/services/redis.service')
 const TestHelper = require('../../utils/test-helper')
 
@@ -34,7 +30,7 @@ describe('/user-details/owner/address-enter route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/owner/address-enter.route.test.js
+++ b/test/routes/owner/address-enter.route.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
-const TestHelper = require('../../utils/test-helper')
-
-jest.mock('../../../server/services/cookie.service')
-
-jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
+const TestHelper = require('../../utils/test-helper')
 
 const CharacterLimits = require('../../mock-data/character-limits')
 

--- a/test/routes/owner/address-find.route.test.js
+++ b/test/routes/owner/address-find.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const TestHelper = require('../../utils/test-helper')
 const AddressService = require('../../../server/services/address.service')
 const RedisService = require('../../../server/services/redis.service')
@@ -38,7 +34,7 @@ describe('/user-details/owner/address-find route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/owner/address-find.route.test.js
+++ b/test/routes/owner/address-find.route.test.js
@@ -1,16 +1,12 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
 const TestHelper = require('../../utils/test-helper')
-
-jest.mock('../../../server/services/cookie.service')
-
-jest.mock('../../../server/services/redis.service')
-const RedisService = require('../../../server/services/redis.service')
-
-jest.mock('../../../server/services/address.service')
 const AddressService = require('../../../server/services/address.service')
+const RedisService = require('../../../server/services/redis.service')
 
 const {
   singleAddress,

--- a/test/routes/owner/address-find.route.test.js
+++ b/test/routes/owner/address-find.route.test.js
@@ -2,6 +2,7 @@
 
 const TestHelper = require('../../utils/test-helper')
 const AddressService = require('../../../server/services/address.service')
+jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 
 const {

--- a/test/routes/owner/address-international.route.test.js
+++ b/test/routes/owner/address-international.route.test.js
@@ -1,11 +1,6 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const RedisService = require('../../../server/services/redis.service')
-
 const TestHelper = require('../../utils/test-helper')
 const CharacterLimits = require('../../mock-data/character-limits')
 
@@ -25,7 +20,7 @@ describe('/user-details/owner/address-international route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/owner/address-international.route.test.js
+++ b/test/routes/owner/address-international.route.test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 const TestHelper = require('../../utils/test-helper')
 const CharacterLimits = require('../../mock-data/character-limits')

--- a/test/routes/owner/address-international.route.test.js
+++ b/test/routes/owner/address-international.route.test.js
@@ -1,14 +1,12 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
-const TestHelper = require('../../utils/test-helper')
-
-jest.mock('../../../server/services/cookie.service')
-
-jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 
+const TestHelper = require('../../utils/test-helper')
 const CharacterLimits = require('../../mock-data/character-limits')
 
 describe('/user-details/owner/address-international route', () => {

--- a/test/routes/owner/contact-details.route.test.js
+++ b/test/routes/owner/contact-details.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../../server')
-
 const RedisService = require('../../../server/services/redis.service')
 const TestHelper = require('../../utils/test-helper')
 
@@ -28,7 +24,7 @@ describe('user-details/owner/contact-details route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/owner/contact-details.route.test.js
+++ b/test/routes/owner/contact-details.route.test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 const TestHelper = require('../../utils/test-helper')
 

--- a/test/routes/owner/contact-details.route.test.js
+++ b/test/routes/owner/contact-details.route.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../../server')
 
-const TestHelper = require('../../utils/test-helper')
-
-jest.mock('../../../server/services/cookie.service')
-
-jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
+const TestHelper = require('../../utils/test-helper')
 
 const CharacterLimits = require('../../mock-data/character-limits')
 

--- a/test/routes/privacy-notice.route.test.js
+++ b/test/routes/privacy-notice.route.test.js
@@ -1,10 +1,10 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
-
-jest.mock('../../server/services/cookie.service')
 
 describe('/privacy-notice', () => {
   let server

--- a/test/routes/privacy-notice.route.test.js
+++ b/test/routes/privacy-notice.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../server')
-
 const TestHelper = require('../utils/test-helper')
 
 describe('/privacy-notice', () => {
@@ -63,7 +59,7 @@ describe('/privacy-notice', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/remove-document.route.test.js
+++ b/test/routes/remove-document.route.test.js
@@ -1,14 +1,13 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const fs = require('fs')
 
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 
-jest.mock('../../server/services/cookie.service')
-
-jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 describe('/remove-document route', () => {

--- a/test/routes/remove-document.route.test.js
+++ b/test/routes/remove-document.route.test.js
@@ -4,6 +4,7 @@ const fs = require('fs')
 
 const TestHelper = require('../utils/test-helper')
 
+jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 describe('/remove-document route', () => {

--- a/test/routes/remove-document.route.test.js
+++ b/test/routes/remove-document.route.test.js
@@ -1,10 +1,6 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
 const fs = require('fs')
-
-const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 
@@ -18,7 +14,7 @@ describe('/remove-document route', () => {
   const redisKey = 'upload-document'
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/remove-photo.route.test.js
+++ b/test/routes/remove-photo.route.test.js
@@ -1,13 +1,13 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const fs = require('fs')
 
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 
-jest.mock('../../server/services/cookie.service')
-jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 describe('/remove-photo route', () => {

--- a/test/routes/remove-photo.route.test.js
+++ b/test/routes/remove-photo.route.test.js
@@ -4,6 +4,7 @@ const fs = require('fs')
 
 const TestHelper = require('../utils/test-helper')
 
+jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 describe('/remove-photo route', () => {

--- a/test/routes/remove-photo.route.test.js
+++ b/test/routes/remove-photo.route.test.js
@@ -1,10 +1,6 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
 const fs = require('fs')
-
-const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 
@@ -18,7 +14,7 @@ describe('/remove-photo route', () => {
   const redisKey = 'upload-photo'
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/save-record.route.test.js
+++ b/test/routes/save-record.route.test.js
@@ -8,6 +8,7 @@ const {
   RedisKeys
 } = require('../../server/utils/constants')
 
+jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 jest.mock('../../server/services/odata.service')

--- a/test/routes/save-record.route.test.js
+++ b/test/routes/save-record.route.test.js
@@ -1,5 +1,7 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
@@ -10,9 +12,6 @@ const {
   RedisKeys
 } = require('../../server/utils/constants')
 
-jest.mock('../../server/services/cookie.service')
-
-jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 jest.mock('../../server/services/odata.service')

--- a/test/routes/save-record.route.test.js
+++ b/test/routes/save-record.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../server')
-
 const TestHelper = require('../utils/test-helper')
 
 const {
@@ -26,7 +22,7 @@ describe('/save-record route', () => {
   const nextUrl = '/service-complete'
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/service-complete.route.test.js
+++ b/test/routes/service-complete.route.test.js
@@ -1,10 +1,6 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
 const { ItemType, RedisKeys } = require('../../server/utils/constants')
-
-const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 
@@ -39,7 +35,7 @@ describe('/service-complete route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/service-complete.route.test.js
+++ b/test/routes/service-complete.route.test.js
@@ -1,14 +1,13 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const { ItemType, RedisKeys } = require('../../server/utils/constants')
 
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 
-jest.mock('../../server/services/cookie.service')
-
-jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 jest.mock('../../server/services/payment.service')

--- a/test/routes/service-complete.route.test.js
+++ b/test/routes/service-complete.route.test.js
@@ -4,6 +4,7 @@ const { ItemType, RedisKeys } = require('../../server/utils/constants')
 
 const TestHelper = require('../utils/test-helper')
 
+jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 jest.mock('../../server/services/payment.service')

--- a/test/routes/service-status.route.test.js
+++ b/test/routes/service-status.route.test.js
@@ -1,5 +1,7 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')

--- a/test/routes/service-status.route.test.js
+++ b/test/routes/service-status.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../server')
-
 const TestHelper = require('../utils/test-helper')
 
 describe('Enter Permit Number route', () => {
@@ -25,7 +21,7 @@ describe('Enter Permit Number route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/upload-document.route.test.js
+++ b/test/routes/upload-document.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../server')
-
 const TestHelper = require('../utils/test-helper')
 
 const RedisService = require('../../server/services/redis.service')
@@ -30,7 +26,7 @@ describe('/upload-document route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/upload-document.route.test.js
+++ b/test/routes/upload-document.route.test.js
@@ -2,6 +2,7 @@
 
 const TestHelper = require('../utils/test-helper')
 
+jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 describe('/upload-document route', () => {

--- a/test/routes/upload-document.route.test.js
+++ b/test/routes/upload-document.route.test.js
@@ -1,11 +1,11 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 
-jest.mock('../../server/services/cookie.service')
-jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 describe('/upload-document route', () => {

--- a/test/routes/upload-photo.route.test.js
+++ b/test/routes/upload-photo.route.test.js
@@ -2,6 +2,7 @@
 
 const TestHelper = require('../utils/test-helper')
 
+jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 describe('/upload-photo route', () => {

--- a/test/routes/upload-photo.route.test.js
+++ b/test/routes/upload-photo.route.test.js
@@ -1,11 +1,11 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 
-jest.mock('../../server/services/cookie.service')
-jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 describe('/upload-photo route', () => {

--- a/test/routes/upload-photo.route.test.js
+++ b/test/routes/upload-photo.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../server')
-
 const TestHelper = require('../utils/test-helper')
 
 const RedisService = require('../../server/services/redis.service')
@@ -32,7 +28,7 @@ describe('/upload-photo route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/want-to-add-documents.route.test.js
+++ b/test/routes/want-to-add-documents.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../server')
-
 const TestHelper = require('../utils/test-helper')
 
 describe('/want-to-add-documents route', () => {
@@ -24,7 +20,7 @@ describe('/want-to-add-documents route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/want-to-add-documents.route.test.js
+++ b/test/routes/want-to-add-documents.route.test.js
@@ -1,10 +1,10 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
-
-jest.mock('../../server/services/cookie.service')
 
 describe('/want-to-add-documents route', () => {
   let server

--- a/test/routes/what-type-of-item-is-it.route.test.js
+++ b/test/routes/what-type-of-item-is-it.route.test.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const TestHelper = require('../utils/test-helper')
-
 const RedisService = require('../../server/services/redis.service')
 
-describe.skip('/what-type-of-item-is-it route', () => {
+const TestHelper = require('../utils/test-helper')
+
+describe('/what-type-of-item-is-it route', () => {
   let server
   const url = '/what-type-of-item-is-it'
   const nextUrl = '/can-continue'

--- a/test/routes/what-type-of-item-is-it.route.test.js
+++ b/test/routes/what-type-of-item-is-it.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../server')
-
 const TestHelper = require('../utils/test-helper')
 
 const RedisService = require('../../server/services/redis.service')
@@ -29,7 +25,7 @@ describe('/what-type-of-item-is-it route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/what-type-of-item-is-it.route.test.js
+++ b/test/routes/what-type-of-item-is-it.route.test.js
@@ -1,11 +1,11 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 
-jest.mock('../../server/services/cookie.service')
-jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 describe('/what-type-of-item-is-it route', () => {

--- a/test/routes/what-type-of-item-is-it.route.test.js
+++ b/test/routes/what-type-of-item-is-it.route.test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 const TestHelper = require('../utils/test-helper')

--- a/test/routes/what-type-of-item-is-it.route.test.js
+++ b/test/routes/what-type-of-item-is-it.route.test.js
@@ -4,7 +4,7 @@ const TestHelper = require('../utils/test-helper')
 
 const RedisService = require('../../server/services/redis.service')
 
-describe('/what-type-of-item-is-it route', () => {
+describe.skip('/what-type-of-item-is-it route', () => {
   let server
   const url = '/what-type-of-item-is-it'
   const nextUrl = '/can-continue'

--- a/test/routes/who-owns-the-item.route.test.js
+++ b/test/routes/who-owns-the-item.route.test.js
@@ -1,11 +1,11 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 
-jest.mock('../../server/services/cookie.service')
-jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 describe('/who-owns-the-item route', () => {

--- a/test/routes/who-owns-the-item.route.test.js
+++ b/test/routes/who-owns-the-item.route.test.js
@@ -2,6 +2,7 @@
 
 const TestHelper = require('../utils/test-helper')
 
+jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 describe('/who-owns-the-item route', () => {

--- a/test/routes/who-owns-the-item.route.test.js
+++ b/test/routes/who-owns-the-item.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../server')
-
 const TestHelper = require('../utils/test-helper')
 
 const RedisService = require('../../server/services/redis.service')
@@ -22,7 +18,7 @@ describe('/who-owns-the-item route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/why-is-item-rmi.route.test.js
+++ b/test/routes/why-is-item-rmi.route.test.js
@@ -1,9 +1,5 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
-const createServer = require('../../server')
-
 const TestHelper = require('../utils/test-helper')
 
 const RedisService = require('../../server/services/redis.service')
@@ -40,7 +36,7 @@ describe('/why-is-item-rmi route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(() => {

--- a/test/routes/why-is-item-rmi.route.test.js
+++ b/test/routes/why-is-item-rmi.route.test.js
@@ -2,6 +2,7 @@
 
 const TestHelper = require('../utils/test-helper')
 
+jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 const CharacterLimits = require('../mock-data/character-limits')

--- a/test/routes/why-is-item-rmi.route.test.js
+++ b/test/routes/why-is-item-rmi.route.test.js
@@ -1,11 +1,11 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 
-jest.mock('../../server/services/cookie.service')
-jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 const CharacterLimits = require('../mock-data/character-limits')

--- a/test/routes/your-documents.route.test.js
+++ b/test/routes/your-documents.route.test.js
@@ -1,14 +1,13 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const fs = require('fs')
 
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 
-jest.mock('../../server/services/cookie.service')
-
-jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 describe('/your-documents route', () => {

--- a/test/routes/your-documents.route.test.js
+++ b/test/routes/your-documents.route.test.js
@@ -1,10 +1,6 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
 const fs = require('fs')
-
-const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 
@@ -26,7 +22,7 @@ describe('/your-documents route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/your-documents.route.test.js
+++ b/test/routes/your-documents.route.test.js
@@ -4,6 +4,7 @@ const fs = require('fs')
 
 const TestHelper = require('../utils/test-helper')
 
+jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 describe('/your-documents route', () => {

--- a/test/routes/your-photos.route.test.js
+++ b/test/routes/your-photos.route.test.js
@@ -1,10 +1,6 @@
 'use strict'
 
-jest.mock('@defra/hapi-gapi')
-
 const fs = require('fs')
-
-const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 
@@ -26,7 +22,7 @@ describe('/your-photos route', () => {
   let document
 
   beforeAll(async () => {
-    server = await createServer()
+    server = await TestHelper.createServer()
   })
 
   afterAll(async () => {

--- a/test/routes/your-photos.route.test.js
+++ b/test/routes/your-photos.route.test.js
@@ -1,14 +1,13 @@
 'use strict'
 
+jest.mock('@defra/hapi-gapi')
+
 const fs = require('fs')
 
 const createServer = require('../../server')
 
 const TestHelper = require('../utils/test-helper')
 
-jest.mock('../../server/services/cookie.service')
-
-jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 describe('/your-photos route', () => {

--- a/test/routes/your-photos.route.test.js
+++ b/test/routes/your-photos.route.test.js
@@ -4,6 +4,7 @@ const fs = require('fs')
 
 const TestHelper = require('../utils/test-helper')
 
+jest.mock('../../server/services/redis.service')
 const RedisService = require('../../server/services/redis.service')
 
 describe('/your-photos route', () => {

--- a/test/utils/test-helper.js
+++ b/test/utils/test-helper.js
@@ -7,6 +7,8 @@ const CookieService = require('../../server/services/cookie.service')
 const RedisService = require('../../server/services/redis.service')
 const AnalyticsService = require('../../server/services/analytics.service')
 
+const createServer = require('../../server')
+
 const elementIds = {
   backLink: 'back-link'
 }
@@ -27,6 +29,12 @@ module.exports = class TestHelper {
 
     jest.mock('../../server/services/analytics.service')
     AnalyticsService.sendEvent = jest.fn()
+  }
+
+  static createServer () {
+    jest.mock('@defra/hapi-gapi')
+
+    return createServer()
   }
 
   /**

--- a/test/utils/test-helper.js
+++ b/test/utils/test-helper.js
@@ -19,6 +19,9 @@ module.exports = class TestHelper {
   static createMocks () {
     jest.mock('../../server/services/address.service')
 
+    jest.mock('../../server/services/analytics.service')
+    AnalyticsService.sendEvent = jest.fn()
+
     jest.mock('../../server/services/cookie.service')
     CookieService.checkSessionCookie = jest
       .fn()
@@ -26,9 +29,6 @@ module.exports = class TestHelper {
 
     jest.mock('../../server/services/redis.service')
     RedisService.set = jest.fn()
-
-    jest.mock('../../server/services/analytics.service')
-    AnalyticsService.sendEvent = jest.fn()
   }
 
   static createServer () {

--- a/test/utils/test-helper.js
+++ b/test/utils/test-helper.js
@@ -17,9 +17,6 @@ const DEFAULT_VALIDATION_SUMMARY_HEADING = 'There is a problem'
 
 module.exports = class TestHelper {
   static createMocks () {
-    jest.mock('../../server/services/redis.service')
-    RedisService.set = jest.fn()
-
     jest.mock('../../server/services/address.service')
 
     jest.mock('../../server/services/analytics.service')
@@ -30,8 +27,7 @@ module.exports = class TestHelper {
       .fn()
       .mockReturnValue('THE_SESSION_COOKIE')
 
-    // jest.mock('../../server/services/redis.service')
-    // RedisService.set = jest.fn()
+    RedisService.set = jest.fn()
   }
 
   static createServer () {

--- a/test/utils/test-helper.js
+++ b/test/utils/test-helper.js
@@ -5,6 +5,7 @@ const { JSDOM } = jsdom
 
 const CookieService = require('../../server/services/cookie.service')
 const RedisService = require('../../server/services/redis.service')
+const AnalyticsService = require('../../server/services/analytics.service')
 
 const elementIds = {
   backLink: 'back-link'
@@ -14,11 +15,18 @@ const DEFAULT_VALIDATION_SUMMARY_HEADING = 'There is a problem'
 
 module.exports = class TestHelper {
   static createMocks () {
+    jest.mock('../../server/services/address.service')
+
+    jest.mock('../../server/services/cookie.service')
     CookieService.checkSessionCookie = jest
       .fn()
       .mockReturnValue('THE_SESSION_COOKIE')
 
+    jest.mock('../../server/services/redis.service')
     RedisService.set = jest.fn()
+
+    jest.mock('../../server/services/analytics.service')
+    AnalyticsService.sendEvent = jest.fn()
   }
 
   /**

--- a/test/utils/test-helper.js
+++ b/test/utils/test-helper.js
@@ -17,6 +17,9 @@ const DEFAULT_VALIDATION_SUMMARY_HEADING = 'There is a problem'
 
 module.exports = class TestHelper {
   static createMocks () {
+    jest.mock('../../server/services/redis.service')
+    RedisService.set = jest.fn()
+
     jest.mock('../../server/services/address.service')
 
     jest.mock('../../server/services/analytics.service')
@@ -27,8 +30,8 @@ module.exports = class TestHelper {
       .fn()
       .mockReturnValue('THE_SESSION_COOKIE')
 
-    jest.mock('../../server/services/redis.service')
-    RedisService.set = jest.fn()
+    // jest.mock('../../server/services/redis.service')
+    // RedisService.set = jest.fn()
   }
 
   static createServer () {


### PR DESCRIPTION
IVORY-445: Unit tests don't work without internet access

Fixed problem of unit tests not running when not connected to the internet due to a recently added Google Analytics plugin. A new AnalyticsService has been added to allow the call to the plugin to be stubbed out.

Refactored the _getContext methods in route files so that this is only called once per GET or POST.

Added new TestHelper.createServer() method that now mocks out the Google Analytics library('@defra/hapi-gapi') before creating the test server, to save having to do this in all unit test files.