### PR TITLE
Fixed problem with fields only containing numeric characters

### DIFF
--- a/server/services/redis.service.js
+++ b/server/services/redis.service.js
@@ -10,15 +10,13 @@ module.exports = class RedisService {
       `${request.state[DEFRA_IVORY_SESSION_KEY]}.${key}`
     )
 
-    let parsedValue
-    if (redisValue !== null) {
+    let parsedValue = redisValue
+    if (_isJsonString(redisValue)) {
       try {
         parsedValue = JSON.parse(redisValue)
       } catch (e) {
         parsedValue = redisValue
       }
-    } else {
-      parsedValue = null
     }
 
     return parsedValue
@@ -36,3 +34,6 @@ module.exports = class RedisService {
     client.del(keyWithSessionId)
   }
 }
+
+const _isJsonString = value =>
+  value && value.length && value.startsWith('{') && value.endsWith('}')


### PR DESCRIPTION
IVORY-622: Error after payment page: 3rd party RMI application

There was an issue with the Redis Service that is causing the issue.

In RedisService.get we are returning a string from the Redis cache and then we are trying to Json.parse it back into an object, but if the value is a number, e.g. ‘123’ then the Json.parse function was converting it from the string into a number 123, which then bombed out the WebApi call on that field.

This has been changed so that now the Redis Service only parses the strings coming out of the cache if they are JSON objects.