### PR TITLE
Updated page title to meet new accessiblity requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/views/layout.html
+++ b/server/views/layout.html
@@ -33,7 +33,7 @@
     Error: 
   {% endif %}
 
-  {{ pageTitle }} - Department for Environment, Food & Rural Affairs – GOV.UK
+  {{ pageTitle }} - {{ serviceName }} – GOV.UK
 {% endblock %}
 
 {% block beforeContent %}


### PR DESCRIPTION
IVORY-543: Update page title to meet accessibility review requirement from latest review

The page title (i.e. the text that appears when you hover over the browser tab) should include the service name is now in the following format:

page heading - service name - GOV.UK