### PR TITLE
Fixed copy bug in why-is-item-rmi page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "0.24.20",
+  "version": "0.24.21",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/views/why-is-item-rmi.html
+++ b/server/views/why-is-item-rmi.html
@@ -14,7 +14,7 @@
 
       <p class="govuk-body" id="para1">Make your case in the text box below.</p>
 
-      <p class="govuk-body" id="para2">You can upload supporting documents later on in this service. If you’d prefer to make your case within these documents, use the text box to summarise any documents you want to upload.</p>
+      <p class="govuk-body" id="para2">You can upload supporting documents later in this service. If you’d prefer to make your case within these documents, use the text box to summarise any documents you want to upload.</p>
 
       {% set detailHtml %}
         <p class="govuk-body" id="para3">The item must have been made before 1 January 1918 and be:</p>

--- a/test/routes/why-is-item-rmi.route.test.js
+++ b/test/routes/why-is-item-rmi.route.test.js
@@ -93,7 +93,7 @@ describe('/why-is-item-rmi route', () => {
       _checkElement(
         document,
         elementIds.para2,
-        'You can upload supporting documents later on in this service. If you’d prefer to make your case within these documents, use the text box to summarise any documents you want to upload.'
+        'You can upload supporting documents later in this service. If you’d prefer to make your case within these documents, use the text box to summarise any documents you want to upload.'
       )
 
       _checkElement(


### PR DESCRIPTION
IVORY-548: Why RMI help text bug

Removed word 'on' from the copy to match the specification.