### PR TITLE
Fixes for error when uploading large documents and images

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/utils/config.js
+++ b/server/utils/config.js
@@ -23,7 +23,7 @@ const schema = joi.object().keys({
     .default('Declare elephant ivory you intend to sell or hire out'),
   logLevel: joi.string().default('warn'),
   requestTimeout: joi.number(),
-  maximumFileSize: joi.number().default(30),
+  maximumFileSize: joi.number().default(10),
   redisHost: joi.string(),
   redisPort: joi.number(),
   redisPassword: joi.string(),

--- a/server/utils/upload.js
+++ b/server/utils/upload.js
@@ -26,7 +26,7 @@ const checkForFileSizeError = async (request, redisKey) => {
   if ((await RedisService.get(request, redisKey)) === 'true') {
     errors.push({
       name: 'files',
-      text: `The file must be smaller than ${config.maximumFileSize}mb`
+      text: `The file must be smaller than ${config.maximumFileSize}MB`
     })
   }
 

--- a/server/views/upload-document.html
+++ b/server/views/upload-document.html
@@ -31,7 +31,7 @@
 
         <ul id="helpText3" class="govuk-list govuk-list--bullet">
           <li>a PDF or Microsoft Word document</li>
-          <li>smaller than {{ maximumFileSize }}mb</li>
+          <li>smaller than {{ maximumFileSize }}MB</li>
         </ul>
 
       {{ govukFileUpload({

--- a/server/views/upload-photo.html
+++ b/server/views/upload-photo.html
@@ -34,7 +34,7 @@
 
         <ul id="helpText6" class="govuk-list govuk-list--bullet">
           <li>in JPG or PNG format</li>
-          <li>smaller than {{ maximumFileSize }}mb</li>
+          <li>smaller than {{ maximumFileSize }}MB</li>
         </ul>
 
       {{ govukFileUpload({

--- a/test/routes/upload-document.route.test.js
+++ b/test/routes/upload-document.route.test.js
@@ -118,7 +118,7 @@ describe('/upload-document route', () => {
           `#${elementIds.helpText3} > li:nth-child(2)`
         )
         expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual('smaller than 30mb')
+        expect(TestHelper.getTextContent(element)).toEqual('smaller than 10MB')
       })
 
       it('should have the file chooser', () => {

--- a/test/routes/upload-photo.route.test.js
+++ b/test/routes/upload-photo.route.test.js
@@ -124,7 +124,7 @@ describe('/upload-photo route', () => {
           `#${elementIds.helpText6} > li:nth-child(2)`
         )
         expect(element).toBeTruthy()
-        expect(TestHelper.getTextContent(element)).toEqual('smaller than 30mb')
+        expect(TestHelper.getTextContent(element)).toEqual('smaller than 10MB')
       })
 
       it('should have the file chooser', () => {


### PR DESCRIPTION
IVORY-419: Error when uploading large documents and images

Initially, documents and images of up to 30MB were allowed. However, this caused a problem when the application was deployed into the Azure infrastructure, due to timeout issues. In order to solve this issue, it has been agreed that the file size limit can be reduced to 10MB.