### PR TITLE
Provide performance test mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "1.0.9",
+  "version": "1.0.11",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/routes/make-payment.route.js
+++ b/server/routes/make-payment.route.js
@@ -6,11 +6,16 @@ const RedisHelper = require('../services/redis-helper.service')
 const RedisService = require('../services/redis.service')
 
 const { Paths, RedisKeys, Analytics } = require('../utils/constants')
+const config = require('../utils/config')
 
 const TARGET_COMPLETION_DATE_PERIOD_DAYS = 30
 
 const handlers = {
   get: async (request, h) => {
+    if (config.performanceTestMode) {
+      return h.redirect(Paths.SERVICE_COMPLETE)
+    }
+
     const isSection2 = await RedisHelper.isSection2(request)
 
     const [

--- a/server/utils/config.js
+++ b/server/utils/config.js
@@ -66,7 +66,8 @@ const schema = joi.object().keys({
   disableAntimalware: joi.bool(),
   useBasicAuth: joi.bool().valid(true, false),
   defraUsername: joi.string(),
-  defraPassword: joi.string()
+  defraPassword: joi.string(),
+  performanceTestMode: joi.bool()
 })
 
 // Build config
@@ -120,7 +121,8 @@ const config = {
   disableAntimalware: process.env.DISABLE_ANTIMALWARE,
   useBasicAuth: getBoolean(process.env.USE_BASIC_AUTH || false),
   defraUsername: process.env.DEFRA_USERNAME,
-  defraPassword: process.env.DEFRA_PASSWORD
+  defraPassword: process.env.DEFRA_PASSWORD,
+  performanceTestMode: process.env.PERFORMANCE_TEST_MODE
 }
 
 // Validate config

--- a/test/routes/make-payment.route.test.js
+++ b/test/routes/make-payment.route.test.js
@@ -13,6 +13,8 @@ const PaymentService = require('../../server/services/payment.service')
 
 const { ItemType, RedisKeys } = require('../../server/utils/constants')
 
+const config = require('../../server/utils/config')
+
 const paymentReference = 'ABCDEF'
 const paymentId = 'THE_PAYMENT_ID'
 
@@ -184,6 +186,21 @@ describe('/make-payment route', () => {
       )
 
       expect(response.headers.location).toEqual(nextUrl)
+    })
+
+    it('should go straight tothe "Service complete" page when in performace test mode', async () => {
+      config.performanceTestMode = true
+
+      const response = await TestHelper.submitGetRequest(
+        server,
+        getOptions,
+        302,
+        false
+      )
+
+      expect(response.headers.location).toEqual('/service-complete')
+
+      config.performanceTestMode = false
     })
   })
 })


### PR DESCRIPTION
IVORY-631: Provide a performance test mode

This change adds a new PERFORMANCE_TEST_MODE environment variable which, when set, causes the flow to go straight from the /make-payment route to the /service-complete route. This is for performance test purposes only and is used to bypass the following parts of the service:

- Making a Gov Pay payment
- Sending Gov Notify confirmation emails
- Saving a record in the Dataverse

In the longer term we should look to implement stubs for Gov Pay, Gov Notify and the Dataverse, but this change will allow us to complete the user journeys in the performance test mode and allow us to demonstrate that when the journeys are completed, the corresponding user session data is removed.