### PR TITLE
Emails not sent to third party business owner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/routes/service-complete.route.js
+++ b/server/routes/service-complete.route.js
@@ -260,7 +260,9 @@ const _sendSection2OwnerEmailThirdParty = context => {
   const recipientEmail = context.ownerContactDetails.emailAddress
   const payload = {
     submissionReference: context.submissionReference,
-    fullName: context.ownerContactDetails.fullName
+    fullName:
+      context.ownerContactDetails.fullName ||
+      context.ownerContactDetails.businessName
   }
 
   _sendEmail(templateId, recipientEmail, payload)

--- a/server/routes/service-complete.route.js
+++ b/server/routes/service-complete.route.js
@@ -272,7 +272,9 @@ const _sendSection2OwnerEmailThirdPartyResale = context => {
   const templateId = config.govNotifyTemplateSection2OwnerEmailThirdPartyResale
   const recipientEmail = context.ownerContactDetails.emailAddress
   const payload = {
-    fullName: context.ownerContactDetails.fullName,
+    fullName:
+      context.ownerContactDetails.fullName ||
+      context.ownerContactDetails.businessName,
     certificateNumber: context.certificateNumber
   }
 

--- a/server/routes/service-complete.route.js
+++ b/server/routes/service-complete.route.js
@@ -272,9 +272,7 @@ const _sendSection2OwnerEmailThirdPartyResale = context => {
   const templateId = config.govNotifyTemplateSection2OwnerEmailThirdPartyResale
   const recipientEmail = context.ownerContactDetails.emailAddress
   const payload = {
-    fullName:
-      context.ownerContactDetails.fullName ||
-      context.ownerContactDetails.businessName,
+    fullName: context.ownerContactDetails.fullName,
     certificateNumber: context.certificateNumber
   }
 
@@ -299,7 +297,10 @@ const _sendSection10OwnerEmail = context => {
   const recipientEmail = context.ownerContactDetails.emailAddress
   const payload = {
     submissionReference: context.submissionReference,
-    fullName: context.ownerContactDetails.fullName,
+    fullName:
+      context.ownerContactDetails.fullName ||
+      context.ownerContactDetails.businessName,
+
     exemptionType: context.itemType
   }
 


### PR DESCRIPTION
IVORY-618: Emails not sent to third party business owner

Section 2 and Section 10 emails were not being sent to the owner when the owner is a business and the application is being made by a third party (i.e. not the applicant).

The reason is that in this situation the fullName field is blank, instead we have to use the businessName field.