### PR TITLE
Provide direct access to eligibility checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/index.js
+++ b/server/index.js
@@ -5,7 +5,11 @@ const Bcrypt = require('bcrypt')
 
 const config = require('./utils/config')
 const { options } = require('./utils/cookie-config')
-const { DEFRA_IVORY_SESSION_KEY, Paths } = require('./utils/constants')
+const {
+  DEFRA_IVORY_SESSION_KEY,
+  HOME_URL,
+  Paths
+} = require('./utils/constants')
 
 const CookieService = require('./services/cookie.service')
 
@@ -74,7 +78,8 @@ const _registerPlugins = async server => {
 const _checkSessionCookie = (request, h) => {
   const pathname = request.url.pathname
   const excludeCookieCheckUrls = [
-    '/',
+    HOME_URL,
+    Paths.USE_CHECKER,
     Paths.SERVICE_STATUS,
     Paths.SESSION_TIMED_OUT
   ]

--- a/server/routes/home.route.js
+++ b/server/routes/home.route.js
@@ -5,13 +5,15 @@ const CookieService = require('../services/cookie.service')
 const RedisService = require('../services/redis.service')
 
 const {
-  HOME_URL,
   DEFRA_IVORY_SESSION_KEY,
-  Paths
+  Paths,
+  HOME_URL
 } = require('../utils/constants')
 
 const handlers = {
   get: async (request, h) => {
+    const useChecker = request.query.useChecker
+
     const sessionCookie = CookieService.getSessionCookie(request, false)
 
     if (sessionCookie) {
@@ -19,7 +21,9 @@ const handlers = {
     }
     _setCookieSessionId(h)
 
-    return h.redirect(Paths.HOW_CERTAIN)
+    return useChecker
+      ? h.redirect(Paths.CONTAIN_ELEPHANT_IVORY)
+      : h.redirect(Paths.HOW_CERTAIN)
   }
 }
 

--- a/server/routes/use-checker.route.js
+++ b/server/routes/use-checker.route.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const { HOME_URL, Paths } = require('../utils/constants')
+
+const handlers = {
+  get: async (request, h) => {
+    return h.redirect(`${HOME_URL}?useChecker=true`)
+  }
+}
+
+module.exports = [
+  {
+    method: 'GET',
+    path: Paths.USE_CHECKER,
+    handler: handlers.get
+  }
+]

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -292,6 +292,7 @@ const Paths = {
   UPLOAD_DOCUMENT: '/upload-document',
   UPLOAD_PHOTO: '/upload-photo',
   UPLOAD_TIMEOUT: '/errors/upload-timeout',
+  USE_CHECKER: '/use-checker',
   WHAT_CAPACITY: '/what-capacity',
   WANT_TO_ADD_DOCUMENTS: '/want-to-add-documents',
   WHAT_TYPE_OF_ITEM_IS_IT: '/what-type-of-item-is-it',
@@ -433,14 +434,7 @@ const UploadDocument = {
   MAX_DOCUMENTS: 6,
   MAX_FILES_IN_REQUEST_PAYLOAD: 1,
   PDF_EXTENSION: '.PDF',
-  ALLOWED_EXTENSIONS: [
-    '.DOC',
-    '.DOCX',
-    '.PDF',
-    '.JPG',
-    '.JPEG',
-    '.PNG'
-  ]
+  ALLOWED_EXTENSIONS: ['.DOC', '.DOCX', '.PDF', '.JPG', '.JPEG', '.PNG']
 }
 
 module.exports = Object.freeze({

--- a/test/routes/home.route.test.js
+++ b/test/routes/home.route.test.js
@@ -12,6 +12,7 @@ describe('/ route', () => {
   let server
   const url = '/'
   const nextUrl = '/eligibility-checker/how-certain'
+  const nextUrlUseChecker = '/eligibility-checker/contain-elephant-ivory'
 
   beforeAll(async () => {
     server = await TestHelper.createServer()
@@ -40,6 +41,21 @@ describe('/ route', () => {
       )
 
       expect(response.headers.location).toEqual(nextUrl)
+    })
+
+    it('should redirect to the "Contain ivory" route when the useChecker querystring parameter is set', async () => {
+      const getOptionsUseChecker = {
+        method: 'GET',
+        url: '/?useChecker=true'
+      }
+      const response = await TestHelper.submitGetRequest(
+        server,
+        getOptionsUseChecker,
+        302,
+        false
+      )
+
+      expect(response.headers.location).toEqual(nextUrlUseChecker)
     })
 
     it('should delete previous session data if there is any', async () => {

--- a/test/routes/use-checker.route.test.js
+++ b/test/routes/use-checker.route.test.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const TestHelper = require('../utils/test-helper')
+
+describe('/ route', () => {
+  let server
+  const url = '/use-checker'
+  const nextUrl = '/?useChecker=true'
+
+  beforeAll(async () => {
+    server = await TestHelper.createServer()
+  })
+
+  afterAll(async () => {
+    await server.stop()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('GET', () => {
+    const getOptions = {
+      method: 'GET',
+      url
+    }
+
+    it('should redirect to the home screen with the useChecker querystring parameter', async () => {
+      const response = await TestHelper.submitGetRequest(
+        server,
+        getOptions,
+        302,
+        false
+      )
+
+      expect(response.headers.location).toEqual(nextUrl)
+    })
+  })
+})


### PR DESCRIPTION
IVORY-628: Provide direct access to eligibility checker

Added new **/use-checker** route to allow users to directly access the eligibility checker without having to explicitly visit the home screen.

When they visit **/use-checker** 
they are re-directed to the home screen with a querystring parameter: **/?useChecker=true**

When the user arrives at the home screen with the querystring parameter set, this creates the session cookie and then redirects them straight into the eligibility checker.