### PR TITLE
Added missing Gov UK links to guidance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "1.0.9",
+  "version": "1.0.12",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/routes/can-continue.route.js
+++ b/server/routes/can-continue.route.js
@@ -58,7 +58,7 @@ const _getContext = async request => {
     isRevoked: await RedisHelper.isRevoked(request),
     hasAppliedBefore: await RedisHelper.hasAppliedBefore(request),
     isAlreadyCertified: await RedisHelper.isAlreadyCertified(request),
-    cancelLink: Urls.GOV_UK_HOME,
+    cancelLink: Urls.GOV_UK_TOP_OF_MAIN,
     sla: SLA
   }
 

--- a/server/routes/eligibility-checker/cannot-continue.route.js
+++ b/server/routes/eligibility-checker/cannot-continue.route.js
@@ -36,7 +36,7 @@ const handlers = {
       label: context.pageTitle
     })
 
-    return h.redirect(Urls.GOV_UK_HOME)
+    return h.redirect(Urls.GOV_UK_TOP_OF_MAIN)
   }
 }
 

--- a/server/routes/eligibility-checker/cannot-trade.route.js
+++ b/server/routes/eligibility-checker/cannot-trade.route.js
@@ -26,7 +26,7 @@ const handlers = {
       label: 'Cannot Trade'
     })
 
-    return h.redirect(Urls.GOV_UK_HOME)
+    return h.redirect(Urls.GOV_UK_TOP_OF_MAIN)
   }
 }
 

--- a/server/routes/eligibility-checker/do-not-need-service.route.js
+++ b/server/routes/eligibility-checker/do-not-need-service.route.js
@@ -36,7 +36,7 @@ const handlers = {
       label: context.pageTitle
     })
 
-    return h.redirect(Urls.GOV_UK_HOME)
+    return h.redirect(Urls.GOV_UK_TOP_OF_MAIN)
   }
 }
 

--- a/server/routes/share-details-of-item.route.js
+++ b/server/routes/share-details-of-item.route.js
@@ -4,11 +4,12 @@ const AnalyticsService = require('../services/analytics.service')
 const RedisService = require('../services/redis.service')
 
 const {
+  Analytics,
   Options,
   Paths,
-  Views,
   RedisKeys,
-  Analytics
+  Urls,
+  Views
 } = require('../utils/constants')
 const { buildErrorSummary, Validators } = require('../utils/validation')
 
@@ -65,6 +66,7 @@ const _getContext = async request => {
 
   return {
     pageTitle: 'Help our experts by allowing us to share details of your item',
+    piLink: Urls.GOV_UK_PRESCRIBED_INSTITUTIONS,
     items: [
       {
         value: Options.YES,

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -220,7 +220,10 @@ const PaymentResult = {
 }
 
 const Urls = {
-  GOV_UK_HOME: 'https://www.gov.uk/'
+  GOV_UK_TOP_OF_MAIN:
+    'https://www.gov.uk/guidance/dealing-in-items-containing-ivory-or-made-of-ivory',
+  GOV_UK_PRESCRIBED_INSTITUTIONS:
+    'https://www.gov.uk/guidance/ivory-apply-for-an-exemption-certificate-to-deal-in-pre-1918-outstandingly-high-artistic-cultural-or-historical-value-items#prescribed-institutions'
 }
 
 const Paths = {

--- a/server/views/layout.html
+++ b/server/views/layout.html
@@ -26,7 +26,7 @@
     homepageUrl: "/",
     containerClasses: "govuk-width-container",
     serviceName: serviceName,
-    serviceUrl: "/"
+    serviceUrl: "https://www.gov.uk/guidance/declare-ivory-you-intend-to-sell-or-hire-out"
   }) }}
 {% endblock %}
 

--- a/server/views/share-details-of-item.html
+++ b/server/views/share-details-of-item.html
@@ -11,7 +11,7 @@
 
       <h1 class="govuk-heading-l" id="pageTitle">Help our experts by allowing us to share details of your item</h1>
 
-      <p class="govuk-body" id="para1">To further their knowledge and understanding of pre-1918 ivory items of outstandingly high artistic, cultural, and historical value, we'd like to share details of your application with a closed group of 'Prescribed Institutions'. <a id="piLink" href="about:blank" target="_blank" rel="noopener noreferrer" class="govuk-link">Prescribed Institutions (opens in a new window or tab)</a> are the experts who will be assessing the ivory items.</p>
+      <p class="govuk-body" id="para1">To further their knowledge and understanding of pre-1918 ivory items of outstandingly high artistic, cultural, and historical value, we'd like to share details of your application with a closed group of 'Prescribed Institutions'. <a id="piLink" href="{{ piLink }}" target="_blank" rel="noopener noreferrer" class="govuk-link">Prescribed Institutions (opens in a new window or tab)</a> are the experts who will be assessing the ivory items.</p>
 
       <p class="govuk-body" id="para2">We will only share:</p>
 

--- a/test/routes/can-continue.route.test.js
+++ b/test/routes/can-continue.route.test.js
@@ -192,7 +192,7 @@ describe('/can-continue route', () => {
           TestHelper.checkLink(
             element,
             'Cancel and return to GOV.UK',
-            'https://www.gov.uk/'
+            'https://www.gov.uk/guidance/dealing-in-items-containing-ivory-or-made-of-ivory'
           )
         })
       })
