### PR TITLE
Updated GOV.UK banner link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/plugins/views.plugin.js
+++ b/server/plugins/views.plugin.js
@@ -3,6 +3,7 @@
 const path = require('path')
 const nunjucks = require('nunjucks')
 const config = require('../utils/config')
+const constants = require('../utils/constants')
 const pkg = require('../../package.json')
 const analyticsAccount = config.analyticsAccount
 
@@ -38,6 +39,8 @@ module.exports = {
     context: {
       appVersion: pkg.version,
       assetPath: '/assets',
+      govUkHome: constants.Urls.GOV_UK_HOME,
+      serviceNameUrl: constants.Urls.GOV_UK_SERVICE_HOME,
       serviceName: config.serviceName,
       pageTitle: `${config.serviceName} - GOV.UK`,
       analyticsAccount: analyticsAccount

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -220,6 +220,9 @@ const PaymentResult = {
 }
 
 const Urls = {
+  GOV_UK_HOME: 'https://www.gov.uk',
+  GOV_UK_SERVICE_HOME:
+    'https://www.gov.uk/guidance/declare-ivory-you-intend-to-sell-or-hire-out',
   GOV_UK_TOP_OF_MAIN:
     'https://www.gov.uk/guidance/dealing-in-items-containing-ivory-or-made-of-ivory',
   GOV_UK_PRESCRIBED_INSTITUTIONS:

--- a/server/views/layout.html
+++ b/server/views/layout.html
@@ -23,10 +23,10 @@
 
 {% block header %}
   {{ govukHeader({
-    homepageUrl: "/",
+    homepageUrl: govUkHome,
     containerClasses: "govuk-width-container",
     serviceName: serviceName,
-    serviceUrl: "https://www.gov.uk/guidance/declare-ivory-you-intend-to-sell-or-hire-out"
+    serviceUrl: serviceNameUrl
   }) }}
 {% endblock %}
 


### PR DESCRIPTION
IVORY-639: GOV.UK in banner should link to Gov UK Home

The GOV UK link in the banner was incorrect. It was linking to: / i.e. the start of our service.

This was incorrect, instead it should link to: https://www.gov.uk