### PR TITLE
Fixed problem generating submission reference at the beginning of the flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "0.25.6",
+  "version": "0.25.7",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/routes/eligibility-checker/how-certain.route.js
+++ b/server/routes/eligibility-checker/how-certain.route.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const RandomString = require('randomstring')
+
 const AnalyticsService = require('../../services/analytics.service')
 const RedisService = require('../../services/redis.service')
 
@@ -48,6 +50,14 @@ const handlers = {
         .code(400)
     }
 
+    const submissionReference = _generateSubmissionReference()
+
+    await RedisService.set(
+      request,
+      RedisKeys.SUBMISSION_REFERENCE,
+      submissionReference
+    )
+
     await RedisService.set(
       request,
       RedisKeys.USED_CHECKER,
@@ -87,6 +97,19 @@ const _validateForm = payload => {
     })
   }
   return errors
+}
+
+/**
+ * Generates a random 8 character uppercase alphanumeric reference
+ * @returns Reference
+ */
+const _generateSubmissionReference = () => {
+  return RandomString.generate({
+    length: 8,
+    readable: true,
+    charset: 'alphanumeric',
+    capitalization: 'uppercase'
+  })
 }
 
 module.exports = [

--- a/server/routes/home.route.js
+++ b/server/routes/home.route.js
@@ -1,28 +1,16 @@
 'use strict'
 
 const { v4: uuidv4 } = require('uuid')
-const RandomString = require('randomstring')
-
-const RedisService = require('../services/redis.service')
 
 const {
   HOME_URL,
   DEFRA_IVORY_SESSION_KEY,
-  Paths,
-  RedisKeys
+  Paths
 } = require('../utils/constants')
 
 const handlers = {
   get: async (request, h) => {
     _setCookieSessionId(h)
-
-    const submissionReference = _generateSubmissionReference()
-
-    await RedisService.set(
-      request,
-      RedisKeys.SUBMISSION_REFERENCE,
-      submissionReference
-    )
 
     return h.redirect(Paths.HOW_CERTAIN)
   }
@@ -30,19 +18,6 @@ const handlers = {
 
 const _setCookieSessionId = h => {
   h.state(DEFRA_IVORY_SESSION_KEY, uuidv4())
-}
-
-/**
- * Generates a random 8 character uppercase alphanumeric reference
- * @returns Reference
- */
-const _generateSubmissionReference = () => {
-  return RandomString.generate({
-    length: 8,
-    readable: true,
-    charset: 'alphanumeric',
-    capitalization: 'uppercase'
-  })
 }
 
 module.exports = [

--- a/test/routes/eligibility-checker/how-certain.route.test.js
+++ b/test/routes/eligibility-checker/how-certain.route.test.js
@@ -1,8 +1,13 @@
 'use strict'
 
+jest.mock('randomstring')
+const RandomString = require('randomstring')
+
 jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
+
 const TestHelper = require('../../utils/test-helper')
+const { RedisKeys } = require('../../../server/utils/constants')
 
 describe('/eligibility-checker/how-certain route', () => {
   let server
@@ -163,8 +168,13 @@ describe('/eligibility-checker/how-certain route', () => {
   })
 })
 
+const paymentReference = 'ABCDEF'
+
 const _createMocks = () => {
   TestHelper.createMocks()
+
+  RandomString.generate = jest.fn().mockReturnValue(paymentReference)
+  RedisService.get = jest.fn()
 }
 
 const _checkSelectedRadioAction = async (
@@ -180,7 +190,13 @@ const _checkSelectedRadioAction = async (
 
   const response = await TestHelper.submitPostRequest(server, postOptions)
 
-  expect(RedisService.set).toBeCalledTimes(1)
+  expect(RedisService.set).toBeCalledTimes(2)
+
+  expect(RedisService.set).toBeCalledWith(
+    expect.any(Object),
+    RedisKeys.SUBMISSION_REFERENCE,
+    paymentReference
+  )
 
   expect(RedisService.set).toBeCalledWith(
     expect.any(Object),

--- a/test/routes/home.route.test.js
+++ b/test/routes/home.route.test.js
@@ -1,13 +1,6 @@
 'use strict'
 
-jest.mock('randomstring')
-const RandomString = require('randomstring')
-
-jest.mock('../../server/services/redis.service')
-const RedisService = require('../../server/services/redis.service')
-
 const TestHelper = require('../utils/test-helper')
-const { RedisKeys } = require('../../server/utils/constants')
 
 describe('/ route', () => {
   let server
@@ -22,10 +15,6 @@ describe('/ route', () => {
     await server.stop()
   })
 
-  beforeEach(() => {
-    _createMocks()
-  })
-
   afterEach(() => {
     jest.clearAllMocks()
   })
@@ -37,32 +26,13 @@ describe('/ route', () => {
     }
 
     it('should redirect to the "How certain" route', async () => {
-      expect(RedisService.set).toBeCalledTimes(0)
-
       const response = await TestHelper.submitPostRequest(
         server,
         getOptions,
         302
       )
 
-      expect(RedisService.set).toBeCalledTimes(1)
-
-      expect(RedisService.set).toBeCalledWith(
-        expect.any(Object),
-        RedisKeys.SUBMISSION_REFERENCE,
-        paymentReference
-      )
-
       expect(response.headers.location).toEqual(nextUrl)
     })
   })
 })
-
-const paymentReference = 'ABCDEF'
-
-const _createMocks = () => {
-  TestHelper.createMocks()
-
-  RandomString.generate = jest.fn().mockReturnValue(paymentReference)
-  RedisService.get = jest.fn()
-}


### PR DESCRIPTION
IVORY-604:  Error after share details of item page

The generation of the submission reference has been moved to the beginning of the flow. But it can't be generated on the same page as when the session cookie is created, therefore it has been moved to the next page (/how-certain).