### PR TITLE
Add Redis values that were missing due to new /use-checker route

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/routes/eligibility-checker/contain-elephant-ivory.route.js
+++ b/server/routes/eligibility-checker/contain-elephant-ivory.route.js
@@ -11,7 +11,10 @@ const {
   Analytics
 } = require('../../utils/constants')
 const { buildErrorSummary, Validators } = require('../../utils/validation')
-const { getStandardOptions } = require('../../utils/general')
+const {
+  getStandardOptions,
+  generateSubmissionReference
+} = require('../../utils/general')
 
 const handlers = {
   get: (request, h) => {
@@ -51,6 +54,23 @@ const handlers = {
     if (payload.containElephantIvory === Options.NO) {
       await RedisService.set(request, RedisKeys.ARE_YOU_A_MUSEUM, false)
     }
+
+    let submissionReference = await RedisService.get(
+      request,
+      RedisKeys.SUBMISSION_REFERENCE
+    )
+
+    if (!submissionReference) {
+      submissionReference = generateSubmissionReference()
+
+      await RedisService.set(
+        request,
+        RedisKeys.SUBMISSION_REFERENCE,
+        submissionReference
+      )
+    }
+
+    await RedisService.set(request, RedisKeys.USED_CHECKER, true)
 
     AnalyticsService.sendEvent(request, {
       category: Analytics.Category.ELIGIBILITY_CHECKER,

--- a/server/routes/eligibility-checker/how-certain.route.js
+++ b/server/routes/eligibility-checker/how-certain.route.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const RandomString = require('randomstring')
-
 const AnalyticsService = require('../../services/analytics.service')
 const RedisService = require('../../services/redis.service')
 
 const { Analytics, Paths, Views, RedisKeys } = require('../../utils/constants')
 const { buildErrorSummary, Validators } = require('../../utils/validation')
+
+const { generateSubmissionReference } = require('../../utils/general')
 
 const completelyCertain = 'Completely'
 
@@ -50,7 +50,7 @@ const handlers = {
         .code(400)
     }
 
-    const submissionReference = _generateSubmissionReference()
+    const submissionReference = generateSubmissionReference()
 
     await RedisService.set(
       request,
@@ -97,19 +97,6 @@ const _validateForm = payload => {
     })
   }
   return errors
-}
-
-/**
- * Generates a random 8 character uppercase alphanumeric reference
- * @returns Reference
- */
-const _generateSubmissionReference = () => {
-  return RandomString.generate({
-    length: 8,
-    readable: true,
-    charset: 'alphanumeric',
-    capitalization: 'uppercase'
-  })
 }
 
 module.exports = [

--- a/server/utils/general.js
+++ b/server/utils/general.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const RandomString = require('randomstring')
+
 const { ItemType, Options } = require('./constants')
 
 const MUSICAL_PERCENTAGE = 20
@@ -65,10 +67,24 @@ const PNG_IMAGE_REGEXP = /^iVBORw0KGgo/g
 // if it is PNG or JPEG.
 const isPngImage = imageBase64 => imageBase64.match(PNG_IMAGE_REGEXP) !== null
 
+/**
+ * Generates a random 8 character uppercase alphanumeric reference
+ * @returns Reference
+ */
+const generateSubmissionReference = () => {
+  return RandomString.generate({
+    length: 8,
+    readable: true,
+    charset: 'alphanumeric',
+    capitalization: 'uppercase'
+  })
+}
+
 module.exports = {
   addPayloadToContext,
   convertToCommaSeparatedTitleCase,
   formatNumberWithCommas,
+  generateSubmissionReference,
   getIvoryVolumePercentage,
   getStandardOptions,
   isPngImage

--- a/test/routes/eligibility-checker/contain-elephant-ivory.route.test.js
+++ b/test/routes/eligibility-checker/contain-elephant-ivory.route.test.js
@@ -1,7 +1,11 @@
 'use strict'
 
+jest.mock('randomstring')
+const RandomString = require('randomstring')
+
 jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
+
 const TestHelper = require('../../utils/test-helper')
 const { Options, RedisKeys } = require('../../../server/utils/constants')
 
@@ -214,7 +218,7 @@ const _checkSelectedRadioAction = async (
   const response = await TestHelper.submitPostRequest(server, postOptions)
 
   expect(RedisService.set).toBeCalledTimes(
-    selectedOption === Options.NO ? 2 : 1
+    selectedOption === Options.NO ? 4 : 3
   )
 
   expect(RedisService.set).toBeCalledWith(
@@ -231,9 +235,26 @@ const _checkSelectedRadioAction = async (
     )
   }
 
+  expect(RedisService.set).toBeCalledWith(
+    expect.any(Object),
+    RedisKeys.SUBMISSION_REFERENCE,
+    submissionReference
+  )
+
+  expect(RedisService.set).toBeCalledWith(
+    expect.any(Object),
+    RedisKeys.USED_CHECKER,
+    true
+  )
+
   expect(response.headers.location).toEqual(nextUrl)
 }
 
+const submissionReference = 'ABCDEF'
+
 const _createMocks = () => {
   TestHelper.createMocks()
+
+  RedisService.get = jest.fn().mockResolvedValue(null)
+  RandomString.generate = jest.fn().mockReturnValue(submissionReference)
 }

--- a/test/routes/eligibility-checker/how-certain.route.test.js
+++ b/test/routes/eligibility-checker/how-certain.route.test.js
@@ -168,12 +168,12 @@ describe('/eligibility-checker/how-certain route', () => {
   })
 })
 
-const paymentReference = 'ABCDEF'
+const submissionReference = 'ABCDEF'
 
 const _createMocks = () => {
   TestHelper.createMocks()
 
-  RandomString.generate = jest.fn().mockReturnValue(paymentReference)
+  RandomString.generate = jest.fn().mockReturnValue(submissionReference)
   RedisService.get = jest.fn()
 }
 
@@ -195,7 +195,7 @@ const _checkSelectedRadioAction = async (
   expect(RedisService.set).toBeCalledWith(
     expect.any(Object),
     RedisKeys.SUBMISSION_REFERENCE,
-    paymentReference
+    submissionReference
   )
 
   expect(RedisService.set).toBeCalledWith(

--- a/test/utils/general.test.js
+++ b/test/utils/general.test.js
@@ -1,7 +1,11 @@
 'use strict'
 
+jest.mock('randomstring')
+const RandomString = require('randomstring')
+
 const {
-  convertToCommaSeparatedTitleCase
+  convertToCommaSeparatedTitleCase,
+  generateSubmissionReference
 } = require('../../server/utils/general')
 
 describe('General utils', () => {
@@ -24,6 +28,15 @@ describe('General utils', () => {
       expect(
         convertToCommaSeparatedTitleCase('THE\r\nQUICK\r\nBROWN\r\nFOX')
       ).toEqual('The, Quick, Brown, Fox')
+    })
+  })
+
+  describe('generateSubmissionReference method', () => {
+    it('should generate a random submission reference', () => {
+      const submissionReference = 'ABCDEF'
+      RandomString.generate = jest.fn().mockReturnValue(submissionReference)
+
+      expect(generateSubmissionReference()).toEqual(submissionReference)
     })
   })
 })


### PR DESCRIPTION
IVORY-629: Using Direct Eligibility checker link - 500 error after declaration page

Added values to Redis that are bypassed when coming in via the new /use-checker route, instead of coming in via /eligibility-checker/how-certain.

Method:

Look up the submission reference - this may have already been set in the previous screen. If not, i.e. the user came in via the new /use-checker route, then generate the submission reference and store in Redis.

Set the used-checker flag to true - this will not have been set on the previous screen if the user has come in via the new /use-checker route.