### PR TITLE
Fix bugs relating to missing HTML content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "0.25.5",
+  "version": "0.25.6",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/views/ivory-volume.html
+++ b/server/views/ivory-volume.html
@@ -54,12 +54,7 @@
             {
               value: options[2].label,
               text: options[2].label,
-              checked: options[2].checked
-            },
-            {
-              value: options[3].label,
-              text: options[3].label,
-              checked: options[3].checked,
+              checked: options[2].checked,
               conditional: {
                 html: otherHtml
               }

--- a/server/views/share-details-of-item.html
+++ b/server/views/share-details-of-item.html
@@ -17,7 +17,7 @@
 
       <ul class="govuk-list govuk-list--bullet" id="shareReasons">
         <li>information about the item from your application, such as the description</li>
-        <li>photographs of the item</li>
+        <li>photographs of the item declared in your application</li>
         <li>the outcome of your application</li>
         <li>this information once you have received the outcome of your application</li>
       </ul>

--- a/test/routes/share-details-of-item.test.js
+++ b/test/routes/share-details-of-item.test.js
@@ -101,7 +101,7 @@ describe('/who-owns-the-item route', () => {
       )
       expect(element).toBeTruthy()
       expect(TestHelper.getTextContent(element)).toEqual(
-        'photographs of the item'
+        'photographs of the item declared in your application'
       )
 
       element = document.querySelector(


### PR DESCRIPTION
IVORY-603: Share details of your item - Missing Content
IVORY-605: Ivory volume - Other reason - Text field NOT displaying 

Fixed a pair of issues where some HTML content wasn't appearing when it should have been.