### PR TITLE
CYA page - page section copy regression issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "0.24.37",
+  "version": "0.24.38",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/views/check-your-answers.html
+++ b/server/views/check-your-answers.html
@@ -36,7 +36,7 @@
       {% endif %}
 
       {% if not isAlreadyCertified %}
-        <h2 id="itemDescriptionSubHeading" class="govuk-heading-m">Why item qualifies for exemption</h2>
+        <h2 id="itemDescriptionSubHeading" class="govuk-heading-m">Description of the item</h2>
 
         {{ govukSummaryList({
           classes: 'govuk-!-margin-bottom-9',

--- a/test/routes/check-your-answers.route.test.js
+++ b/test/routes/check-your-answers.route.test.js
@@ -178,7 +178,7 @@ describe('/check-your-answers route', () => {
         _checkSubheading(
           document,
           elementIds.subHeadings.itemDescription,
-          'Why item qualifies for exemption'
+          'Description of the item'
         )
 
         _checkSummary(document, elementIds.summaries.itemDescription)
@@ -224,7 +224,7 @@ describe('/check-your-answers route', () => {
         _checkSubheading(
           document,
           elementIds.subHeadings.itemDescription,
-          'Why item qualifies for exemption'
+          'Description of the item'
         )
 
         _checkSummary(document, elementIds.summaries.itemDescription)


### PR DESCRIPTION
IVORY-558: Check your answers page - regression issue

Fixed a bug relating to the text displayed for one of the Check your answers page section headings.