### PR TITLE
Applied fix for file size error messages not appearing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "0.24.3",
+  "version": "0.24.4",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/utils/upload.js
+++ b/server/utils/upload.js
@@ -23,7 +23,8 @@ const checkForDuplicates = (payload, uploadData) => {
 
 const checkForFileSizeError = async (request, redisKey) => {
   const errors = []
-  if ((await RedisService.get(request, redisKey)) === 'true') {
+
+  if (await RedisService.get(request, redisKey)) {
     errors.push({
       name: 'files',
       text: `The file must be smaller than ${config.maximumFileSize}MB`


### PR DESCRIPTION
IVORY-419: Image and file uploads - "file too large" error message not appearing

While investigating IVORY-419 it was noticed that the "file too large" error message was no longer appearing. This was because the way the boolean values in Redis are saved has recently changed. This is now fixed - the "file too large" error does now appear, but it is unlikely that this has fixed the actual problem reported in IVORY-419, but further investigation of that issue will now be possible.