### PR TITLE
Legal halt page - added missing help text for S2 already certified applications

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "0.24.26",
+  "version": "0.24.27",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/routes/legal-responsibility.route.js
+++ b/server/routes/legal-responsibility.route.js
@@ -53,6 +53,9 @@ const _getContext = async request => {
   const certificateCancelledOrRevoked =
     "If we later find out that the information you’ve given is not accurate, the exemption certificate may be cancelled or 'revoked'."
 
+  const certificateCancelledOrRevokedAlredyCertified =
+    "If we later find out that the item has been damaged or altered, the exemption certificate is likely to be cancelled or 'revoked'. In this case a new application for an exemption certificate would have to be made before you can sell or hire out the item."
+
   if (!isSection2) {
     context.pageTitle =
       'Both the owner and applicant are jointly responsible for providing accurate information'
@@ -62,18 +65,16 @@ const _getContext = async request => {
       stopIfUnsure
     ]
   } else {
-    if (isAlreadyCertified) {
-      context.pageTitle =
-        'Both the owner and the person selling the certified item are jointly responsible for ensuring it remains exempt'
-    } else {
-      context.pageTitle =
-        'Both the owner and applicant are jointly responsible for providing accurate information'
-    }
+    context.pageTitle = isAlreadyCertified
+      ? 'Both the owner and the person selling the certified item are jointly responsible for ensuring it remains exempt'
+      : 'Both the owner and applicant are jointly responsible for providing accurate information'
 
     context.helpTextParas = [
       haveOwnerPermission,
       stopIfUnsure,
-      certificateCancelledOrRevoked
+      isAlreadyCertified
+        ? certificateCancelledOrRevokedAlredyCertified
+        : certificateCancelledOrRevoked
     ]
   }
 

--- a/test/routes/legal-responsibility.route.test.js
+++ b/test/routes/legal-responsibility.route.test.js
@@ -201,7 +201,7 @@ describe('/legal-responsibility route', () => {
         element = document.querySelector(`#${elementIds.helpTextPara3}`)
         expect(element).toBeTruthy()
         expect(TestHelper.getTextContent(element)).toEqual(
-          "If we later find out that the information you’ve given is not accurate, the exemption certificate may be cancelled or 'revoked'."
+          "If we later find out that the item has been damaged or altered, the exemption certificate is likely to be cancelled or 'revoked'. In this case a new application for an exemption certificate would have to be made before you can sell or hire out the item."
         )
       })
 


### PR DESCRIPTION
IVORY-552: S2 and already certified - Legal halt "help text" some content missing on FE

Some legal help text was missing for already certified S2 applications. This has been added.