### PR TITLE
Refactor/fix redis cache problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/routes/check-your-answers.route.js
+++ b/server/routes/check-your-answers.route.js
@@ -124,12 +124,17 @@ module.exports = [
 ]
 
 const _getDocumentSummary = async request => {
-  const uploadDocuments = JSON.parse(
-    await RedisService.get(request, RedisKeys.UPLOAD_DOCUMENT)
-  ) || {
-    files: [],
-    fileData: [],
-    fileSizes: []
+  let uploadDocuments = await RedisService.get(
+    request,
+    RedisKeys.UPLOAD_DOCUMENT
+  )
+
+  if (!uploadDocuments) {
+    uploadDocuments = {
+      files: [],
+      fileData: [],
+      fileSizes: []
+    }
   }
 
   const documentRows = uploadDocuments.files.map((file, index) => {
@@ -154,8 +159,7 @@ const _getExemptionReasonSummary = async (
   isSection2,
   isMesuem
 ) => {
-  const ivoryAge =
-    JSON.parse(await RedisService.get(request, RedisKeys.IVORY_AGE)) || {}
+  const ivoryAge = await RedisService.get(request, RedisKeys.IVORY_AGE)
 
   if (ivoryAge.otherReason) {
     ivoryAge.ivoryAge.pop()
@@ -172,13 +176,16 @@ const _getExemptionReasonSummary = async (
   const ivoryAgeList = `<ul>${ivoryAgeFormatted.join('')}</ul>`
 
   const whyRmi = await RedisService.get(request, RedisKeys.WHY_IS_ITEM_RMI)
-  const ivoryVolume = JSON.parse(
-    (await RedisService.get(request, RedisKeys.IVORY_VOLUME)) || '{}'
-  )
-  const ivoryVolumeFormatted =
-    ivoryVolume.ivoryVolume === 'Other reason'
-      ? ivoryVolume.otherReason
-      : ivoryVolume.ivoryVolume
+  const ivoryVolume = await RedisService.get(request, RedisKeys.IVORY_VOLUME)
+
+  let ivoryVolumeFormatted
+
+  if (ivoryVolume) {
+    ivoryVolumeFormatted =
+      ivoryVolume.ivoryVolume === 'Other reason'
+        ? ivoryVolume.otherReason
+        : ivoryVolume.ivoryVolume
+  }
 
   let ivoryIntegral = await RedisService.get(request, RedisKeys.IVORY_INTEGRAL)
   if (ivoryIntegral === 'Both of the above') {
@@ -252,9 +259,10 @@ const _getExemptionTypeSummary = exemptionType => [
 ]
 
 const _getItemDescriptionSummary = async (request, isSection2) => {
-  const itemDescription =
-    JSON.parse(await RedisService.get(request, RedisKeys.DESCRIBE_THE_ITEM)) ||
-    {}
+  const itemDescription = await RedisService.get(
+    request,
+    RedisKeys.DESCRIBE_THE_ITEM
+  )
 
   const itemDescriptionSummary = [
     _getSummaryListRow(
@@ -306,18 +314,19 @@ const _getOwnerSummary = async (request, ownedByApplicant) => {
   )
 
   const capacity = _formatCapacity(
-    JSON.parse(await RedisService.get(request, RedisKeys.WHAT_CAPACITY)) || {}
+    await RedisService.get(request, RedisKeys.WHAT_CAPACITY)
   )
 
-  const ownerContactDetails = JSON.parse(
-    (await RedisService.get(request, RedisKeys.OWNER_CONTACT_DETAILS)) || '{}'
+  const ownerContactDetails = await RedisService.get(
+    request,
+    RedisKeys.OWNER_CONTACT_DETAILS
   )
 
   const ownerAddress = await RedisService.get(request, RedisKeys.OWNER_ADDRESS)
 
-  const applicantContactDetails = JSON.parse(
-    (await RedisService.get(request, RedisKeys.APPLICANT_CONTACT_DETAILS)) ||
-      '{}'
+  const applicantContactDetails = await RedisService.get(
+    request,
+    RedisKeys.APPLICANT_CONTACT_DETAILS
   )
 
   const applicantAddress = await RedisService.get(
@@ -689,14 +698,16 @@ const _getOwnerSummaryApplicantDefault = async (
 }
 
 const _getPhotoSummary = async request => {
-  const uploadPhotos = JSON.parse(
-    await RedisService.get(request, RedisKeys.UPLOAD_PHOTO)
-  ) || {
-    files: [],
-    fileData: [],
-    fileSizes: [],
-    thumbnails: [],
-    thumbnailData: []
+  let uploadPhotos = await RedisService.get(request, RedisKeys.UPLOAD_PHOTO)
+
+  if (!uploadPhotos) {
+    uploadPhotos = {
+      files: [],
+      fileData: [],
+      fileSizes: [],
+      thumbnails: [],
+      thumbnailData: []
+    }
   }
 
   const imageRows = uploadPhotos.thumbnails.map((file, index) => {

--- a/server/routes/common/address-choose.route.js
+++ b/server/routes/common/address-choose.route.js
@@ -108,8 +108,9 @@ const _getContext = async (request, addressType) => {
     RedisKeys.OWNED_BY_APPLICANT
   )
 
-  const addresses = JSON.parse(
-    await RedisService.get(request, RedisKeys.ADDRESS_FIND_RESULTS)
+  const addresses = await RedisService.get(
+    request,
+    RedisKeys.ADDRESS_FIND_RESULTS
   )
 
   const items = addresses.map(item => {

--- a/server/routes/common/address-confirm.route.js
+++ b/server/routes/common/address-confirm.route.js
@@ -104,8 +104,9 @@ const _getContext = async (request, addressType) => {
     context = _getContextForApplicantAddressType()
   }
 
-  const addresses = JSON.parse(
-    await RedisService.get(request, RedisKeys.ADDRESS_FIND_RESULTS)
+  const addresses = await RedisService.get(
+    request,
+    RedisKeys.ADDRESS_FIND_RESULTS
   )
 
   context.address = addresses[0].Address

--- a/server/routes/common/address-enter.route.js
+++ b/server/routes/common/address-enter.route.js
@@ -109,8 +109,9 @@ const _getContext = async (request, addressType, isGet = true) => {
     (await RedisService.get(request, RedisKeys.OWNED_BY_APPLICANT)) ===
     Options.YES
 
-  const addresses = JSON.parse(
-    await RedisService.get(request, RedisKeys.ADDRESS_FIND_RESULTS)
+  const addresses = await RedisService.get(
+    request,
+    RedisKeys.ADDRESS_FIND_RESULTS
   )
 
   const resultSize = addresses.length

--- a/server/routes/describe-the-item.route.js
+++ b/server/routes/describe-the-item.route.js
@@ -89,8 +89,9 @@ const _getContext = async (request, itemType) => {
     isSection2: itemType === ItemType.HIGH_VALUE
   }
 
-  const itemDescription = JSON.parse(
-    await RedisService.get(request, RedisKeys.DESCRIBE_THE_ITEM)
+  const itemDescription = await RedisService.get(
+    request,
+    RedisKeys.DESCRIBE_THE_ITEM
   )
 
   _addRedisDataToContext(context, itemDescription)

--- a/server/routes/ivory-age.route.js
+++ b/server/routes/ivory-age.route.js
@@ -79,7 +79,7 @@ const _getContext = async request => {
   if (request.payload) {
     payload = request.payload
   } else {
-    payload = JSON.parse(await RedisService.get(request, RedisKeys.IVORY_AGE))
+    payload = await RedisService.get(request, RedisKeys.IVORY_AGE)
   }
 
   const itemType = await _getItemType(request)

--- a/server/routes/ivory-volume.route.js
+++ b/server/routes/ivory-volume.route.js
@@ -89,9 +89,7 @@ const _getContext = async request => {
   if (request.payload) {
     payload = request.payload
   } else {
-    payload = JSON.parse(
-      await RedisService.get(request, RedisKeys.IVORY_VOLUME)
-    )
+    payload = await RedisService.get(request, RedisKeys.IVORY_VOLUME)
   }
 
   const ivoryVolume = payload ? payload.ivoryVolume : null

--- a/server/routes/legal-responsibility.route.js
+++ b/server/routes/legal-responsibility.route.js
@@ -29,9 +29,7 @@ const handlers = {
       label: context.pageTitle
     })
 
-    const uploadData = JSON.parse(
-      await RedisService.get(request, RedisKeys.UPLOAD_PHOTO)
-    )
+    const uploadData = await RedisService.get(request, RedisKeys.UPLOAD_PHOTO)
 
     return uploadData && uploadData.files && uploadData.files.length
       ? h.redirect(Paths.YOUR_PHOTOS)

--- a/server/routes/make-payment.route.js
+++ b/server/routes/make-payment.route.js
@@ -30,8 +30,9 @@ const handlers = {
       ? 'Ivory Act application for a certificate'
       : 'Ivory Act self-assessment'
 
-    const applicantContactDetails = JSON.parse(
-      await RedisService.get(request, RedisKeys.APPLICANT_CONTACT_DETAILS)
+    const applicantContactDetails = await RedisService.get(
+      request,
+      RedisKeys.APPLICANT_CONTACT_DETAILS
     )
 
     const response = await PaymentService.makePayment(

--- a/server/routes/remove-document.route.js
+++ b/server/routes/remove-document.route.js
@@ -10,8 +10,9 @@ const { Paths, RedisKeys } = require('../utils/constants')
 
 const handlers = {
   get: async (request, h) => {
-    const uploadData = JSON.parse(
-      await RedisService.get(request, RedisKeys.UPLOAD_DOCUMENT)
+    const uploadData = await RedisService.get(
+      request,
+      RedisKeys.UPLOAD_DOCUMENT
     )
 
     for (const array in uploadData) {

--- a/server/routes/remove-photo.route.js
+++ b/server/routes/remove-photo.route.js
@@ -10,9 +10,7 @@ const { Paths, RedisKeys } = require('../utils/constants')
 
 const handlers = {
   get: async (request, h) => {
-    const uploadData = JSON.parse(
-      await RedisService.get(request, RedisKeys.UPLOAD_PHOTO)
-    )
+    const uploadData = await RedisService.get(request, RedisKeys.UPLOAD_PHOTO)
 
     for (const array in uploadData) {
       uploadData[array].splice(

--- a/server/routes/save-record.route.js
+++ b/server/routes/save-record.route.js
@@ -52,8 +52,9 @@ const handlers = {
 }
 
 const _createRecord = async (request, itemType, isSection2) => {
-  const itemDescription = JSON.parse(
-    await RedisService.get(request, RedisKeys.DESCRIBE_THE_ITEM)
+  const itemDescription = await RedisService.get(
+    request,
+    RedisKeys.DESCRIBE_THE_ITEM
   )
 
   const body = isSection2
@@ -73,8 +74,9 @@ const _updateRecord = async (request, entity, isSection2) => {
 }
 
 const _updateRecordAttachments = async (request, entity) => {
-  const supportingInformation = JSON.parse(
-    await RedisService.get(request, RedisKeys.UPLOAD_DOCUMENT)
+  const supportingInformation = await RedisService.get(
+    request,
+    RedisKeys.UPLOAD_DOCUMENT
   )
 
   if (supportingInformation) {
@@ -117,14 +119,7 @@ const _createSection2Body = async (request, itemType, itemDescription) => {
 }
 
 const _createSection10Body = async (request, itemType, itemDescription) => {
-  const ivoryVolumeStringified = await RedisService.get(
-    request,
-    RedisKeys.IVORY_VOLUME
-  )
-
-  const ivoryVolume = ivoryVolumeStringified
-    ? JSON.parse(ivoryVolumeStringified)
-    : null
+  const ivoryVolume = await RedisService.get(request, RedisKeys.IVORY_VOLUME)
 
   return {
     ...(await _getCommonFields(request, itemDescription)),
@@ -133,12 +128,10 @@ const _createSection10Body = async (request, itemType, itemDescription) => {
       RedisKeys.SUBMISSION_REFERENCE
     ),
     [DataVerseFieldName.EXEMPTION_TYPE]: _getExemptionCategoryCode(itemType),
-    [DataVerseFieldName.WHY_IVORY_EXEMPT]: ivoryVolume
+    [DataVerseFieldName.WHY_IVORY_EXEMPT]: ivoryVolume.ivoryVolume
       ? _getIvoryVolumeReasonCode(ivoryVolume.ivoryVolume)
       : null,
-    [DataVerseFieldName.WHY_IVORY_EXEMPT_OTHER_REASON]: ivoryVolume
-      ? ivoryVolume.otherReason
-      : null,
+    [DataVerseFieldName.WHY_IVORY_EXEMPT_OTHER_REASON]: ivoryVolume.otherReason,
     [DataVerseFieldName.WHY_IVORY_INTEGRAL]:
       itemType === ItemType.TEN_PERCENT
         ? _getIvoryIntegralReasonCode(
@@ -151,9 +144,7 @@ const _createSection10Body = async (request, itemType, itemDescription) => {
 const _getCommonFields = async (request, itemDescription) => {
   const now = new Date().toISOString()
 
-  const ivoryAge = JSON.parse(
-    await RedisService.get(request, RedisKeys.IVORY_AGE)
-  )
+  const ivoryAge = await RedisService.get(request, RedisKeys.IVORY_AGE)
 
   return {
     createdon: now,
@@ -189,23 +180,15 @@ const _addOwnerAndApplicantDetails = async request => {
     (await RedisService.get(request, RedisKeys.OWNED_BY_APPLICANT)) ===
     Options.YES
 
-  let ownerContactDetails = await RedisService.get(
+  const ownerContactDetails = await RedisService.get(
     request,
     RedisKeys.OWNER_CONTACT_DETAILS
   )
 
-  if (ownerContactDetails) {
-    ownerContactDetails = JSON.parse(ownerContactDetails)
-  }
-
-  let applicantContactDetails = await RedisService.get(
+  const applicantContactDetails = await RedisService.get(
     request,
     RedisKeys.APPLICANT_CONTACT_DETAILS
   )
-
-  if (applicantContactDetails) {
-    applicantContactDetails = JSON.parse(applicantContactDetails)
-  }
 
   const ownerAddress = await RedisService.get(request, RedisKeys.OWNER_ADDRESS)
   const ownerAddressInternational =
@@ -226,8 +209,10 @@ const _addOwnerAndApplicantDetails = async request => {
     RedisKeys.SELLING_ON_BEHALF_OF
   )
 
-  const capacityResponse =
-    JSON.parse(await RedisService.get(request, RedisKeys.WHAT_CAPACITY)) || {}
+  const capacityResponse = await RedisService.get(
+    request,
+    RedisKeys.WHAT_CAPACITY
+  )
 
   const capacity = capacityResponse ? capacityResponse.whatCapacity : null
   const capacityOther = capacityResponse ? capacityResponse.otherCapacity : null
@@ -303,9 +288,7 @@ const _getPostcode = (address, isInternationalAddress) => {
 }
 
 const _addInitialPhoto = async request => {
-  const photos = JSON.parse(
-    await RedisService.get(request, RedisKeys.UPLOAD_PHOTO)
-  )
+  const photos = await RedisService.get(request, RedisKeys.UPLOAD_PHOTO)
 
   return {
     [DataVerseFieldName.PHOTO_1]:
@@ -314,9 +297,7 @@ const _addInitialPhoto = async request => {
 }
 
 const _addAdditionalPhotos = async request => {
-  const photos = JSON.parse(
-    await RedisService.get(request, RedisKeys.UPLOAD_PHOTO)
-  )
+  const photos = await RedisService.get(request, RedisKeys.UPLOAD_PHOTO)
 
   const additionalPhotos = {}
   if (photos && photos.files && photos.files.length > 1) {

--- a/server/routes/service-complete.route.js
+++ b/server/routes/service-complete.route.js
@@ -77,13 +77,14 @@ const _getContext = async (request, isSection2, ownedByApplicant) => {
     RedisKeys.SUBMISSION_REFERENCE
   )
 
-  const ownerContactDetails = JSON.parse(
-    (await RedisService.get(request, RedisKeys.OWNER_CONTACT_DETAILS)) || '{}'
+  const ownerContactDetails = await RedisService.get(
+    request,
+    RedisKeys.OWNER_CONTACT_DETAILS
   )
 
-  const applicantContactDetails = JSON.parse(
-    (await RedisService.get(request, RedisKeys.APPLICANT_CONTACT_DETAILS)) ||
-      '{}'
+  const applicantContactDetails = await RedisService.get(
+    request,
+    RedisKeys.APPLICANT_CONTACT_DETAILS
   )
 
   return {

--- a/server/routes/upload-document.route.js
+++ b/server/routes/upload-document.route.js
@@ -20,8 +20,9 @@ const handlers = {
   get: async (request, h) => {
     const context = await _getContext(request)
 
-    const uploadData = JSON.parse(
-      await RedisService.get(request, RedisKeys.UPLOAD_DOCUMENT)
+    const uploadData = await RedisService.get(
+      request,
+      RedisKeys.UPLOAD_DOCUMENT
     )
 
     if (
@@ -68,7 +69,11 @@ const handlers = {
     }
 
     try {
-      const isInfected = await AntimalwareService.scan(request, payload.files.path, filename)
+      const isInfected = await AntimalwareService.scan(
+        request,
+        payload.files.path,
+        filename
+      )
 
       if (!isInfected) {
         const file = await fs.promises.readFile(payload.files.path)
@@ -132,12 +137,14 @@ const handlers = {
 }
 
 const _getContext = async request => {
-  const uploadData = JSON.parse(
-    await RedisService.get(request, RedisKeys.UPLOAD_DOCUMENT)
-  ) || {
-    files: [],
-    fileData: [],
-    fileSizes: []
+  let uploadData = await RedisService.get(request, RedisKeys.UPLOAD_DOCUMENT)
+
+  if (!uploadData) {
+    uploadData = {
+      files: [],
+      fileData: [],
+      fileSizes: []
+    }
   }
 
   const hideHelpText = uploadData.files.length

--- a/server/routes/upload-photo.route.js
+++ b/server/routes/upload-photo.route.js
@@ -23,9 +23,7 @@ const handlers = {
   get: async (request, h) => {
     const context = await _getContext(request)
 
-    const uploadData = JSON.parse(
-      await RedisService.get(request, RedisKeys.UPLOAD_PHOTO)
-    )
+    const uploadData = await RedisService.get(request, RedisKeys.UPLOAD_PHOTO)
 
     if (
       uploadData &&
@@ -71,7 +69,11 @@ const handlers = {
     }
 
     try {
-      const isInfected = await AntimalwareService.scan(request, payload.files.path, filename)
+      const isInfected = await AntimalwareService.scan(
+        request,
+        payload.files.path,
+        filename
+      )
 
       if (!isInfected) {
         const extension = path.extname(filename)
@@ -155,14 +157,16 @@ const handlers = {
 }
 
 const _getContext = async request => {
-  const uploadData = JSON.parse(
-    await RedisService.get(request, RedisKeys.UPLOAD_PHOTO)
-  ) || {
-    files: [],
-    fileData: [],
-    fileSizes: [],
-    thumbnails: [],
-    thumbnailData: []
+  let uploadData = await RedisService.get(request, RedisKeys.UPLOAD_PHOTO)
+
+  if (!uploadData) {
+    uploadData = {
+      files: [],
+      fileData: [],
+      fileSizes: [],
+      thumbnails: [],
+      thumbnailData: []
+    }
   }
 
   const hideHelpText = uploadData.files.length

--- a/server/routes/user-details/applicant/contact-details.route.js
+++ b/server/routes/user-details/applicant/contact-details.route.js
@@ -79,14 +79,10 @@ const _getContext = async request => {
     (await RedisService.get(request, RedisKeys.WORK_FOR_A_BUSINESS)) ===
     Options.YES
 
-  let contactDetails = await RedisService.get(
+  const contactDetails = await RedisService.get(
     request,
     RedisKeys.APPLICANT_CONTACT_DETAILS
   )
-
-  if (contactDetails) {
-    contactDetails = JSON.parse(contactDetails)
-  }
 
   const context = { pageTitle, workForABusiness, ...contactDetails }
 

--- a/server/routes/user-details/owner/contact-details.route.js
+++ b/server/routes/user-details/owner/contact-details.route.js
@@ -79,21 +79,15 @@ const _getContext = async request => {
   if (request.payload) {
     payload = request.payload
   } else {
-    payload = JSON.parse(
-      await RedisService.get(request, RedisKeys.OWNER_CONTACT_DETAILS)
-    )
+    await RedisService.get(request, RedisKeys.OWNER_CONTACT_DETAILS)
   }
 
   const hasEmailAddress = payload ? payload.hasEmailAddress : null
 
-  let contactDetails = await RedisService.get(
+  const contactDetails = await RedisService.get(
     request,
     RedisKeys.OWNER_CONTACT_DETAILS
   )
-
-  if (contactDetails) {
-    contactDetails = JSON.parse(contactDetails)
-  }
 
   const sellingOnBehalfOf = await RedisService.get(
     request,

--- a/server/routes/what-capacity.route.js
+++ b/server/routes/what-capacity.route.js
@@ -74,8 +74,7 @@ const _getContext = async request => {
   if (request.payload) {
     payload = request.payload
   } else {
-    payload =
-      JSON.parse(await RedisService.get(request, RedisKeys.WHAT_CAPACITY)) || {}
+    payload = await RedisService.get(request, RedisKeys.WHAT_CAPACITY)
   }
 
   const whatCapacity = payload ? payload.whatCapacity : null

--- a/server/routes/why-is-item-rmi.route.js
+++ b/server/routes/why-is-item-rmi.route.js
@@ -57,6 +57,8 @@ const handlers = {
 const _getContext = async request => {
   const whyRmi = await RedisService.get(request, RedisKeys.WHY_IS_ITEM_RMI)
 
+  console.log('whyRmi:', whyRmi)
+
   return {
     pageTitle:
       'Why is your item of outstandingly high artistic, cultural or historical value?',

--- a/server/routes/why-is-item-rmi.route.js
+++ b/server/routes/why-is-item-rmi.route.js
@@ -57,8 +57,6 @@ const handlers = {
 const _getContext = async request => {
   const whyRmi = await RedisService.get(request, RedisKeys.WHY_IS_ITEM_RMI)
 
-  console.log('whyRmi:', whyRmi)
-
   return {
     pageTitle:
       'Why is your item of outstandingly high artistic, cultural or historical value?',

--- a/server/routes/your-documents.route.js
+++ b/server/routes/your-documents.route.js
@@ -34,12 +34,14 @@ const handlers = {
 }
 
 const _getContext = async request => {
-  const uploadData = JSON.parse(
-    await RedisService.get(request, RedisKeys.UPLOAD_DOCUMENT)
-  ) || {
-    files: [],
-    fileData: [],
-    fileSizes: []
+  let uploadData = await RedisService.get(request, RedisKeys.UPLOAD_DOCUMENT)
+
+  if (!uploadData) {
+    uploadData = {
+      files: [],
+      fileData: [],
+      fileSizes: []
+    }
   }
 
   const rows = uploadData.files.map((file, index) => {

--- a/server/routes/your-photos.route.js
+++ b/server/routes/your-photos.route.js
@@ -43,14 +43,16 @@ const handlers = {
 }
 
 const _getContext = async request => {
-  const uploadData = JSON.parse(
-    await RedisService.get(request, RedisKeys.UPLOAD_PHOTO)
-  ) || {
-    files: [],
-    fileData: [],
-    fileSizes: [],
-    thumbnails: [],
-    thumbnailData: []
+  let uploadData = await RedisService.get(request, RedisKeys.UPLOAD_PHOTO)
+
+  if (!uploadData) {
+    uploadData = {
+      files: [],
+      fileData: [],
+      fileSizes: [],
+      thumbnails: [],
+      thumbnailData: []
+    }
   }
 
   for (const [index, thumbnailFilename] of uploadData.thumbnails.entries()) {

--- a/server/services/redis.service.js
+++ b/server/services/redis.service.js
@@ -4,9 +4,24 @@ const { DEFRA_IVORY_SESSION_KEY } = require('../utils/constants')
 const REDIS_TTL_IN_SECONDS = 86400
 
 module.exports = class RedisService {
-  static get (request, key) {
+  static async get (request, key) {
     const client = request.redis.client
-    return client.get(`${request.state[DEFRA_IVORY_SESSION_KEY]}.${key}`)
+    const redisValue = await client.get(
+      `${request.state[DEFRA_IVORY_SESSION_KEY]}.${key}`
+    )
+
+    let parsedValue
+    if (redisValue !== null) {
+      try {
+        parsedValue = JSON.parse(redisValue)
+      } catch (e) {
+        parsedValue = redisValue
+      }
+    } else {
+      parsedValue = null
+    }
+
+    return parsedValue
   }
 
   static set (request, key, value) {

--- a/test/routes/applicant/address-choose.route.test.js
+++ b/test/routes/applicant/address-choose.route.test.js
@@ -57,7 +57,7 @@ describe('/user-details/applicant/address-choose route', () => {
       RedisService.get = jest
         .fn()
         .mockResolvedValueOnce('No')
-        .mockResolvedValueOnce(JSON.stringify(multipleAddresses))
+        .mockResolvedValueOnce(multipleAddresses)
         .mockResolvedValueOnce(nameOrNumber)
         .mockResolvedValueOnce(postcode)
 
@@ -138,7 +138,7 @@ describe('/user-details/applicant/address-choose route', () => {
       RedisService.get = jest
         .fn()
         .mockResolvedValueOnce('No')
-        .mockResolvedValueOnce(JSON.stringify(multipleAddresses))
+        .mockResolvedValueOnce(multipleAddresses)
         .mockResolvedValueOnce(nameOrNumber)
         .mockResolvedValueOnce(postcode)
 
@@ -172,7 +172,7 @@ describe('/user-details/applicant/address-choose route', () => {
         RedisService.get = jest
           .fn()
           .mockResolvedValueOnce('No')
-          .mockResolvedValueOnce(JSON.stringify(singleAddress))
+          .mockResolvedValueOnce(singleAddress)
       })
 
       it('should store the selected address in Redis and progress to the next route when the user selects an address', async () => {
@@ -210,7 +210,7 @@ describe('/user-details/applicant/address-choose route', () => {
         RedisService.get = jest
           .fn()
           .mockResolvedValueOnce('Yes')
-          .mockResolvedValueOnce(JSON.stringify(singleAddress))
+          .mockResolvedValueOnce(singleAddress)
       })
 
       it('should display a validation error message if the user does not select an address', async () => {

--- a/test/routes/applicant/address-confirm.route.test.js
+++ b/test/routes/applicant/address-confirm.route.test.js
@@ -51,7 +51,7 @@ describe('/user-details/applicant/address-confirm route', () => {
         RedisService.get = jest
           .fn()
           .mockResolvedValueOnce('No')
-          .mockResolvedValueOnce(JSON.stringify(singleAddress))
+          .mockResolvedValueOnce(singleAddress)
 
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
@@ -136,7 +136,7 @@ describe('/user-details/applicant/address-confirm route', () => {
         RedisService.get = jest
           .fn()
           .mockResolvedValueOnce('No')
-          .mockResolvedValueOnce(JSON.stringify(singleAddress))
+          .mockResolvedValueOnce(singleAddress)
           .mockResolvedValueOnce('No')
       })
 

--- a/test/routes/applicant/address-enter.route.test.js
+++ b/test/routes/applicant/address-enter.route.test.js
@@ -52,9 +52,7 @@ describe('/user-details/applicant/address-enter route', () => {
 
     describe('GET: All page modes', () => {
       beforeEach(async () => {
-        RedisService.get = jest
-          .fn()
-          .mockResolvedValue(JSON.stringify(singleAddress))
+        RedisService.get = jest.fn().mockResolvedValue(singleAddress)
 
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
@@ -89,7 +87,7 @@ describe('/user-details/applicant/address-enter route', () => {
           RedisService.get = jest
             .fn()
             .mockResolvedValueOnce('No')
-            .mockResolvedValue(JSON.stringify(singleAddress))
+            .mockResolvedValue(singleAddress)
 
           document = await TestHelper.submitGetRequest(server, getOptions)
         })
@@ -110,7 +108,7 @@ describe('/user-details/applicant/address-enter route', () => {
           RedisService.get = jest
             .fn()
             .mockResolvedValueOnce('No')
-            .mockResolvedValueOnce(JSON.stringify(multipleAddresses))
+            .mockResolvedValueOnce(multipleAddresses)
 
           document = await TestHelper.submitGetRequest(server, getOptions)
         })
@@ -138,7 +136,7 @@ describe('/user-details/applicant/address-enter route', () => {
           RedisService.get = jest
             .fn()
             .mockResolvedValueOnce('No')
-            .mockResolvedValueOnce(JSON.stringify(addresses))
+            .mockResolvedValueOnce(addresses)
 
           document = await TestHelper.submitGetRequest(server, getOptions)
         })
@@ -159,7 +157,7 @@ describe('/user-details/applicant/address-enter route', () => {
           RedisService.get = jest
             .fn()
             .mockResolvedValueOnce('No')
-            .mockResolvedValueOnce(JSON.stringify([]))
+            .mockResolvedValueOnce([])
 
           document = await TestHelper.submitGetRequest(server, getOptions)
         })
@@ -199,7 +197,7 @@ describe('/user-details/applicant/address-enter route', () => {
           RedisService.get = jest
             .fn()
             .mockResolvedValueOnce('Yes')
-            .mockResolvedValueOnce(JSON.stringify(singleAddress))
+            .mockResolvedValueOnce(singleAddress)
         })
 
         it('should store the selected address in Redis and progress to the next route when the user selects an address', async () => {
@@ -248,7 +246,7 @@ describe('/user-details/applicant/address-enter route', () => {
           RedisService.get = jest
             .fn()
             .mockResolvedValueOnce('No')
-            .mockResolvedValueOnce(JSON.stringify(singleAddress))
+            .mockResolvedValueOnce(singleAddress)
         })
 
         it('should store the selected address in Redis and progress to the next route when the user selects an address', async () => {
@@ -288,7 +286,7 @@ describe('/user-details/applicant/address-enter route', () => {
         RedisService.get = jest
           .fn()
           .mockResolvedValueOnce('Yes')
-          .mockResolvedValueOnce(JSON.stringify(singleAddress))
+          .mockResolvedValueOnce(singleAddress)
       })
 
       it('should display a validation error message if the user does not enter address line 1', async () => {

--- a/test/routes/applicant/contact-details.route.test.js
+++ b/test/routes/applicant/contact-details.route.test.js
@@ -49,7 +49,7 @@ describe('user-details/applicant/contact-details route', () => {
         RedisService.get = jest
           .fn()
           .mockResolvedValueOnce('No')
-          .mockResolvedValueOnce(JSON.stringify({}))
+          .mockResolvedValueOnce({})
 
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
@@ -109,7 +109,7 @@ describe('user-details/applicant/contact-details route', () => {
         RedisService.get = jest
           .fn()
           .mockResolvedValueOnce('Yes')
-          .mockResolvedValueOnce(JSON.stringify({}))
+          .mockResolvedValueOnce({})
 
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
@@ -140,7 +140,7 @@ describe('user-details/applicant/contact-details route', () => {
         RedisService.get = jest
           .fn()
           .mockResolvedValueOnce('Yes')
-          .mockResolvedValueOnce(JSON.stringify({}))
+          .mockResolvedValueOnce({})
       })
 
       it('should store the value in Redis and progress to the next route when all fields have been entered correctly', async () => {
@@ -175,7 +175,7 @@ describe('user-details/applicant/contact-details route', () => {
         RedisService.get = jest
           .fn()
           .mockResolvedValueOnce('Yes')
-          .mockResolvedValueOnce(JSON.stringify({}))
+          .mockResolvedValueOnce({})
       })
 
       it('should display a validation error message if the user does not enter the full name', async () => {

--- a/test/routes/check-your-answers.route.test.js
+++ b/test/routes/check-your-answers.route.test.js
@@ -1006,29 +1006,27 @@ const _createMocks = (
   RedisService.get = jest.fn((request, redisKey) => {
     const mockDataMap = {
       [RedisKeys.WHAT_TYPE_OF_ITEM_IS_IT]: itemType,
-      [RedisKeys.DESCRIBE_THE_ITEM]: JSON.stringify(mockItemDescription),
-      [RedisKeys.UPLOAD_PHOTO]: JSON.stringify(mockPhotos),
+      [RedisKeys.DESCRIBE_THE_ITEM]: mockItemDescription,
+      [RedisKeys.UPLOAD_PHOTO]: mockPhotos,
       [RedisKeys.WHY_IS_ITEM_RMI]: whyRmi,
-      [RedisKeys.IVORY_VOLUME]: JSON.stringify(mockIvoryVolume),
+      [RedisKeys.IVORY_VOLUME]: mockIvoryVolume,
       [RedisKeys.IVORY_INTEGRAL]: ivoryIntegral,
-      [RedisKeys.IVORY_AGE]: JSON.stringify(mockIvoryAge),
-      [RedisKeys.UPLOAD_DOCUMENT]: JSON.stringify(mockDocuments),
+      [RedisKeys.IVORY_AGE]: mockIvoryAge,
+      [RedisKeys.UPLOAD_DOCUMENT]: mockDocuments,
       [RedisKeys.OWNED_BY_APPLICANT]: ownedByApplicant
         ? Options.YES
         : Options.NO,
-      [RedisKeys.OWNER_CONTACT_DETAILS]: JSON.stringify(
-        mockOwnerContactDetails
-      ),
-      [RedisKeys.APPLICANT_CONTACT_DETAILS]: JSON.stringify(
-        ownedByApplicant ? mockOwnerContactDetails : mockApplicantContactDetails
-      ),
+      [RedisKeys.OWNER_CONTACT_DETAILS]: mockOwnerContactDetails,
+      [RedisKeys.APPLICANT_CONTACT_DETAILS]: ownedByApplicant
+        ? mockOwnerContactDetails
+        : mockApplicantContactDetails,
       [RedisKeys.OWNER_ADDRESS]: ownerAddress,
       [RedisKeys.APPLICANT_ADDRESS]: applicantAddress,
       [RedisKeys.INTENTION_FOR_ITEM]: saleIntention,
-      [RedisKeys.WHAT_CAPACITY]: JSON.stringify({
+      [RedisKeys.WHAT_CAPACITY]: {
         whatCapacity: 'Other',
         otherCapacity: 'Some other capacity'
-      }),
+      },
       [RedisKeys.WORK_FOR_A_BUSINESS]: Options.YES,
       [RedisKeys.SELLING_ON_BEHALF_OF]: sellingOnBehalfOf
     }

--- a/test/routes/describe-the-item.route.test.js
+++ b/test/routes/describe-the-item.route.test.js
@@ -75,7 +75,7 @@ describe('/describe-the-item route', () => {
         RedisService.get = jest
           .fn()
           .mockResolvedValueOnce(ItemTypes.MUSICAL)
-          .mockResolvedValueOnce(JSON.stringify(itemDescription))
+          .mockResolvedValueOnce(itemDescription)
 
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
@@ -150,7 +150,7 @@ describe('/describe-the-item route', () => {
         RedisService.get = jest
           .fn()
           .mockResolvedValueOnce(ItemTypes.HIGH_VALUE)
-          .mockResolvedValueOnce(JSON.stringify(itemDescription))
+          .mockResolvedValueOnce(itemDescription)
 
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
@@ -245,7 +245,7 @@ describe('/describe-the-item route', () => {
         RedisService.get = jest
           .fn()
           .mockResolvedValueOnce(ItemTypes.HIGH_VALUE)
-          .mockResolvedValueOnce(JSON.stringify(itemDescription))
+          .mockResolvedValueOnce(itemDescription)
       })
 
       it('should display a validation error message if the user does not enter "What is the item?"', async () => {
@@ -370,7 +370,7 @@ const _checkSuccessfulPost = async (
   RedisService.get = jest
     .fn()
     .mockResolvedValueOnce(itemType)
-    .mockResolvedValueOnce(JSON.stringify(itemDescription))
+    .mockResolvedValueOnce(itemDescription)
 
   postOptions.payload = itemDescription
 

--- a/test/routes/ivory-age.route.test.js
+++ b/test/routes/ivory-age.route.test.js
@@ -59,15 +59,13 @@ describe('/ivory-age route', () => {
       beforeEach(async () => {
         RedisService.get = jest
           .fn()
-          .mockResolvedValueOnce(
-            JSON.stringify({
-              ivoryAge: [
-                'It has a stamp, serial number or signature to prove its age',
-                'Other reason'
-              ],
-              otherReason: 'Some other reason'
-            })
-          )
+          .mockResolvedValueOnce({
+            ivoryAge: [
+              'It has a stamp, serial number or signature to prove its age',
+              'Other reason'
+            ],
+            otherReason: 'Some other reason'
+          })
           .mockResolvedValueOnce(ItemType.MUSICAL)
 
         document = await TestHelper.submitGetRequest(server, getOptions)
@@ -102,11 +100,9 @@ describe('/ivory-age route', () => {
       beforeEach(async () => {
         RedisService.get = jest
           .fn()
-          .mockResolvedValueOnce(
-            JSON.stringify({
-              ivoryAge: ['It’s been in the family since before 3 March 1947']
-            })
-          )
+          .mockResolvedValueOnce({
+            ivoryAge: ['It’s been in the family since before 3 March 1947']
+          })
           .mockResolvedValueOnce(ItemType.TEN_PERCENT)
 
         document = await TestHelper.submitGetRequest(server, getOptions)
@@ -127,11 +123,9 @@ describe('/ivory-age route', () => {
       beforeEach(async () => {
         RedisService.get = jest
           .fn()
-          .mockResolvedValueOnce(
-            JSON.stringify({
-              ivoryAge: ['It’s been in the family since before 1918']
-            })
-          )
+          .mockResolvedValueOnce({
+            ivoryAge: ['It’s been in the family since before 1918']
+          })
           .mockResolvedValueOnce(ItemType.MINIATURE)
 
         document = await TestHelper.submitGetRequest(server, getOptions)
@@ -152,11 +146,9 @@ describe('/ivory-age route', () => {
       beforeEach(async () => {
         RedisService.get = jest
           .fn()
-          .mockResolvedValueOnce(
-            JSON.stringify({
-              ivoryAge: ['It’s been in the family since before 1918']
-            })
-          )
+          .mockResolvedValueOnce({
+            ivoryAge: ['It’s been in the family since before 1918']
+          })
           .mockResolvedValueOnce(ItemType.HIGH_VALUE)
 
         document = await TestHelper.submitGetRequest(server, getOptions)
@@ -178,15 +170,13 @@ describe('/ivory-age route', () => {
         beforeEach(async () => {
           RedisService.get = jest
             .fn()
-            .mockResolvedValueOnce(
-              JSON.stringify({
-                ivoryAge: [
-                  'It’s been in the family since before 1975',
-                  'Other reason'
-                ],
-                otherReason: 'Some other reason'
-              })
-            )
+            .mockResolvedValueOnce({
+              ivoryAge: [
+                'It’s been in the family since before 1975',
+                'Other reason'
+              ],
+              otherReason: 'Some other reason'
+            })
             .mockResolvedValueOnce(ItemType.MUSICAL)
 
           document = await TestHelper.submitGetRequest(server, getOptions)
@@ -201,15 +191,13 @@ describe('/ivory-age route', () => {
         beforeEach(async () => {
           RedisService.get = jest
             .fn()
-            .mockResolvedValueOnce(
-              JSON.stringify({
-                ivoryAge: [
-                  'It’s been in the family since before 3 March 1947',
-                  'Other reason'
-                ],
-                otherReason: 'Some other reason'
-              })
-            )
+            .mockResolvedValueOnce({
+              ivoryAge: [
+                'It’s been in the family since before 3 March 1947',
+                'Other reason'
+              ],
+              otherReason: 'Some other reason'
+            })
             .mockResolvedValueOnce(ItemType.TEN_PERCENT)
 
           document = await TestHelper.submitGetRequest(server, getOptions)
@@ -224,15 +212,13 @@ describe('/ivory-age route', () => {
         beforeEach(async () => {
           RedisService.get = jest
             .fn()
-            .mockResolvedValueOnce(
-              JSON.stringify({
-                ivoryAge: [
-                  'It’s been in the family since before 1918',
-                  'Other reason'
-                ],
-                otherReason: 'Some other reason'
-              })
-            )
+            .mockResolvedValueOnce({
+              ivoryAge: [
+                'It’s been in the family since before 1918',
+                'Other reason'
+              ],
+              otherReason: 'Some other reason'
+            })
             .mockResolvedValueOnce(ItemType.MINIATURE)
 
           document = await TestHelper.submitGetRequest(server, getOptions)
@@ -247,15 +233,13 @@ describe('/ivory-age route', () => {
         beforeEach(async () => {
           RedisService.get = jest
             .fn()
-            .mockResolvedValueOnce(
-              JSON.stringify({
-                ivoryAge: [
-                  'It’s been in the family since before 1918',
-                  'Other reason'
-                ],
-                otherReason: 'Some other reason'
-              })
-            )
+            .mockResolvedValueOnce({
+              ivoryAge: [
+                'It’s been in the family since before 1918',
+                'Other reason'
+              ],
+              otherReason: 'Some other reason'
+            })
             .mockResolvedValueOnce(ItemType.MUSEUM)
 
           document = await TestHelper.submitGetRequest(server, getOptions)
@@ -270,15 +254,13 @@ describe('/ivory-age route', () => {
         beforeEach(async () => {
           RedisService.get = jest
             .fn()
-            .mockResolvedValueOnce(
-              JSON.stringify({
-                ivoryAge: [
-                  'It’s been in the family since before 1918',
-                  'Other reason'
-                ],
-                otherReason: 'Some other reason'
-              })
-            )
+            .mockResolvedValueOnce({
+              ivoryAge: [
+                'It’s been in the family since before 1918',
+                'Other reason'
+              ],
+              otherReason: 'Some other reason'
+            })
             .mockResolvedValueOnce(ItemType.HIGH_VALUE)
 
           document = await TestHelper.submitGetRequest(server, getOptions)
@@ -306,13 +288,11 @@ describe('/ivory-age route', () => {
       beforeEach(async () => {
         RedisService.get = jest
           .fn()
-          .mockResolvedValueOnce(
-            JSON.stringify({
-              ivoryAge: [
-                'It has a stamp, serial number or signature to prove its age'
-              ]
-            })
-          )
+          .mockResolvedValueOnce({
+            ivoryAge: [
+              'It has a stamp, serial number or signature to prove its age'
+            ]
+          })
           .mockResolvedValueOnce(ItemType.MUSICAL)
       })
 

--- a/test/routes/ivory-volume.route.test.js
+++ b/test/routes/ivory-volume.route.test.js
@@ -53,7 +53,7 @@ describe('/ivory-volume route', () => {
       beforeEach(async () => {
         RedisService.get = jest
           .fn()
-          .mockResolvedValueOnce(JSON.stringify({}))
+          .mockResolvedValueOnce({})
           .mockResolvedValueOnce(ItemType.MINIATURE)
 
         document = await TestHelper.submitGetRequest(server, getOptions)
@@ -126,7 +126,7 @@ describe('/ivory-volume route', () => {
       beforeEach(async () => {
         RedisService.get = jest
           .fn()
-          .mockResolvedValueOnce(JSON.stringify({}))
+          .mockResolvedValueOnce({})
           .mockResolvedValueOnce(ItemType.MUSICAL)
 
         document = await TestHelper.submitGetRequest(server, getOptions)
@@ -159,7 +159,7 @@ describe('/ivory-volume route', () => {
       beforeEach(async () => {
         RedisService.get = jest
           .fn()
-          .mockResolvedValueOnce(JSON.stringify({}))
+          .mockResolvedValueOnce({})
           .mockResolvedValueOnce(ItemType.MINIATURE)
       })
 
@@ -206,7 +206,7 @@ describe('/ivory-volume route', () => {
       beforeEach(async () => {
         RedisService.get = jest
           .fn()
-          .mockResolvedValueOnce(JSON.stringify({}))
+          .mockResolvedValueOnce({})
           .mockResolvedValueOnce(ItemType.MINIATURE)
       })
 

--- a/test/routes/legal-responsibility.route.test.js
+++ b/test/routes/legal-responsibility.route.test.js
@@ -154,16 +154,14 @@ describe('/legal-responsibility route', () => {
 
     describe('Success', () => {
       it('should redirect the correct route when there are no uploaded photos', async () => {
-        RedisService.get = jest.fn().mockResolvedValue(JSON.stringify({}))
+        RedisService.get = jest.fn().mockResolvedValue({})
 
         const response = await TestHelper.submitPostRequest(server, postOptions)
         expect(response.headers.location).toEqual(nextUrlNoPhotos)
       })
 
       it('should redirect the correct route when there are some uploaded photos', async () => {
-        RedisService.get = jest
-          .fn()
-          .mockResolvedValue(JSON.stringify(mockPhotos))
+        RedisService.get = jest.fn().mockResolvedValue(mockPhotos)
 
         const response = await TestHelper.submitPostRequest(server, postOptions)
         expect(response.headers.location).toEqual(nextUrlSomePhotos)

--- a/test/routes/make-payment.route.test.js
+++ b/test/routes/make-payment.route.test.js
@@ -60,12 +60,10 @@ describe('/make-payment route', () => {
         .mockResolvedValueOnce(
           'Musical instrument made before 1975 with less than 20% ivory'
         )
-        .mockResolvedValueOnce(
-          JSON.stringify({
-            name: 'OWNER_NAME',
-            emailAddress: 'OWNER_EMAIL_ADDRESS'
-          })
-        )
+        .mockResolvedValueOnce({
+          name: 'OWNER_NAME',
+          emailAddress: 'OWNER_EMAIL_ADDRESS'
+        })
 
       const response = await TestHelper.submitGetRequest(
         server,
@@ -122,12 +120,10 @@ describe('/make-payment route', () => {
         .mockResolvedValueOnce(
           'Item made before 1918 that has outstandingly high artistic, cultural or historical value'
         )
-        .mockResolvedValueOnce(
-          JSON.stringify({
-            name: 'OWNER_NAME',
-            emailAddress: 'OWNER_EMAIL_ADDRESS'
-          })
-        )
+        .mockResolvedValueOnce({
+          name: 'OWNER_NAME',
+          emailAddress: 'OWNER_EMAIL_ADDRESS'
+        })
 
       const response = await TestHelper.submitGetRequest(
         server,

--- a/test/routes/owner/address-choose.route.test.js
+++ b/test/routes/owner/address-choose.route.test.js
@@ -62,7 +62,7 @@ describe('/user-details/owner/address-choose route', () => {
       beforeEach(async () => {
         const mockData = {
           [RedisKeys.OWNED_BY_APPLICANT]: 'Yes',
-          [RedisKeys.ADDRESS_FIND_RESULTS]: JSON.stringify(multipleAddresses),
+          [RedisKeys.ADDRESS_FIND_RESULTS]: multipleAddresses,
           [RedisKeys.ADDRESS_FIND_NAME_OR_NUMBER]: nameOrNumber,
           [RedisKeys.ADDRESS_FIND_POSTCODE]: postcode
         }
@@ -149,7 +149,7 @@ describe('/user-details/owner/address-choose route', () => {
 
         const mockData = {
           [RedisKeys.OWNED_BY_APPLICANT]: 'Yes',
-          [RedisKeys.ADDRESS_FIND_RESULTS]: JSON.stringify(multipleAddresses),
+          [RedisKeys.ADDRESS_FIND_RESULTS]: multipleAddresses,
           [RedisKeys.ADDRESS_FIND_NAME_OR_NUMBER]: nameOrNumber,
           [RedisKeys.ADDRESS_FIND_POSTCODE]: postcode
         }
@@ -174,7 +174,7 @@ describe('/user-details/owner/address-choose route', () => {
       beforeEach(async () => {
         const mockData = {
           [RedisKeys.OWNED_BY_APPLICANT]: 'No',
-          [RedisKeys.ADDRESS_FIND_RESULTS]: JSON.stringify(multipleAddresses),
+          [RedisKeys.ADDRESS_FIND_RESULTS]: multipleAddresses,
           [RedisKeys.ADDRESS_FIND_NAME_OR_NUMBER]: nameOrNumber,
           [RedisKeys.ADDRESS_FIND_POSTCODE]: postcode
         }
@@ -261,7 +261,7 @@ describe('/user-details/owner/address-choose route', () => {
 
         const mockData = {
           [RedisKeys.OWNED_BY_APPLICANT]: 'No',
-          [RedisKeys.ADDRESS_FIND_RESULTS]: JSON.stringify(multipleAddresses),
+          [RedisKeys.ADDRESS_FIND_RESULTS]: multipleAddresses,
           [RedisKeys.ADDRESS_FIND_NAME_OR_NUMBER]: nameOrNumber,
           [RedisKeys.ADDRESS_FIND_POSTCODE]: postcode
         }
@@ -300,7 +300,7 @@ describe('/user-details/owner/address-choose route', () => {
       beforeEach(() => {
         const mockData = {
           [RedisKeys.OWNED_BY_APPLICANT]: 'Yes',
-          [RedisKeys.ADDRESS_FIND_RESULTS]: JSON.stringify(multipleAddresses)
+          [RedisKeys.ADDRESS_FIND_RESULTS]: multipleAddresses
         }
 
         RedisService.get = jest.fn((request, redisKey) => {
@@ -344,7 +344,7 @@ describe('/user-details/owner/address-choose route', () => {
         RedisService.get = jest
           .fn()
           .mockResolvedValueOnce('No')
-          .mockResolvedValueOnce(JSON.stringify(singleAddress))
+          .mockResolvedValueOnce(singleAddress)
       })
 
       it('should store the selected address in Redis and progress to the next route when the user selects an address', async () => {
@@ -384,7 +384,7 @@ describe('/user-details/owner/address-choose route', () => {
         RedisService.get = jest
           .fn()
           .mockResolvedValueOnce('No')
-          .mockResolvedValueOnce(JSON.stringify(singleAddress))
+          .mockResolvedValueOnce(singleAddress)
       })
 
       it('should display a validation error message if the user does not select an address', async () => {

--- a/test/routes/owner/address-confirm.route.test.js
+++ b/test/routes/owner/address-confirm.route.test.js
@@ -53,7 +53,7 @@ describe('/user-details/owner/address-confirm route', () => {
         RedisService.get = jest
           .fn()
           .mockResolvedValueOnce('Yes')
-          .mockResolvedValueOnce(JSON.stringify(singleAddress))
+          .mockResolvedValueOnce(singleAddress)
 
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
@@ -123,7 +123,7 @@ describe('/user-details/owner/address-confirm route', () => {
         RedisService.get = jest
           .fn()
           .mockResolvedValueOnce('No')
-          .mockResolvedValueOnce(JSON.stringify(singleAddress))
+          .mockResolvedValueOnce(singleAddress)
 
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
@@ -207,7 +207,7 @@ describe('/user-details/owner/address-confirm route', () => {
         RedisService.get = jest
           .fn()
           .mockResolvedValueOnce('Yes')
-          .mockResolvedValueOnce(JSON.stringify(singleAddress))
+          .mockResolvedValueOnce(singleAddress)
           .mockResolvedValueOnce('Yes')
       })
 
@@ -246,7 +246,7 @@ describe('/user-details/owner/address-confirm route', () => {
         RedisService.get = jest
           .fn()
           .mockResolvedValueOnce('No')
-          .mockResolvedValueOnce(JSON.stringify(singleAddress))
+          .mockResolvedValueOnce(singleAddress)
           .mockResolvedValueOnce('No')
       })
 

--- a/test/routes/owner/address-enter.route.test.js
+++ b/test/routes/owner/address-enter.route.test.js
@@ -52,9 +52,7 @@ describe('/user-details/owner/address-enter route', () => {
 
     describe('GET: All page modes', () => {
       beforeEach(async () => {
-        RedisService.get = jest
-          .fn()
-          .mockResolvedValue(JSON.stringify(singleAddress))
+        RedisService.get = jest.fn().mockResolvedValue(singleAddress)
 
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
@@ -89,7 +87,7 @@ describe('/user-details/owner/address-enter route', () => {
           RedisService.get = jest
             .fn()
             .mockResolvedValueOnce('No')
-            .mockResolvedValue(JSON.stringify(singleAddress))
+            .mockResolvedValue(singleAddress)
 
           document = await TestHelper.submitGetRequest(server, getOptions)
         })
@@ -110,7 +108,7 @@ describe('/user-details/owner/address-enter route', () => {
           RedisService.get = jest
             .fn()
             .mockResolvedValueOnce('No')
-            .mockResolvedValueOnce(JSON.stringify(multipleAddresses))
+            .mockResolvedValueOnce(multipleAddresses)
 
           document = await TestHelper.submitGetRequest(server, getOptions)
         })
@@ -138,7 +136,7 @@ describe('/user-details/owner/address-enter route', () => {
           RedisService.get = jest
             .fn()
             .mockResolvedValueOnce('No')
-            .mockResolvedValueOnce(JSON.stringify(addresses))
+            .mockResolvedValueOnce(addresses)
 
           document = await TestHelper.submitGetRequest(server, getOptions)
         })
@@ -159,7 +157,7 @@ describe('/user-details/owner/address-enter route', () => {
           RedisService.get = jest
             .fn()
             .mockResolvedValueOnce('No')
-            .mockResolvedValueOnce(JSON.stringify([]))
+            .mockResolvedValueOnce([])
 
           document = await TestHelper.submitGetRequest(server, getOptions)
         })
@@ -196,7 +194,7 @@ describe('/user-details/owner/address-enter route', () => {
           RedisService.get = jest
             .fn()
             .mockResolvedValueOnce('Yes')
-            .mockResolvedValueOnce(JSON.stringify(singleAddress))
+            .mockResolvedValueOnce(singleAddress)
         })
 
         it('should store the selected address in Redis and progress to the next route when the user selects an address', async () => {
@@ -235,7 +233,7 @@ describe('/user-details/owner/address-enter route', () => {
           RedisService.get = jest
             .fn()
             .mockResolvedValueOnce('No')
-            .mockResolvedValueOnce(JSON.stringify(singleAddress))
+            .mockResolvedValueOnce(singleAddress)
         })
 
         it('should store the selected address in Redis and progress to the next route when the user selects an address', async () => {
@@ -275,7 +273,7 @@ describe('/user-details/owner/address-enter route', () => {
         RedisService.get = jest
           .fn()
           .mockResolvedValueOnce('Yes')
-          .mockResolvedValueOnce(JSON.stringify(singleAddress))
+          .mockResolvedValueOnce(singleAddress)
       })
 
       it('should display a validation error message if the user does not enter address line 1', async () => {

--- a/test/routes/owner/contact-details.route.test.js
+++ b/test/routes/owner/contact-details.route.test.js
@@ -50,8 +50,8 @@ describe('user-details/owner/contact-details route', () => {
       beforeEach(async () => {
         RedisService.get = jest
           .fn()
-          .mockResolvedValueOnce(JSON.stringify({}))
-          .mockResolvedValueOnce(JSON.stringify({}))
+          .mockResolvedValueOnce({})
+          .mockResolvedValueOnce({})
           .mockResolvedValueOnce('An individual')
 
         document = await TestHelper.submitGetRequest(server, getOptions)
@@ -123,8 +123,8 @@ describe('user-details/owner/contact-details route', () => {
       beforeEach(async () => {
         RedisService.get = jest
           .fn()
-          .mockResolvedValueOnce(JSON.stringify({}))
-          .mockResolvedValueOnce(JSON.stringify({}))
+          .mockResolvedValueOnce({})
+          .mockResolvedValueOnce({})
           .mockResolvedValueOnce('A business')
 
         document = await TestHelper.submitGetRequest(server, getOptions)
@@ -143,8 +143,8 @@ describe('user-details/owner/contact-details route', () => {
       beforeEach(async () => {
         RedisService.get = jest
           .fn()
-          .mockResolvedValueOnce(JSON.stringify({}))
-          .mockResolvedValueOnce(JSON.stringify({}))
+          .mockResolvedValueOnce({})
+          .mockResolvedValueOnce({})
           .mockResolvedValueOnce('A business')
 
         document = await TestHelper.submitGetRequest(server, getOptions)
@@ -176,8 +176,8 @@ describe('user-details/owner/contact-details route', () => {
         beforeEach(() => {
           RedisService.get = jest
             .fn()
-            .mockResolvedValueOnce(JSON.stringify({}))
-            .mockResolvedValueOnce(JSON.stringify({}))
+            .mockResolvedValueOnce({})
+            .mockResolvedValueOnce({})
             .mockResolvedValueOnce('An individual')
         })
 
@@ -211,8 +211,8 @@ describe('user-details/owner/contact-details route', () => {
         beforeEach(() => {
           RedisService.get = jest
             .fn()
-            .mockResolvedValueOnce(JSON.stringify({}))
-            .mockResolvedValueOnce(JSON.stringify({}))
+            .mockResolvedValueOnce({})
+            .mockResolvedValueOnce({})
             .mockResolvedValueOnce('Another business')
         })
 
@@ -247,7 +247,7 @@ describe('user-details/owner/contact-details route', () => {
         beforeEach(() => {
           RedisService.get = jest
             .fn()
-            .mockResolvedValueOnce(JSON.stringify({}))
+            .mockResolvedValueOnce({})
             .mockResolvedValueOnce('An individual')
         })
 
@@ -340,7 +340,7 @@ describe('user-details/owner/contact-details route', () => {
         beforeEach(() => {
           RedisService.get = jest
             .fn()
-            .mockResolvedValueOnce(JSON.stringify({}))
+            .mockResolvedValueOnce({})
             .mockResolvedValueOnce('A business')
         })
 

--- a/test/routes/remove-document.route.test.js
+++ b/test/routes/remove-document.route.test.js
@@ -37,7 +37,7 @@ describe('/remove-document route', () => {
 
     describe('GET: One document', () => {
       beforeEach(() => {
-        RedisService.get = jest.fn().mockResolvedValue(JSON.stringify(mockData))
+        RedisService.get = jest.fn().mockResolvedValue(mockData)
       })
 
       it('should redirect to the "Upload documents" page', async () => {
@@ -75,9 +75,7 @@ describe('/remove-document route', () => {
 
     describe('GET: Multiple documents', () => {
       beforeEach(() => {
-        RedisService.get = jest
-          .fn()
-          .mockResolvedValue(JSON.stringify(mockDataSixPhotos))
+        RedisService.get = jest.fn().mockResolvedValue(mockDataSixPhotos)
       })
 
       it('should redirect to the "Your documents" page', async () => {
@@ -103,9 +101,9 @@ describe('/remove-document route', () => {
           expect.any(Object),
           redisKey,
           JSON.stringify({
-            files: mockDataSixPhotos.files.slice(1),
-            fileData: mockDataSixPhotos.fileData.slice(1),
-            fileSizes: mockDataSixPhotos.fileSizes.slice(1)
+            files: mockDataSixPhotos.files.slice(0),
+            fileData: mockDataSixPhotos.fileData.slice(0),
+            fileSizes: mockDataSixPhotos.fileSizes.slice(0)
           })
         )
 

--- a/test/routes/remove-photo.route.test.js
+++ b/test/routes/remove-photo.route.test.js
@@ -37,7 +37,7 @@ describe('/remove-photo route', () => {
 
     describe('GET: One photo', () => {
       beforeEach(() => {
-        RedisService.get = jest.fn().mockResolvedValue(JSON.stringify(mockData))
+        RedisService.get = jest.fn().mockResolvedValue(mockData)
       })
 
       it('should redirect to the "Upload photos" page', async () => {
@@ -77,9 +77,7 @@ describe('/remove-photo route', () => {
 
     describe('GET: Multiple photos', () => {
       beforeEach(() => {
-        RedisService.get = jest
-          .fn()
-          .mockResolvedValue(JSON.stringify(mockDataSixPhotos))
+        RedisService.get = jest.fn().mockResolvedValue(mockDataSixPhotos)
       })
 
       it('should redirect to the "Your photos" page', async () => {
@@ -105,11 +103,11 @@ describe('/remove-photo route', () => {
           expect.any(Object),
           redisKey,
           JSON.stringify({
-            files: mockDataSixPhotos.files.slice(1),
-            fileData: mockDataSixPhotos.fileData.slice(1),
-            fileSizes: mockDataSixPhotos.fileSizes.slice(1),
-            thumbnails: mockDataSixPhotos.thumbnails.slice(1),
-            thumbnailData: mockDataSixPhotos.thumbnailData.slice(1)
+            files: mockDataSixPhotos.files.slice(0),
+            fileData: mockDataSixPhotos.fileData.slice(0),
+            fileSizes: mockDataSixPhotos.fileSizes.slice(0),
+            thumbnails: mockDataSixPhotos.thumbnails.slice(0),
+            thumbnailData: mockDataSixPhotos.thumbnailData.slice(0)
           })
         )
 

--- a/test/routes/save-record.route.test.js
+++ b/test/routes/save-record.route.test.js
@@ -213,30 +213,30 @@ const mockImageUploadData = {
 const section10RedisMockDataMap = {
   [RedisKeys.PAYMENT_ID]: '123456789',
   [RedisKeys.WHAT_TYPE_OF_ITEM_IS_IT]: ItemType.MUSICAL,
-  [RedisKeys.DESCRIBE_THE_ITEM]: JSON.stringify(mockItemDescriptionSection10),
-  [RedisKeys.IVORY_VOLUME]: JSON.stringify({
+  [RedisKeys.DESCRIBE_THE_ITEM]: mockItemDescriptionSection10,
+  [RedisKeys.IVORY_VOLUME]: {
     ivoryVolume: IvoryVolumeReasons.CLEAR_FROM_LOOKING_AT_IT
-  }),
-  [RedisKeys.IVORY_AGE]: JSON.stringify({
+  },
+  [RedisKeys.IVORY_AGE]: {
     ivoryAge: [
       'It has a stamp, serial number or signature to prove its age',
       'Other reason'
     ],
     otherReason: 'Some other reason'
-  }),
+  },
   [RedisKeys.SUBMISSION_DATE]: 'SUBMISSION_DATE',
   [RedisKeys.SUBMISSION_REFERENCE]: 'SUBMISSION_REFERENCE',
   [RedisKeys.INTENTION_FOR_ITEM]: 'Sell it',
-  [RedisKeys.UPLOAD_PHOTO]: JSON.stringify(mockImageUploadData),
+  [RedisKeys.UPLOAD_PHOTO]: mockImageUploadData,
 
-  [RedisKeys.OWNER_CONTACT_DETAILS]: JSON.stringify(mockOwnerData),
+  [RedisKeys.OWNER_CONTACT_DETAILS]: mockOwnerData,
   [RedisKeys.OWNER_ADDRESS]: 'OWNER_ADDRESS',
-  [RedisKeys.APPLICANT_CONTACT_DETAILS]: JSON.stringify(mockApplicantData),
+  [RedisKeys.APPLICANT_CONTACT_DETAILS]: mockApplicantData,
   [RedisKeys.APPLICANT_ADDRESS]: 'APPLICANT_ADDRESS',
-  [RedisKeys.WHAT_CAPACITY]: JSON.stringify({
+  [RedisKeys.WHAT_CAPACITY]: {
     whatCapacity: 'Other',
     otherCapacity: 'Some other capacity'
-  }),
+  },
   [RedisKeys.WORK_FOR_A_BUSINESS]: true,
   [RedisKeys.SELLING_ON_BEHALF_OF]: 'Other'
 }
@@ -244,32 +244,32 @@ const section10RedisMockDataMap = {
 const section2RedisMockDataMap = {
   [RedisKeys.PAYMENT_ID]: '123456789',
   [RedisKeys.WHAT_TYPE_OF_ITEM_IS_IT]: ItemType.HIGH_VALUE,
-  [RedisKeys.DESCRIBE_THE_ITEM]: JSON.stringify(mockItemDescriptionSection2),
-  [RedisKeys.IVORY_VOLUME]: JSON.stringify({
+  [RedisKeys.DESCRIBE_THE_ITEM]: mockItemDescriptionSection2,
+  [RedisKeys.IVORY_VOLUME]: {
     ivoryVolume: IvoryVolumeReasons.CLEAR_FROM_LOOKING_AT_IT
-  }),
-  [RedisKeys.IVORY_AGE]: JSON.stringify({
+  },
+  [RedisKeys.IVORY_AGE]: {
     ivoryAge: [
       'It has a stamp, serial number or signature to prove its age',
       'Other reason'
     ],
     otherReason: 'Some other reason'
-  }),
+  },
   [RedisKeys.SUBMISSION_DATE]: 'SUBMISSION_DATE',
   [RedisKeys.SUBMISSION_REFERENCE]: 'SUBMISSION_REFERENCE',
   [RedisKeys.INTENTION_FOR_ITEM]: 'Hire it out',
-  [RedisKeys.UPLOAD_PHOTO]: JSON.stringify(mockImageUploadData),
-  [RedisKeys.OWNER_CONTACT_DETAILS]: JSON.stringify(mockOwnerData),
+  [RedisKeys.UPLOAD_PHOTO]: mockImageUploadData,
+  [RedisKeys.OWNER_CONTACT_DETAILS]: mockOwnerData,
   [RedisKeys.OWNER_ADDRESS]: 'OWNER_ADDRESS',
-  [RedisKeys.APPLICANT_CONTACT_DETAILS]: JSON.stringify(mockApplicantData),
+  [RedisKeys.APPLICANT_CONTACT_DETAILS]: mockApplicantData,
   [RedisKeys.APPLICANT_ADDRESS]: 'APPLICANT_ADDRESS',
   [RedisKeys.TARGET_COMPLETION_DATE]: 'TARGET_COMPLETION_DATE',
-  [RedisKeys.UPLOAD_DOCUMENT]: JSON.stringify(mockFileAttachmentData),
+  [RedisKeys.UPLOAD_DOCUMENT]: mockFileAttachmentData,
   [RedisKeys.WHY_IS_ITEM_RMI]: 'RMI_REASON',
-  [RedisKeys.WHAT_CAPACITY]: JSON.stringify({
+  [RedisKeys.WHAT_CAPACITY]: {
     whatCapacity: 'Other',
     otherCapacity: 'Some other capacity'
-  }),
+  },
   [RedisKeys.WORK_FOR_A_BUSINESS]: true,
   [RedisKeys.SELLING_ON_BEHALF_OF]: 'Other'
 }

--- a/test/routes/service-complete.route.test.js
+++ b/test/routes/service-complete.route.test.js
@@ -472,7 +472,7 @@ const mockApplicantContactDetails = {
 const redisMockDataMap = {
   [RedisKeys.PAYMENT_ID]: paymentReference,
   [RedisKeys.SUBMISSION_REFERENCE]: submissionReference,
-  [RedisKeys.OWNER_CONTACT_DETAILS]: JSON.stringify(mockOwnerContactDetails)
+  [RedisKeys.OWNER_CONTACT_DETAILS]: mockOwnerContactDetails
 }
 
 const _createMocks = () => {
@@ -484,11 +484,10 @@ const _createMocks = () => {
 const _createSection2RedisMock = ownedByApplicant => {
   redisMockDataMap[RedisKeys.WHAT_TYPE_OF_ITEM_IS_IT] = ItemType.HIGH_VALUE
   redisMockDataMap[RedisKeys.OWNED_BY_APPLICANT] = ownedByApplicant
-  redisMockDataMap[RedisKeys.APPLICANT_CONTACT_DETAILS] = JSON.stringify(
+  redisMockDataMap[RedisKeys.APPLICANT_CONTACT_DETAILS] =
     ownedByApplicant === Options.YES
       ? mockOwnerContactDetails
       : mockApplicantContactDetails
-  )
 
   RedisService.get = jest.fn((request, redisKey) => {
     return redisMockDataMap[redisKey]
@@ -498,11 +497,10 @@ const _createSection2RedisMock = ownedByApplicant => {
 const _createSection10RedisMock = ownedByApplicant => {
   redisMockDataMap[RedisKeys.WHAT_TYPE_OF_ITEM_IS_IT] = ItemType.MUSICAL
   redisMockDataMap[RedisKeys.OWNED_BY_APPLICANT] = ownedByApplicant
-  redisMockDataMap[RedisKeys.APPLICANT_CONTACT_DETAILS] = JSON.stringify(
+  redisMockDataMap[RedisKeys.APPLICANT_CONTACT_DETAILS] =
     ownedByApplicant === Options.YES
       ? mockOwnerContactDetails
       : mockApplicantContactDetails
-  )
 
   RedisService.get = jest.fn((request, redisKey) => {
     return redisMockDataMap[redisKey]

--- a/test/routes/upload-document.route.test.js
+++ b/test/routes/upload-document.route.test.js
@@ -150,7 +150,7 @@ describe('/upload-document route', () => {
           fileData: [],
           fileSizes: [100, 200]
         }
-        RedisService.get = jest.fn().mockResolvedValue(JSON.stringify(mockData))
+        RedisService.get = jest.fn().mockResolvedValue(mockData)
 
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
@@ -402,7 +402,7 @@ describe('/upload-document route', () => {
         fileData: [],
         fileSizes: [100]
       }
-      RedisService.get = jest.fn().mockReturnValue(JSON.stringify(mockData))
+      RedisService.get = jest.fn().mockReturnValue(mockData)
 
       response = await TestHelper.submitPostRequest(server, postOptions, 400)
     })
@@ -442,9 +442,9 @@ const _createMocks = () => {
   }
   RedisService.get = jest
     .fn()
-    .mockResolvedValueOnce(JSON.stringify(mockData))
+    .mockResolvedValueOnce(mockData)
     .mockResolvedValueOnce('false')
-    .mockResolvedValueOnce(JSON.stringify(mockData))
+    .mockResolvedValueOnce(mockData)
 }
 
 const _checkValidation = async (
@@ -455,7 +455,11 @@ const _checkValidation = async (
   errorCode = 400
 ) => {
   postOptions.payload.files = payloadFile
-  const response = await TestHelper.submitPostRequest(server, postOptions, errorCode)
+  const response = await TestHelper.submitPostRequest(
+    server,
+    postOptions,
+    errorCode
+  )
   await TestHelper.checkValidationError(
     response,
     'files',

--- a/test/routes/upload-photo.route.test.js
+++ b/test/routes/upload-photo.route.test.js
@@ -158,7 +158,7 @@ describe('/upload-photo route', () => {
           thumbnails: ['lamp-thumbnail.png', 'chair-thumbnail.jpeg'],
           thumbnailData: []
         }
-        RedisService.get = jest.fn().mockResolvedValue(JSON.stringify(mockData))
+        RedisService.get = jest.fn().mockResolvedValue(mockData)
 
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
@@ -413,7 +413,7 @@ describe('/upload-photo route', () => {
         thumbnails: ['lamp-thumbnail.png'],
         thumbnailData: []
       }
-      RedisService.get = jest.fn().mockReturnValue(JSON.stringify(mockData))
+      RedisService.get = jest.fn().mockReturnValue(mockData)
 
       response = await TestHelper.submitPostRequest(server, postOptions, 400)
     })
@@ -452,9 +452,9 @@ const _createMocks = () => {
   }
   RedisService.get = jest
     .fn()
-    .mockResolvedValueOnce(JSON.stringify(mockData))
+    .mockResolvedValueOnce(mockData)
     .mockResolvedValueOnce('false')
-    .mockResolvedValueOnce(JSON.stringify(mockData))
+    .mockResolvedValueOnce(mockData)
 }
 
 const _checkValidation = async (
@@ -465,7 +465,11 @@ const _checkValidation = async (
   errorCode = 400
 ) => {
   postOptions.payload.files = payloadFile
-  const response = await TestHelper.submitPostRequest(server, postOptions, errorCode)
+  const response = await TestHelper.submitPostRequest(
+    server,
+    postOptions,
+    errorCode
+  )
   await TestHelper.checkValidationError(
     response,
     'files',

--- a/test/routes/what-capacity.route.test.js
+++ b/test/routes/what-capacity.route.test.js
@@ -52,7 +52,7 @@ describe('/what-capacity route', () => {
     beforeEach(async () => {
       RedisService.get = jest
         .fn()
-        .mockResolvedValueOnce(JSON.stringify({}))
+        .mockResolvedValueOnce({})
         .mockResolvedValueOnce(ItemType.MINIATURE)
 
       document = await TestHelper.submitGetRequest(server, getOptions)

--- a/test/routes/your-documents.route.test.js
+++ b/test/routes/your-documents.route.test.js
@@ -46,9 +46,7 @@ describe('/your-documents route', () => {
 
     describe('GET: 0 documents', () => {
       beforeEach(async () => {
-        RedisService.get = jest
-          .fn()
-          .mockResolvedValue(JSON.stringify(mockNoData))
+        RedisService.get = jest.fn().mockResolvedValue(mockNoData)
       })
 
       it('should redirect back to the "Upload photo" page if there are no uploaded photos to display', async () => {
@@ -65,7 +63,7 @@ describe('/your-documents route', () => {
 
     describe('GET: 6 or less documents', () => {
       beforeEach(async () => {
-        RedisService.get = jest.fn().mockResolvedValue(JSON.stringify(mockData))
+        RedisService.get = jest.fn().mockResolvedValue(mockData)
 
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
@@ -114,9 +112,7 @@ describe('/your-documents route', () => {
 
     describe('GET: 6 documents', () => {
       beforeEach(async () => {
-        RedisService.get = jest
-          .fn()
-          .mockResolvedValue(JSON.stringify(mockDataSixDocuments))
+        RedisService.get = jest.fn().mockResolvedValue(mockDataSixDocuments)
 
         document = await TestHelper.submitGetRequest(server, getOptions)
       })

--- a/test/routes/your-photos.route.test.js
+++ b/test/routes/your-photos.route.test.js
@@ -46,9 +46,7 @@ describe('/your-photos route', () => {
 
     describe('GET: 0 photos', () => {
       beforeEach(async () => {
-        RedisService.get = jest
-          .fn()
-          .mockResolvedValue(JSON.stringify(mockNoData))
+        RedisService.get = jest.fn().mockResolvedValue(mockNoData)
       })
 
       it('should redirect back to the "Upload photo" page if there are no uploaded photos to display', async () => {
@@ -65,7 +63,7 @@ describe('/your-photos route', () => {
 
     describe('GET: 6 or less photos', () => {
       beforeEach(async () => {
-        RedisService.get = jest.fn().mockResolvedValue(JSON.stringify(mockData))
+        RedisService.get = jest.fn().mockResolvedValue(mockData)
 
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
@@ -108,9 +106,7 @@ describe('/your-photos route', () => {
 
     describe('GET: 6 photos', () => {
       beforeEach(async () => {
-        RedisService.get = jest
-          .fn()
-          .mockResolvedValue(JSON.stringify(mockDataSixPhotos))
+        RedisService.get = jest.fn().mockResolvedValue(mockDataSixPhotos)
 
         document = await TestHelper.submitGetRequest(server, getOptions)
       })

--- a/test/services/redis.service.test.js
+++ b/test/services/redis.service.test.js
@@ -19,7 +19,8 @@ describe('Redis service', () => {
     it('should get a value from Redis', async () => {
       expect(mockRequest.redis.client.get).toBeCalledTimes(0)
 
-      await RedisService.get(mockRequest, redisKey)
+      const redisValue = await RedisService.get(mockRequest, redisKey)
+      expect(redisValue).toEqual(mockRedisValue)
 
       expect(mockRequest.redis.client.get).toBeCalledTimes(1)
       expect(mockRequest.redis.client.get).toBeCalledWith(
@@ -47,6 +48,7 @@ describe('Redis service', () => {
   })
 })
 
+const mockRedisValue = 'MOCK REDIS VALUE'
 const _createMocks = () => {
   mockRequest = jest.fn()
   mockRequest.state = {
@@ -54,7 +56,7 @@ const _createMocks = () => {
   }
   mockRequest.redis = {
     client: {
-      get: jest.fn(),
+      get: jest.fn(() => mockRedisValue),
       setex: jest.fn()
     }
   }


### PR DESCRIPTION
IVORY-486: Error when revisiting previous pages

There was a problem in some circumstances when retrieving data from the Redis cache. Objects going into the cache have to be converted into Strings. When they come back out again, these strings need to be parsed back into objects.

Pages using the Redis service had to handle the fact that the values coming out of the Redis cache could be null. In some pages this wasn't being handled properly.

A refactor of the Redis service and related code has been carried out to encapsulate all of that string parsing and null value handling into the Redis service instead.