### PR TITLE
Fixed third party bug caused by null owner address

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "0.24.41",
+  "version": "0.24.42",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/routes/save-record.route.js
+++ b/server/routes/save-record.route.js
@@ -234,14 +234,12 @@ const _getOwnerAndApplicantDetails = async request => {
     [DataVerseFieldName.OWNER_EMAIL]: ownerContactDetails
       ? ownerContactDetails.emailAddress
       : null,
-    [DataVerseFieldName.OWNER_ADDRESS]: _formatAddress(
-      ownerAddress,
-      ownerAddressInternational
-    ),
-    [DataVerseFieldName.OWNER_POSTCODE]: _getPostcode(
-      ownerAddress,
-      ownerAddressInternational
-    ),
+    [DataVerseFieldName.OWNER_ADDRESS]: ownerAddress
+      ? _formatAddress(ownerAddress, ownerAddressInternational)
+      : null,
+    [DataVerseFieldName.OWNER_POSTCODE]: ownerAddress
+      ? _getPostcode(ownerAddress, ownerAddressInternational)
+      : null,
     [DataVerseFieldName.APPLICANT_NAME]: applicantContactDetails.fullName,
     [DataVerseFieldName.APPLICANT_EMAIL]: applicantContactDetails.emailAddress,
     [DataVerseFieldName.APPLICANT_ADDRESS]: _formatAddress(


### PR DESCRIPTION
IVORY-587: Third party business - Confirmation page throwing 500 error

Fixed bug in third party journeys - when the item is owned by a business, there is not an owner address. Therefore, when formatting the owner address, we need to handle the fact that it may be null.