### PR TITLE
Make Redis Time to Live (TTL) configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,8 @@ REDIS_PORT=6379
 #REDIS_PASSWORD=
 #REDIS_USE_TLS=
 
-# The configuration for Session tracking
+# The configuration for Session tracking and Redis cache Time to Live (TTL).
+# This must be a whole number of hours i.e. COOKIE_TIMEOUT / 1000 / 3600 must be a whole number
 COOKIE_TIMEOUT=86400000
 #COOKIE_VALIDATION_PASSWORD=
 

--- a/README.md
+++ b/README.md
@@ -152,49 +152,49 @@ It's defined as a build task and can be run using `npm run lint`.
 
 The default values will be used if the environment variables are missing or commented out.
 
-| name                                                         | description                  | required | default               |               valid                |
-| ------------------------------------------------------------ | ---------------------------- | :------: | --------------------- | :--------------------------------: |
-| NODE_ENV                                                     | Node environment             |    no    |                       |    development,test,production     |
-| SERVICE_HOST                                                 | Application's URL            |   yes    | http://localhost:3000 |    development,test,production     |
-| SERVICE_PORT                                                 | Port number                  |    no    | 3000                  |                                    |
-| SERVICE_NAME                                                 | Name of the service          |    no    |                       |             Any string             |
-| LOG_LEVEL                                                    | The level of logging         |    no    | warn                  |            warn, debug             |
-| REQUEST_TIMEOUT                                              | Timeout (in milliseconds)    |    no    |                       |            Any integer             |
-| REDIS_HOST                                                   | Redis server IP address      |    no    | localhost             |                                    |
-| REDIS_PORT                                                   | Redis port number            |    no    | 6379                  |                                    |
-| REDIS_PASSWORD                                               | Redis password               |    no    |                       |                                    |
-| REDIS_USE_TLS                                                | Enable/disable SSL/TLS       |    no    |                       |             true,false             |
-| COOKIE_TIMEOUT                                               | Session cookie life in ms    |   yes    | 86400000              |            Any integer             |
-| COOKIE_VALIDATION_PASSWORD                                   | Cookie encoding password     |   yes    |                       |             Any string             |
-| DATAVERSE_AUTHORITY_HOST_URL                                 | Back office Dataverse        |   yes    |                       |                                    |
-| DATAVERSE_TENANT                                             | Back office Dataverse        |   yes    |                       |                                    |
-| DATAVERSE_CLIENT_ID                                          | Back office Dataverse        |   yes    |                       |                                    |
-| DATAVERSE_CLIENT_SECRET                                      | Back office Dataverse        |   yes    |                       |                                    |
-| DATAVERSE_RESOURCE                                           | Back office Dataverse        |   yes    |                       |                                    |
-| DATAVERSE_API_ENDPOINT                                       | Back office Dataverse        |   yes    |                       |     For example: api/data/v9.1     |
-| ADDRESS_LOOKUP_ENABLED                                       | Enable/disable address API   |    no    | false                 |             true,false             |
-| ADDRESS_LOOKUP_URL                                           | Address lookup URL           |    no    | http://some-url       |                                    |
-| ADDRESS_LOOKUP_PASSPHRASE                                    | Address lookup passphrase    |    no    |                       |                                    |
-| ADDRESS_LOOKUP_PFX_CERT                                      | Address lookup certificate   |    no    |                       | PFX file location or Base64 string |
-| GOV_NOTIFY_KEY                                               | Gov Notify config            |   yes    |                       |                                    |
-| GOV_NOTIFY_TEMPLATE_SECTION_10_APPLICANT_CONFIRMATION        | Gov Notify email template ID |   yes    |                       |                                    |
-| GOV_NOTIFY_TEMPLATE_SECTION_10_OWNER_CONFIRMATION            | Gov Notify email template ID |   yes    |                       |                                    |
-| GOV_NOTIFY_TEMPLATE_SECTION_2_APPLICANT_CONFIRMATION         | Gov Notify email template ID |   yes    |                       |                                    |
-| GOV_NOTIFY_TEMPLATE_SECTION_2_OWNER_EMAIL_THIRD_PARTY        | Gov Notify email template ID |   yes    |                       |                                    |
-| GOV_NOTIFY_TEMPLATE_SECTION_2_OWNER_EMAIL_THIRD_PARTY_RESALE | Gov Notify email template ID |   yes    |                       |                                    |
-| GOV_NOTIFY_TEMPLATE_SECTION_2_RESALE_APPLICANT_CONFIRMATION  | Gov Notify email template ID |   yes    |                       |                                    |
-| PAYMENT_ENABLED                                              | Gov Pay config               |   yes    | false                 |  true,false (currently not used)   |
-| PAYMENT_URL                                                  | Gov Pay config               |   yes    |                       |                                    |
-| PAYMENT_API_KEY                                              | Gov Pay config               |   yes    |                       |                                    |
-| PAYMENT_AMOUNT_BAND_A                                        | Amount charged in pence      |   yes    |                       |            Any integer             |
-| PAYMENT_AMOUNT_BAND_B                                        | Amount charged in pence      |   yes    |                       |            Any integer             |
-| GOOGLE_ANALYTICS_ID                                          | GA Tracking ID               |    no    | UA-YYYYYY-YY          |   A Google Analytics Tracking ID   |
-| AIRBRAKE_HOST                                                | Airbrake host                |    no    |                       |        https://some-url.com        |
-| AIRBRAKE_PROJECT_KEY                                         | Airbrake project key         |    no    |                       |             Any string             |
-| USE_BASIC_AUTH                                               | Enable basic authentication  |    no    | false                 |             true,false             |
-| CLAMSCAN_BINARIES                                            | Location of the binary       |    no    | /usr/bin/             |                                    |
-| CLAMSCAN_PREFERENCE                                          | Prefered scanning method     |    no    | clamdscan             |        clamdscan, clamscan         |
-| CLAMSCAN_DEBUG                                               | log msgs to the console      |    no    | false                 |             true,false             |
-| DISABLE_ANTIMALWARE                                          | Disables the anti-malware    |    no    | false                 |             true,false             |
-| DEFRA_USERNAME                                               | The basic authentication username    |    yes    |                  |             Any string             |
-| DEFRA_PASSWORD                                              | The basic authentication password encoded (hashed)    |    yes    |                  |              Only the first 72 bytes of string are used             |
+| name                                                         | description                                         | required | default               |                          valid                          |
+| ------------------------------------------------------------ | --------------------------------------------------- | :------: | --------------------- | :-----------------------------------------------------: |
+| NODE_ENV                                                     | Node environment                                    |    no    |                       |               development,test,production               |
+| SERVICE_HOST                                                 | Application's URL                                   |   yes    | http://localhost:3000 |               development,test,production               |
+| SERVICE_PORT                                                 | Port number                                         |    no    | 3000                  |                                                         |
+| SERVICE_NAME                                                 | Name of the service                                 |    no    |                       |                       Any string                        |
+| LOG_LEVEL                                                    | The level of logging                                |    no    | warn                  |                       warn, debug                       |
+| REQUEST_TIMEOUT                                              | Timeout (in milliseconds)                           |    no    |                       |                       Any integer                       |
+| REDIS_HOST                                                   | Redis server IP address                             |    no    | localhost             |                                                         |
+| REDIS_PORT                                                   | Redis port number                                   |    no    | 6379                  |                                                         |
+| REDIS_PASSWORD                                               | Redis password                                      |    no    |                       |                                                         |
+| REDIS_USE_TLS                                                | Enable/disable SSL/TLS                              |    no    |                       |                       true,false                        |
+| COOKIE_TIMEOUT                                               | Session cookie life in ms. representing whole hours |   yes    | 86400000              | Any integer (n) where n / 1000 / 3600 is a whole number |
+| COOKIE_VALIDATION_PASSWORD                                   | Cookie encoding password                            |   yes    |                       |                       Any string                        |
+| DATAVERSE_AUTHORITY_HOST_URL                                 | Back office Dataverse                               |   yes    |                       |                                                         |
+| DATAVERSE_TENANT                                             | Back office Dataverse                               |   yes    |                       |                                                         |
+| DATAVERSE_CLIENT_ID                                          | Back office Dataverse                               |   yes    |                       |                                                         |
+| DATAVERSE_CLIENT_SECRET                                      | Back office Dataverse                               |   yes    |                       |                                                         |
+| DATAVERSE_RESOURCE                                           | Back office Dataverse                               |   yes    |                       |                                                         |
+| DATAVERSE_API_ENDPOINT                                       | Back office Dataverse                               |   yes    |                       |               For example: api/data/v9.1                |
+| ADDRESS_LOOKUP_ENABLED                                       | Enable/disable address API                          |    no    | false                 |                       true,false                        |
+| ADDRESS_LOOKUP_URL                                           | Address lookup URL                                  |    no    | http://some-url       |                                                         |
+| ADDRESS_LOOKUP_PASSPHRASE                                    | Address lookup passphrase                           |    no    |                       |                                                         |
+| ADDRESS_LOOKUP_PFX_CERT                                      | Address lookup certificate                          |    no    |                       |           PFX file location or Base64 string            |
+| GOV_NOTIFY_KEY                                               | Gov Notify config                                   |   yes    |                       |                                                         |
+| GOV_NOTIFY_TEMPLATE_SECTION_10_APPLICANT_CONFIRMATION        | Gov Notify email template ID                        |   yes    |                       |                                                         |
+| GOV_NOTIFY_TEMPLATE_SECTION_10_OWNER_CONFIRMATION            | Gov Notify email template ID                        |   yes    |                       |                                                         |
+| GOV_NOTIFY_TEMPLATE_SECTION_2_APPLICANT_CONFIRMATION         | Gov Notify email template ID                        |   yes    |                       |                                                         |
+| GOV_NOTIFY_TEMPLATE_SECTION_2_OWNER_EMAIL_THIRD_PARTY        | Gov Notify email template ID                        |   yes    |                       |                                                         |
+| GOV_NOTIFY_TEMPLATE_SECTION_2_OWNER_EMAIL_THIRD_PARTY_RESALE | Gov Notify email template ID                        |   yes    |                       |                                                         |
+| GOV_NOTIFY_TEMPLATE_SECTION_2_RESALE_APPLICANT_CONFIRMATION  | Gov Notify email template ID                        |   yes    |                       |                                                         |
+| PAYMENT_ENABLED                                              | Gov Pay config                                      |   yes    | false                 |             true,false (currently not used)             |
+| PAYMENT_URL                                                  | Gov Pay config                                      |   yes    |                       |                                                         |
+| PAYMENT_API_KEY                                              | Gov Pay config                                      |   yes    |                       |                                                         |
+| PAYMENT_AMOUNT_BAND_A                                        | Amount charged in pence                             |   yes    |                       |                       Any integer                       |
+| PAYMENT_AMOUNT_BAND_B                                        | Amount charged in pence                             |   yes    |                       |                       Any integer                       |
+| GOOGLE_ANALYTICS_ID                                          | GA Tracking ID                                      |    no    | UA-YYYYYY-YY          |             A Google Analytics Tracking ID              |
+| AIRBRAKE_HOST                                                | Airbrake host                                       |    no    |                       |                  https://some-url.com                   |
+| AIRBRAKE_PROJECT_KEY                                         | Airbrake project key                                |    no    |                       |                       Any string                        |
+| USE_BASIC_AUTH                                               | Enable basic authentication                         |    no    | false                 |                       true,false                        |
+| CLAMSCAN_BINARIES                                            | Location of the binary                              |    no    | /usr/bin/             |                                                         |
+| CLAMSCAN_PREFERENCE                                          | Prefered scanning method                            |    no    | clamdscan             |                   clamdscan, clamscan                   |
+| CLAMSCAN_DEBUG                                               | log msgs to the console                             |    no    | false                 |                       true,false                        |
+| DISABLE_ANTIMALWARE                                          | Disables the anti-malware                           |    no    | false                 |                       true,false                        |
+| DEFRA_USERNAME                                               | The basic authentication username                   |   yes    |                       |                       Any string                        |
+| DEFRA_PASSWORD                                               | The basic authentication password encoded (hashed)  |   yes    |                       |       Only the first 72 bytes of string are used        |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/routes/can-continue.route.js
+++ b/server/routes/can-continue.route.js
@@ -15,6 +15,8 @@ const {
 
 const SLA = 35
 
+const sessionTimeoutInHours = config.cookieTimeout / 1000 / 3600
+
 const handlers = {
   get: async (request, h) => {
     const context = await _getContext(request)
@@ -52,6 +54,7 @@ const _getContext = async request => {
   )
 
   const context = {
+    sessionTimeoutInHours,
     itemType,
     isSection2: await RedisHelper.isSection2(request),
     hasUsedChecker: await RedisHelper.hasUsedChecker(request),

--- a/server/services/redis.service.js
+++ b/server/services/redis.service.js
@@ -1,12 +1,16 @@
 'use strict'
 
-const REDIS_TTL_IN_SECONDS = 86400
 const {
   DEFRA_IVORY_SESSION_KEY,
+
   RedisKeys,
   UploadPhoto,
   UploadDocument
 } = require('../utils/constants')
+
+const config = require('../utils/config')
+
+const REDIS_TTL_IN_SECONDS = config.cookieTimeout / 1000
 
 module.exports = class RedisService {
   static async get (request, key) {

--- a/server/utils/config.js
+++ b/server/utils/config.js
@@ -42,7 +42,7 @@ const schema = joi.object().keys({
   addressLookupUrl: joi.string().default(defaultUrl),
   addressLookupPassphrase: joi.string(),
   addressLookupPfxCert: joi.string(),
-  cookieTimeout: joi.number(),
+  cookieTimeout: joi.number().default(86400000),
   cookieValidationPassword: joi
     .string()
     .default('XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'),

--- a/server/views/can-continue.html
+++ b/server/views/can-continue.html
@@ -37,7 +37,7 @@
         </ol>
 
         <div class="govuk-inset-text">
-          <p class="govuk-body" id="timeoutParagraph">You can stop half-way through and come back later. We’ll delete your answers if you close your browser or take more than 24 hours to complete the service.</p>
+          <p class="govuk-body" id="timeoutParagraph">You can stop half-way through and come back later. We’ll delete your answers if you close your browser or take more than {{ sessionTimeoutInHours }} hours to complete the service.</p>
         </div>
         
         {% if isSection2 and not isAlreadyCertified %}


### PR DESCRIPTION
IVORY-630: Make Redis cache timeout configurable

This change utilises the existing COOKIE_TIMEOUT environment variable, which currently controls the user session timeout. This is now used to also set the Redis Time to Live (TTL) as well as to set some dynamic copy on the /can-continue page.

This will allow us to expire data from the Redis cache more quickly if we find that it is filling up with data.