### PR TITLE
Feature/ivory 513 create a cookie banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "0.22.8",
+  "version": "0.22.9",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/routes/eligibility-checker/how-certain.route.js
+++ b/server/routes/eligibility-checker/how-certain.route.js
@@ -10,7 +10,7 @@ const completelyCertain = 'Completely'
 
 const handlers = {
   get: (request, h) => {
-    const context = _getContext()
+    const context = _getContext(request)
 
     return h.view(Views.HOW_CERTAIN, {
       ...context
@@ -18,9 +18,20 @@ const handlers = {
   },
 
   post: async (request, h) => {
-    const context = _getContext()
+    const context = _getContext(request)
     const payload = request.payload
     const errors = _validateForm(payload)
+
+    if (payload.cookies) {
+      h.state('CookieBanner', 'Hidden', {
+        ttl: 24 * 60 * 60 * 1000 * 365, // 1 year
+        path: '/'
+      })
+      return h.view(Views.HOW_CERTAIN, {
+        ...context,
+        hideBanner: true
+      })
+    }
 
     if (errors.length) {
       AnalyticsService.sendEvent(request, {
@@ -57,10 +68,12 @@ const handlers = {
   }
 }
 
-const _getContext = () => {
+const _getContext = (request) => {
+  const hideBanner = request.state.CookieBanner
   return {
     pageTitle:
-      'How certain are you that your item is exempt from the ivory ban?'
+      'How certain are you that your item is exempt from the ivory ban?',
+    hideBanner
   }
 }
 

--- a/server/routes/eligibility-checker/how-certain.route.js
+++ b/server/routes/eligibility-checker/how-certain.route.js
@@ -68,7 +68,7 @@ const handlers = {
   }
 }
 
-const _getContext = (request) => {
+const _getContext = request => {
   const hideBanner = request.state.CookieBanner
   return {
     pageTitle:

--- a/server/views/cookie-policy.html
+++ b/server/views/cookie-policy.html
@@ -45,6 +45,17 @@
             {
               text: "24 hours"
             }
+          ],
+          [
+            {
+              text: "CookieBanner"
+            },
+            {
+              text: "Used to hide the cookie banner"
+            },
+            {
+              text: "1 year"
+            }
           ]
         ]
       }) }}

--- a/server/views/eligibility-checker/how-certain.html
+++ b/server/views/eligibility-checker/how-certain.html
@@ -2,6 +2,38 @@
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
+
+{% block bodyStart %}
+  {% set html %}
+    <p class="govuk-body">By continuing to the next page, you are agreeing to us using essential cookies to make this service work</p>
+  {% endset %}
+
+  <form method="POST">
+    {{ govukCookieBanner({
+      ariaLabel: "Cookies on " + serviceName,
+      hidden: hideBanner,
+      messages: [
+        {
+          headingText: "Cookies on " + serviceName,
+          html: html,
+          actions: [
+            {
+              text: "Hide",
+              type: "submit",
+              name: "cookies",
+              value: true
+            },
+            {
+              text: "View cookies",
+              href: "/cookie-policy"
+            }
+          ]
+        }
+      ]
+    }) }}
+  </form>
+{% endblock %}
 
 {% block formContent %}
 

--- a/test/routes/eligibility-checker/how-certain.route.test.js
+++ b/test/routes/eligibility-checker/how-certain.route.test.js
@@ -18,6 +18,7 @@ describe('/eligibility-checker/how-certain route', () => {
     howCertain2: 'howCertain-2',
     continue: 'continue'
   }
+  const serviceName = 'Declare elephant ivory you intend to sell or hire out'
 
   let document
 
@@ -60,6 +61,14 @@ describe('/eligibility-checker/how-certain route', () => {
       expect(element).toBeTruthy()
       expect(TestHelper.getTextContent(element)).toEqual(
         'How certain are you that your item is exempt from the ivory ban?'
+      )
+    })
+
+    it('should have the correct cookie banner heading', () => {
+      const element = document.querySelector('.govuk-cookie-banner__heading')
+      expect(element).toBeTruthy()
+      expect(TestHelper.getTextContent(element)).toEqual(
+        `Cookies on ${serviceName}`
       )
     })
 


### PR DESCRIPTION
Created cookie banner.

Since the banner is not technically required as we are only using essential cookies. I've just added it to the start page (how-certain) to keep it simple. When hidden it creates a cookie which lasts 1 year. I've run this approach by everyone on the DSU & had no objections.