### PR TITLE
Clear out redundant Redis data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "0.25.12",
+  "version": "1.0.0",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/index.js
+++ b/server/index.js
@@ -88,7 +88,7 @@ const _checkSessionCookie = (request, h) => {
   ) {
     return h.continue
   } else {
-    if (!CookieService.checkSessionCookie(request)) {
+    if (!CookieService.getSessionCookie(request)) {
       return h.redirect(Paths.SESSION_TIMED_OUT).takeover()
     } else {
       return h.continue

--- a/server/routes/home.route.js
+++ b/server/routes/home.route.js
@@ -11,7 +11,7 @@ const {
 
 const handlers = {
   get: async (request, h) => {
-    const sessionKey = (request.state[DEFRA_IVORY_SESSION_KEY])
+    const sessionKey = request.state[DEFRA_IVORY_SESSION_KEY]
     if (sessionKey) {
       RedisService.deleteSessionData(request)
     }

--- a/server/routes/home.route.js
+++ b/server/routes/home.route.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { v4: uuidv4 } = require('uuid')
+const CookieService = require('../services/cookie.service')
 const RedisService = require('../services/redis.service')
 
 const {
@@ -11,8 +12,9 @@ const {
 
 const handlers = {
   get: async (request, h) => {
-    const sessionKey = request.state[DEFRA_IVORY_SESSION_KEY]
-    if (sessionKey) {
+    const hasSessionKey = CookieService.checkForSessionKey(request)
+
+    if (hasSessionKey) {
       RedisService.deleteSessionData(request)
     }
     _setCookieSessionId(h)

--- a/server/routes/home.route.js
+++ b/server/routes/home.route.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { v4: uuidv4 } = require('uuid')
+const RedisService = require('../services/redis.service')
 
 const {
   HOME_URL,
@@ -10,6 +11,10 @@ const {
 
 const handlers = {
   get: async (request, h) => {
+    const sessionKey = (request.state[DEFRA_IVORY_SESSION_KEY])
+    if (sessionKey) {
+      RedisService.deleteSessionData(request)
+    }
     _setCookieSessionId(h)
 
     return h.redirect(Paths.HOW_CERTAIN)

--- a/server/routes/home.route.js
+++ b/server/routes/home.route.js
@@ -12,9 +12,9 @@ const {
 
 const handlers = {
   get: async (request, h) => {
-    const hasSessionKey = CookieService.checkForSessionKey(request)
+    const sessionCookie = CookieService.getSessionCookie(request, false)
 
-    if (hasSessionKey) {
+    if (sessionCookie) {
       RedisService.deleteSessionData(request)
     }
     _setCookieSessionId(h)

--- a/server/routes/service-complete.route.js
+++ b/server/routes/service-complete.route.js
@@ -49,6 +49,8 @@ const handlers = {
       label: context.pageTitle
     })
 
+    RedisService.deleteSessionData(request)
+
     return h
       .view(Views.SERVICE_COMPLETE, {
         ...context

--- a/server/routes/upload-document.route.js
+++ b/server/routes/upload-document.route.js
@@ -9,7 +9,7 @@ const RedisService = require('../services/redis.service')
 const AntimalwareService = require('../services/antimalware.service')
 
 const config = require('../utils/config')
-const { Paths, RedisKeys, Views, Analytics, uploadDocument } = require('../utils/constants')
+const { Paths, RedisKeys, Views, Analytics, UploadDocument } = require('../utils/constants')
 const { buildErrorSummary } = require('../utils/validation')
 const { checkForDuplicates, checkForFileSizeError } = require('../utils/upload')
 
@@ -25,7 +25,7 @@ const handlers = {
     if (
       uploadData &&
       uploadData.files &&
-      uploadData.files.length >= uploadDocument.MAX_DOCUMENTS
+      uploadData.files.length >= UploadDocument.MAX_DOCUMENTS
     ) {
       return h.redirect(Paths.YOUR_DOCUMENTS)
     }
@@ -62,7 +62,7 @@ const handlers = {
     }
 
     if (!errors.length) {
-      if (filename.toUpperCase().endsWith(uploadDocument.PDF_EXTENSION)) {
+      if (filename.toUpperCase().endsWith(UploadDocument.PDF_EXTENSION)) {
         await _checkPdfEncryption(buffer, errors)
       }
     }
@@ -120,7 +120,7 @@ const _getContext = async request => {
     pageTitle: !hideHelpText
       ? 'Add evidence to support your case'
       : 'Add another file',
-    accept: uploadDocument.ALLOWED_EXTENSIONS.join(','),
+    accept: UploadDocument.ALLOWED_EXTENSIONS.join(','),
     fileListUrl: Paths.YOUR_DOCUMENTS,
     maximumFileSize: config.maximumFileSize
   }
@@ -132,7 +132,7 @@ const _validateForm = (payload, uploadData) => {
   if (
     payload.files &&
     Array.isArray(payload.files) &&
-    payload.files.length > uploadDocument.MAX_FILES_IN_REQUEST_PAYLOAD
+    payload.files.length > UploadDocument.MAX_FILES_IN_REQUEST_PAYLOAD
   ) {
     // Note that this error should never happen because in the HTML we have not specified the attributes of:
     // - multiple: true
@@ -153,7 +153,7 @@ const _validateForm = (payload, uploadData) => {
       text: 'The file cannot be empty'
     })
   } else if (
-    !uploadDocument.ALLOWED_EXTENSIONS.includes(
+    !UploadDocument.ALLOWED_EXTENSIONS.includes(
       path.extname(payload.files.filename).toUpperCase()
     )
   ) {

--- a/server/routes/upload-document.route.js
+++ b/server/routes/upload-document.route.js
@@ -9,21 +9,9 @@ const RedisService = require('../services/redis.service')
 const AntimalwareService = require('../services/antimalware.service')
 
 const config = require('../utils/config')
-const { Paths, RedisKeys, Views, Analytics } = require('../utils/constants')
+const { Paths, RedisKeys, Views, Analytics, uploadDocument } = require('../utils/constants')
 const { buildErrorSummary } = require('../utils/validation')
 const { checkForDuplicates, checkForFileSizeError } = require('../utils/upload')
-
-const MAX_DOCUMENTS = 6
-const MAX_FILES_IN_REQUEST_PAYLOAD = 1
-const PDF_EXTENSION = '.PDF'
-const ALLOWED_EXTENSIONS = [
-  '.DOC',
-  '.DOCX',
-  PDF_EXTENSION,
-  '.JPG',
-  '.JPEG',
-  '.PNG'
-]
 
 const handlers = {
   get: async (request, h) => {
@@ -37,7 +25,7 @@ const handlers = {
     if (
       uploadData &&
       uploadData.files &&
-      uploadData.files.length >= MAX_DOCUMENTS
+      uploadData.files.length >= uploadDocument.MAX_DOCUMENTS
     ) {
       return h.redirect(Paths.YOUR_DOCUMENTS)
     }
@@ -74,7 +62,7 @@ const handlers = {
     }
 
     if (!errors.length) {
-      if (filename.toUpperCase().endsWith(PDF_EXTENSION)) {
+      if (filename.toUpperCase().endsWith(uploadDocument.PDF_EXTENSION)) {
         await _checkPdfEncryption(buffer, errors)
       }
     }
@@ -132,7 +120,7 @@ const _getContext = async request => {
     pageTitle: !hideHelpText
       ? 'Add evidence to support your case'
       : 'Add another file',
-    accept: ALLOWED_EXTENSIONS.join(','),
+    accept: uploadDocument.ALLOWED_EXTENSIONS.join(','),
     fileListUrl: Paths.YOUR_DOCUMENTS,
     maximumFileSize: config.maximumFileSize
   }
@@ -144,7 +132,7 @@ const _validateForm = (payload, uploadData) => {
   if (
     payload.files &&
     Array.isArray(payload.files) &&
-    payload.files.length > MAX_FILES_IN_REQUEST_PAYLOAD
+    payload.files.length > uploadDocument.MAX_FILES_IN_REQUEST_PAYLOAD
   ) {
     // Note that this error should never happen because in the HTML we have not specified the attributes of:
     // - multiple: true
@@ -165,7 +153,7 @@ const _validateForm = (payload, uploadData) => {
       text: 'The file cannot be empty'
     })
   } else if (
-    !ALLOWED_EXTENSIONS.includes(
+    !uploadDocument.ALLOWED_EXTENSIONS.includes(
       path.extname(payload.files.filename).toUpperCase()
     )
   ) {

--- a/server/routes/upload-photo.route.js
+++ b/server/routes/upload-photo.route.js
@@ -11,14 +11,9 @@ const RedisService = require('../services/redis.service')
 const AntimalwareService = require('../services/antimalware.service')
 
 const config = require('../utils/config')
-const { Paths, RedisKeys, Views, Analytics } = require('../utils/constants')
+const { Paths, RedisKeys, Views, Analytics, uploadPhoto } = require('../utils/constants')
 const { buildErrorSummary } = require('../utils/validation')
 const { checkForDuplicates, checkForFileSizeError } = require('../utils/upload')
-
-const MAX_PHOTOS = 6
-const MAX_FILES_IN_REQUEST_PAYLOAD = 1
-const THUMBNAIL_WIDTH = 300
-const ALLOWED_EXTENSIONS = ['.JPG', '.JPEG', '.PNG']
 
 const handlers = {
   get: async (request, h) => {
@@ -29,7 +24,7 @@ const handlers = {
     if (
       uploadData &&
       uploadData.files &&
-      uploadData.files.length >= MAX_PHOTOS
+      uploadData.files.length >= uploadPhoto.MAX_PHOTOS
     ) {
       return h.redirect(Paths.YOUR_PHOTOS)
     }
@@ -92,7 +87,7 @@ const handlers = {
         uploadData.fileData.push(base64)
 
         const thumbnailBuffer = await sharp(buffer)
-          .resize(THUMBNAIL_WIDTH, null, {
+          .resize(uploadPhoto.THUMBNAIL_WIDTH, null, {
             withoutEnlargement: true
           })
           .toBuffer()
@@ -172,7 +167,7 @@ const _getContext = async request => {
     hideHelpText,
     uploadData,
     pageTitle: !hideHelpText ? 'Add a photo of your item' : 'Add another photo',
-    accept: ALLOWED_EXTENSIONS.join(','),
+    accept: uploadPhoto.ALLOWED_EXTENSIONS.join(','),
     fileListUrl: Paths.YOUR_PHOTOS,
     maximumFileSize: config.maximumFileSize
   }
@@ -184,7 +179,7 @@ const _validateForm = (payload, uploadData) => {
   if (
     payload.files &&
     Array.isArray(payload.files) &&
-    payload.files.length > MAX_FILES_IN_REQUEST_PAYLOAD
+    payload.files.length > uploadPhoto.MAX_FILES_IN_REQUEST_PAYLOAD
   ) {
     // Note that this error should never happen because in the HTML we have not specified the attributes of:
     // - multiple: true
@@ -205,7 +200,7 @@ const _validateForm = (payload, uploadData) => {
       text: 'The file cannot be empty'
     })
   } else if (
-    !ALLOWED_EXTENSIONS.includes(
+    !uploadPhoto.ALLOWED_EXTENSIONS.includes(
       path.extname(payload.files.filename).toUpperCase()
     )
   ) {

--- a/server/routes/upload-photo.route.js
+++ b/server/routes/upload-photo.route.js
@@ -11,7 +11,7 @@ const RedisService = require('../services/redis.service')
 const AntimalwareService = require('../services/antimalware.service')
 
 const config = require('../utils/config')
-const { Paths, RedisKeys, Views, Analytics, uploadPhoto } = require('../utils/constants')
+const { Paths, RedisKeys, Views, Analytics, UploadPhoto } = require('../utils/constants')
 const { buildErrorSummary } = require('../utils/validation')
 const { checkForDuplicates, checkForFileSizeError } = require('../utils/upload')
 
@@ -24,7 +24,7 @@ const handlers = {
     if (
       uploadData &&
       uploadData.files &&
-      uploadData.files.length >= uploadPhoto.MAX_PHOTOS
+      uploadData.files.length >= UploadPhoto.MAX_PHOTOS
     ) {
       return h.redirect(Paths.YOUR_PHOTOS)
     }
@@ -87,7 +87,7 @@ const handlers = {
         uploadData.fileData.push(base64)
 
         const thumbnailBuffer = await sharp(buffer)
-          .resize(uploadPhoto.THUMBNAIL_WIDTH, null, {
+          .resize(UploadPhoto.THUMBNAIL_WIDTH, null, {
             withoutEnlargement: true
           })
           .toBuffer()
@@ -167,7 +167,7 @@ const _getContext = async request => {
     hideHelpText,
     uploadData,
     pageTitle: !hideHelpText ? 'Add a photo of your item' : 'Add another photo',
-    accept: uploadPhoto.ALLOWED_EXTENSIONS.join(','),
+    accept: UploadPhoto.ALLOWED_EXTENSIONS.join(','),
     fileListUrl: Paths.YOUR_PHOTOS,
     maximumFileSize: config.maximumFileSize
   }
@@ -179,7 +179,7 @@ const _validateForm = (payload, uploadData) => {
   if (
     payload.files &&
     Array.isArray(payload.files) &&
-    payload.files.length > uploadPhoto.MAX_FILES_IN_REQUEST_PAYLOAD
+    payload.files.length > UploadPhoto.MAX_FILES_IN_REQUEST_PAYLOAD
   ) {
     // Note that this error should never happen because in the HTML we have not specified the attributes of:
     // - multiple: true
@@ -200,7 +200,7 @@ const _validateForm = (payload, uploadData) => {
       text: 'The file cannot be empty'
     })
   } else if (
-    !uploadPhoto.ALLOWED_EXTENSIONS.includes(
+    !UploadPhoto.ALLOWED_EXTENSIONS.includes(
       path.extname(payload.files.filename).toUpperCase()
     )
   ) {

--- a/server/services/cookie.service.js
+++ b/server/services/cookie.service.js
@@ -3,6 +3,10 @@
 const { DEFRA_IVORY_SESSION_KEY } = require('../utils/constants')
 
 module.exports = class CookieService {
+  static checkForSessionKey (request) {
+    return request.state[DEFRA_IVORY_SESSION_KEY]
+  }
+
   static checkSessionCookie (request) {
     const sessionCookie = request.state[DEFRA_IVORY_SESSION_KEY]
     if (!sessionCookie) {

--- a/server/services/cookie.service.js
+++ b/server/services/cookie.service.js
@@ -3,11 +3,7 @@
 const { DEFRA_IVORY_SESSION_KEY } = require('../utils/constants')
 
 module.exports = class CookieService {
-  static checkForSessionKey (request) {
-    return request.state[DEFRA_IVORY_SESSION_KEY]
-  }
-
-  static checkSessionCookie (request) {
+  static getSessionCookie (request, displayLogMessage = true) {
     const sessionCookie = request.state[DEFRA_IVORY_SESSION_KEY]
     if (!sessionCookie) {
       console.log(`Session cookie not found for page ${request.url.pathname}`)

--- a/server/services/redis.service.js
+++ b/server/services/redis.service.js
@@ -35,4 +35,18 @@ module.exports = class RedisService {
     const keyWithSessionId = `${request.state[DEFRA_IVORY_SESSION_KEY]}.${key}`
     client.del(keyWithSessionId)
   }
+
+  static deleteSessionData (request) {
+    const client = request.redis.client
+    const sessionKey = request.state[DEFRA_IVORY_SESSION_KEY]
+    client.keys(`${sessionKey}*`, function (err, keys) {
+      if (err) {
+        console.error(err)
+      } else {
+        for (let i = 0; i < keys.length; i++) {
+          client.del(keys[i])
+        }
+      }
+    })
+  }
 }

--- a/server/services/redis.service.js
+++ b/server/services/redis.service.js
@@ -47,7 +47,7 @@ module.exports = class RedisService {
       UploadPhoto.MAX_PHOTOS +
       UploadDocument.MAX_DOCUMENTS
 
-    const keys = await _getMatchingKeys()
+    const keys = await _getMatchingRedisKeys(request)
 
     if (keys.length > totalPossibleKeys) {
       // Mitigates against a malicious attack using this wildcard search to remove all Redis keys
@@ -77,7 +77,7 @@ const _isJsonString = value =>
  * @param {*} request The request containing the Redis cache
  * @returns An array of Redis keys that are prefixed with the session key
  */
-const _getMatchingKeys = async request => {
+const _getMatchingRedisKeys = async request => {
   const client = request.redis.client
   const sessionKey = request.state[DEFRA_IVORY_SESSION_KEY]
 

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -422,6 +422,27 @@ const StatusCodes = {
   SERVICE_UNAVAILABLE: 503
 }
 
+const uploadPhoto = {
+  MAX_PHOTOS: 6,
+  MAX_FILES_IN_REQUEST_PAYLOAD: 1,
+  THUMBNAIL_WIDTH: 300,
+  ALLOWED_EXTENSIONS: ['.JPG', '.JPEG', '.PNG']
+}
+
+const uploadDocument = {
+  MAX_DOCUMENTS: 6,
+  MAX_FILES_IN_REQUEST_PAYLOAD: 1,
+  PDF_EXTENSION: '.PDF',
+  ALLOWED_EXTENSIONS: [
+    '.DOC',
+    '.DOCX',
+    '.PDF',
+    '.JPG',
+    '.JPEG',
+    '.PNG'
+  ]
+}
+
 module.exports = Object.freeze({
   AddressType,
   AgeExemptionReasons,
@@ -443,6 +464,8 @@ module.exports = Object.freeze({
   PaymentResult,
   RedisKeys,
   StatusCodes,
+  uploadDocument,
+  uploadPhoto,
   Urls,
   Views,
   DEFRA_IVORY_SESSION_KEY: 'DefraIvorySession'

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -422,14 +422,14 @@ const StatusCodes = {
   SERVICE_UNAVAILABLE: 503
 }
 
-const uploadPhoto = {
+const UploadPhoto = {
   MAX_PHOTOS: 6,
   MAX_FILES_IN_REQUEST_PAYLOAD: 1,
   THUMBNAIL_WIDTH: 300,
   ALLOWED_EXTENSIONS: ['.JPG', '.JPEG', '.PNG']
 }
 
-const uploadDocument = {
+const UploadDocument = {
   MAX_DOCUMENTS: 6,
   MAX_FILES_IN_REQUEST_PAYLOAD: 1,
   PDF_EXTENSION: '.PDF',
@@ -464,8 +464,8 @@ module.exports = Object.freeze({
   PaymentResult,
   RedisKeys,
   StatusCodes,
-  uploadDocument,
-  uploadPhoto,
+  UploadDocument,
+  UploadPhoto,
   Urls,
   Views,
   DEFRA_IVORY_SESSION_KEY: 'DefraIvorySession'

--- a/test/routes/home.route.test.js
+++ b/test/routes/home.route.test.js
@@ -1,5 +1,11 @@
 'use strict'
 
+jest.mock('../../server/services/redis.service')
+const CookieService = require('../../server/services/cookie.service')
+
+jest.mock('../../server/services/redis.service')
+const RedisService = require('../../server/services/redis.service')
+
 const TestHelper = require('../utils/test-helper')
 
 describe('/ route', () => {
@@ -34,6 +40,28 @@ describe('/ route', () => {
       )
 
       expect(response.headers.location).toEqual(nextUrl)
+    })
+
+    it('should delete previous session data if there is any', async () => {
+      CookieService.checkForSessionKey = jest
+        .fn()
+        .mockReturnValue('THE SESSION KEY')
+
+      expect(RedisService.deleteSessionData).toBeCalledTimes(0)
+
+      await TestHelper.submitGetRequest(server, getOptions, 302, false)
+
+      expect(RedisService.deleteSessionData).toBeCalledTimes(1)
+    })
+
+    it("should NOT delete previous session data if there isn't any", async () => {
+      CookieService.checkForSessionKey = jest.fn().mockReturnValue(null)
+
+      expect(RedisService.deleteSessionData).toBeCalledTimes(0)
+
+      await TestHelper.submitGetRequest(server, getOptions, 302, false)
+
+      expect(RedisService.deleteSessionData).toBeCalledTimes(0)
     })
   })
 })

--- a/test/routes/home.route.test.js
+++ b/test/routes/home.route.test.js
@@ -26,10 +26,11 @@ describe('/ route', () => {
     }
 
     it('should redirect to the "How certain" route', async () => {
-      const response = await TestHelper.submitPostRequest(
+      const response = await TestHelper.submitGetRequest(
         server,
         getOptions,
-        302
+        302,
+        false
       )
 
       expect(response.headers.location).toEqual(nextUrl)

--- a/test/routes/home.route.test.js
+++ b/test/routes/home.route.test.js
@@ -43,7 +43,7 @@ describe('/ route', () => {
     })
 
     it('should delete previous session data if there is any', async () => {
-      CookieService.checkForSessionKey = jest
+      CookieService.getSessionCookie = jest
         .fn()
         .mockReturnValue('THE SESSION KEY')
 
@@ -55,7 +55,7 @@ describe('/ route', () => {
     })
 
     it("should NOT delete previous session data if there isn't any", async () => {
-      CookieService.checkForSessionKey = jest.fn().mockReturnValue(null)
+      CookieService.getSessionCookie = jest.fn().mockReturnValue(null)
 
       expect(RedisService.deleteSessionData).toBeCalledTimes(0)
 

--- a/test/services/cookie.service.test.js
+++ b/test/services/cookie.service.test.js
@@ -3,7 +3,7 @@
 const CookieService = require('../../server/services/cookie.service')
 
 describe('Cookie service', () => {
-  describe('checkSessionCookie method', () => {
+  describe('getSessionCookie method', () => {
     let mockRequest
 
     beforeEach(() => {
@@ -18,14 +18,14 @@ describe('Cookie service', () => {
     })
 
     it('should check and return the session cookie if it exists', async () => {
-      const cookie = CookieService.checkSessionCookie(mockRequest)
+      const cookie = CookieService.getSessionCookie(mockRequest)
 
       expect(cookie).toEqual(mockRequest.state.DefraIvorySession)
     })
 
     it("should check and return a null session cookie if it doesn't exist", async () => {
       mockRequest.state.DefraIvorySession = null
-      const cookie = CookieService.checkSessionCookie(mockRequest)
+      const cookie = CookieService.getSessionCookie(mockRequest)
 
       expect(cookie).toBeNull()
     })

--- a/test/services/redis.service.test.js
+++ b/test/services/redis.service.test.js
@@ -78,7 +78,7 @@ describe('Redis service', () => {
     })
 
     it('should get a string from Redis when it looks like a JSON object but it cannot be parsed', async () => {
-      const mockValue = '{"partial-json-object'
+      const mockValue = '{invalid-json-object}'
 
       _createMocks(mockValue)
 

--- a/test/services/redis.service.test.js
+++ b/test/services/redis.service.test.js
@@ -68,7 +68,6 @@ describe('Redis service', () => {
       expect(mockRequest.redis.client.get).toBeCalledTimes(0)
 
       const redisValue = await RedisService.get(mockRequest, redisKey)
-      console.log(redisValue)
 
       expect(redisValue).toEqual(mockValue)
 

--- a/test/services/redis.service.test.js
+++ b/test/services/redis.service.test.js
@@ -85,7 +85,7 @@ describe('Redis service', () => {
       _createMocks(mockRedisValue)
     })
 
-    it('should delete a value from Redis', async () => {
+    it('should not delete a value from Redis', async () => {
       expect(mockRequest.redis.client.keys).toBeCalledTimes(0)
       expect(mockRequest.redis.client.del).toBeCalledTimes(0)
 

--- a/test/services/redis.service.test.js
+++ b/test/services/redis.service.test.js
@@ -79,6 +79,22 @@ describe('Redis service', () => {
       )
     })
   })
+
+  describe('deleteSessionData method', () => {
+    beforeEach(() => {
+      _createMocks(mockRedisValue)
+    })
+
+    it('should delete a value from Redis', async () => {
+      expect(mockRequest.redis.client.keys).toBeCalledTimes(0)
+      expect(mockRequest.redis.client.del).toBeCalledTimes(0)
+
+      await RedisService.deleteSessionData(mockRequest)
+
+      expect(mockRequest.redis.client.keys).toBeCalledTimes(1)
+      expect(mockRequest.redis.client.del).toBeCalledTimes(0)
+    })
+  })
 })
 
 const mockRedisValue = 'MOCK REDIS VALUE'
@@ -92,7 +108,8 @@ const _createMocks = mockValue => {
     client: {
       del: jest.fn(),
       get: jest.fn(() => mockValue),
-      setex: jest.fn()
+      setex: jest.fn(),
+      keys: jest.fn()
     }
   }
 }

--- a/test/services/redis.service.test.js
+++ b/test/services/redis.service.test.js
@@ -142,8 +142,8 @@ describe('Redis service', () => {
 
       await RedisService.deleteSessionData(mockRequest)
 
-      expect(mockRequest.redis.client.scan).toBeCalledTimes(1)
-      expect(mockRequest.redis.client.del).toBeCalledTimes(3)
+      expect(mockRequest.redis.client.scan).toBeCalledTimes(2)
+      expect(mockRequest.redis.client.del).toBeCalledTimes(6)
     })
   })
 })
@@ -160,7 +160,16 @@ const _createMocks = mockValue => {
       del: jest.fn(),
       get: jest.fn(() => mockValue),
       setex: jest.fn(),
-      scan: jest.fn(() => ['0', ['redis_key_1', 'redis_key_2', 'redis_key_n']])
+      scan: jest
+        .fn()
+        .mockReturnValueOnce([
+          '33',
+          ['redis_key_1', 'redis_key_2', 'redis_key_3']
+        ])
+        .mockReturnValueOnce([
+          '0',
+          ['redis_key_4', 'redis_key_5', 'redis_key_n']
+        ])
     }
   }
 }

--- a/test/services/redis.service.test.js
+++ b/test/services/redis.service.test.js
@@ -136,14 +136,14 @@ describe('Redis service', () => {
       _createMocks(mockRedisValue)
     })
 
-    it('should not delete a value from Redis', async () => {
-      expect(mockRequest.redis.client.keys).toBeCalledTimes(0)
+    it('should delete values from Redis', async () => {
+      expect(mockRequest.redis.client.scan).toBeCalledTimes(0)
       expect(mockRequest.redis.client.del).toBeCalledTimes(0)
 
       await RedisService.deleteSessionData(mockRequest)
 
-      expect(mockRequest.redis.client.keys).toBeCalledTimes(1)
-      expect(mockRequest.redis.client.del).toBeCalledTimes(0)
+      expect(mockRequest.redis.client.scan).toBeCalledTimes(1)
+      expect(mockRequest.redis.client.del).toBeCalledTimes(3)
     })
   })
 })
@@ -160,7 +160,7 @@ const _createMocks = mockValue => {
       del: jest.fn(),
       get: jest.fn(() => mockValue),
       setex: jest.fn(),
-      keys: jest.fn()
+      scan: jest.fn(() => ['0', ['redis_key_1', 'redis_key_2', 'redis_key_n']])
     }
   }
 }

--- a/test/services/redis.service.test.js
+++ b/test/services/redis.service.test.js
@@ -77,6 +77,23 @@ describe('Redis service', () => {
       )
     })
 
+    it('should get a string from Redis when it looks like a JSON object but it cannot be parsed', async () => {
+      const mockValue = '{"partial-json-object'
+
+      _createMocks(mockValue)
+
+      expect(mockRequest.redis.client.get).toBeCalledTimes(0)
+
+      const redisValue = await RedisService.get(mockRequest, redisKey)
+
+      expect(redisValue).toEqual(mockValue)
+
+      expect(mockRequest.redis.client.get).toBeCalledTimes(1)
+      expect(mockRequest.redis.client.get).toBeCalledWith(
+        `${sessionId}.${redisKey}`
+      )
+    })
+
     it('should return null if the key is not found in Redis', async () => {
       _createMocks(null)
 

--- a/test/utils/test-helper.js
+++ b/test/utils/test-helper.js
@@ -23,7 +23,7 @@ module.exports = class TestHelper {
     AnalyticsService.sendEvent = jest.fn()
 
     jest.mock('../../server/services/cookie.service')
-    CookieService.checkSessionCookie = jest
+    CookieService.getSessionCookie = jest
       .fn()
       .mockReturnValue('THE_SESSION_COOKIE')
 


### PR DESCRIPTION
IVORY-621: Clear out redundant Redis data

This clears out the Redis cache for a session when the user completes the journey & also if the user was to get partially through the journey and then start again.

The Redis data has a Time to Live (TTL) of 24 hours, but if a user journey is completed or restarted then any data in Redis for that user no longer has any purpose and takes up valuable storage, therefore it is now removed using the Redis SCAN command.