@@ -794,7 +794,7 @@ describe('/can-continue route', () => {
           TestHelper.checkLink(
             element,
             'Cancel and return to GOV.UK',
-            'https://www.gov.uk/'
+            'https://www.gov.uk/guidance/dealing-in-items-containing-ivory-or-made-of-ivory'
           )
         })
       })

--- a/test/routes/do-not-need-service.route.test.js
+++ b/test/routes/do-not-need-service.route.test.js
@@ -7,6 +7,8 @@ const TestHelper = require('../utils/test-helper')
 describe('Eligibility checker - do not need service route', () => {
   let server
   const url = '/eligibility-checker/do-not-need-service'
+  const nextUrl =
+    'https://www.gov.uk/guidance/dealing-in-items-containing-ivory-or-made-of-ivory'
 
   const elementIds = {
     pageTitle: 'pageTitle',
@@ -96,6 +98,30 @@ describe('Eligibility checker - do not need service route', () => {
         expect(TestHelper.getTextContent(element)).toEqual(
           'Qualifying museums do not need to tell us when they sell or hire out ivory items to each other.'
         )
+      })
+    })
+  })
+
+  describe('POST', () => {
+    let postOptions
+
+    beforeEach(() => {
+      postOptions = {
+        method: 'POST',
+        url,
+        payload: {}
+      }
+    })
+
+    describe('Success', () => {
+      beforeEach(async () => {
+        RedisService.get = jest.fn().mockResolvedValueOnce(null)
+      })
+
+      it('should progress to the next route', async () => {
+        const response = await TestHelper.submitPostRequest(server, postOptions)
+
+        expect(response.headers.location).toEqual(nextUrl)
       })
     })
   })

--- a/test/routes/do-not-need-service.route.test.js
+++ b/test/routes/do-not-need-service.route.test.js
@@ -119,9 +119,7 @@ describe('Eligibility checker - do not need service route', () => {
       })
 
       it('should progress to the next route', async () => {
-        const response = await TestHelper.submitPostRequest(server, postOptions)
-
-        expect(response.headers.location).toEqual(nextUrl)
+        await _checkPostAction(postOptions, server, nextUrl)
       })
     })
   })
@@ -129,4 +127,10 @@ describe('Eligibility checker - do not need service route', () => {
 
 const _createMocks = () => {
   TestHelper.createMocks()
+}
+
+const _checkPostAction = async (postOptions, server, nextUrl) => {
+  const response = await TestHelper.submitPostRequest(server, postOptions)
+
+  expect(response.headers.location).toEqual(nextUrl)
 }

--- a/test/routes/eligibility-checker/cannot-continue.route.test.js
+++ b/test/routes/eligibility-checker/cannot-continue.route.test.js
@@ -9,7 +9,8 @@ const { Options } = require('../../../server/utils/constants')
 describe('/eligibility-checker/cannot-continue route', () => {
   let server
   const url = '/eligibility-checker/cannot-continue'
-  const nextUrl = 'https://www.gov.uk/'
+  const nextUrl =
+    'https://www.gov.uk/guidance/dealing-in-items-containing-ivory-or-made-of-ivory'
 
   const elementIds = {
     pageTitle: 'pageTitle',

--- a/test/routes/eligibility-checker/cannot-trade.route.test.js
+++ b/test/routes/eligibility-checker/cannot-trade.route.test.js
@@ -175,7 +175,7 @@ describe('/eligibility-checker/cannot-trade route', () => {
     })
 
     describe('Success', () => {
-      it('should redirect', async () => {
+      it('should progress to the next route', async () => {
         await _checkPostAction(postOptions, server, nextUrl)
       })
     })

--- a/test/routes/eligibility-checker/cannot-trade.route.test.js
+++ b/test/routes/eligibility-checker/cannot-trade.route.test.js
@@ -5,7 +5,8 @@ const TestHelper = require('../../utils/test-helper')
 describe('/eligibility-checker/cannot-trade route', () => {
   let server
   const url = '/eligibility-checker/cannot-trade'
-  const nextUrl = 'https://www.gov.uk/'
+  const nextUrl =
+    'https://www.gov.uk/guidance/dealing-in-items-containing-ivory-or-made-of-ivory'
 
   const elementIds = {
     pageTitle: 'pageTitle',

--- a/test/routes/share-details-of-item.test.js
+++ b/test/routes/share-details-of-item.test.js
@@ -77,7 +77,7 @@ describe('/who-owns-the-item route', () => {
       TestHelper.checkLink(
         element,
         'Prescribed Institutions (opens in a new window or tab)',
-        'about:blank'
+        'https://www.gov.uk/guidance/ivory-apply-for-an-exemption-certificate-to-deal-in-pre-1918-outstandingly-high-artistic-cultural-or-historical-value-items#prescribed-institutions'
       )
     })
 


### PR DESCRIPTION
IVORY-609: Insert missing gov.uk guidance links into front end service

When the pages were built, the Gov UK guidance pages did not exist. The required links can now be entered into the service.