### PR TITLE
Fixed Redis array issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/services/redis.service.js
+++ b/server/services/redis.service.js
@@ -36,4 +36,7 @@ module.exports = class RedisService {
 }
 
 const _isJsonString = value =>
-  value && value.length && value.startsWith('{') && value.endsWith('}')
+  value &&
+  value.length &&
+  ((value.startsWith('{') && value.endsWith('}')) ||
+    (value.startsWith('[') && value.endsWith(']')))

--- a/test/services/redis.service.test.js
+++ b/test/services/redis.service.test.js
@@ -78,6 +78,32 @@ describe('Redis service', () => {
       )
     })
 
+    it('should get a JSON-encoded array object from Redis', async () => {
+      const mockValue = [
+        {
+          key1: 'VALUE 1',
+          key2: 'VALUE 2'
+        },
+        {
+          key1: 'VALUE 3',
+          key2: 'VALUE 4'
+        }
+      ]
+
+      _createMocks(JSON.stringify(mockValue))
+
+      expect(mockRequest.redis.client.get).toBeCalledTimes(0)
+
+      const redisValue = await RedisService.get(mockRequest, redisKey)
+
+      expect(redisValue).toEqual(mockValue)
+
+      expect(mockRequest.redis.client.get).toBeCalledTimes(1)
+      expect(mockRequest.redis.client.get).toBeCalledWith(
+        `${sessionId}.${redisKey}`
+      )
+    })
+
     it('should return null if the key is not found in Redis', async () => {
       _createMocks(null)
 


### PR DESCRIPTION
IVORY-627: Address find broken

A recent fix to the Redis cache introduced a problem with arrays of objects not being returned properly. The problem manifested itself when performing an address search. This change fixes that issue.
