### PR TITLE
Fixed Redis boolean string issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "1.0.13",
+  "version": "1.1.1",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/services/redis.service.js
+++ b/server/services/redis.service.js
@@ -20,7 +20,10 @@ module.exports = class RedisService {
     )
 
     let parsedValue = redisValue
-    if (_isJsonString(redisValue)) {
+
+    if (_isBooleanString(redisValue)) {
+      parsedValue = redisValue.toLowerCase() === 'true'
+    } else if (_isJsonString(redisValue)) {
       try {
         parsedValue = JSON.parse(redisValue)
       } catch (e) {
@@ -76,6 +79,17 @@ const _isJsonString = value =>
   value.length &&
   ((value.startsWith('{') && value.endsWith('}')) ||
     (value.startsWith('[') && value.endsWith(']')))
+
+/**
+ * Checks a string value to see if it contains a bolean i.e. 'true' or 'false'
+ * @param {*} value The string value to be chekced
+ * @returns True if the string contains a bolean, otherwise false
+ */
+
+const _isBooleanString = value =>
+  value &&
+  value.length &&
+  (value.toLowerCase() === 'true' || value.toLowerCase() === 'false')
 
 /**
  * Scans the Redis cache for all keys matching the session key held in the session.

--- a/server/utils/upload.js
+++ b/server/utils/upload.js
@@ -24,7 +24,9 @@ const checkForDuplicates = (payload, uploadData) => {
 const checkForFileSizeError = async (request, redisKey) => {
   const errors = []
 
-  if (await RedisService.get(request, redisKey)) {
+  const isError = await RedisService.get(request, redisKey)
+
+  if (isError) {
     errors.push({
       name: 'files',
       text: `The file must be smaller than ${config.maximumFileSize}MB`

--- a/test/services/redis.service.test.js
+++ b/test/services/redis.service.test.js
@@ -57,6 +57,36 @@ describe('Redis service', () => {
       )
     })
 
+    it('should get a bolean true value from Redis', async () => {
+      const mockValue = 'true'
+      _createMocks(mockValue)
+
+      expect(mockRequest.redis.client.get).toBeCalledTimes(0)
+
+      const redisValue = await RedisService.get(mockRequest, redisKey)
+      expect(redisValue).toEqual(true)
+
+      expect(mockRequest.redis.client.get).toBeCalledTimes(1)
+      expect(mockRequest.redis.client.get).toBeCalledWith(
+        `${sessionId}.${redisKey}`
+      )
+    })
+
+    it('should get a bolean true value from Redis', async () => {
+      const mockValue = 'false'
+      _createMocks(mockValue)
+
+      expect(mockRequest.redis.client.get).toBeCalledTimes(0)
+
+      const redisValue = await RedisService.get(mockRequest, redisKey)
+      expect(redisValue).toEqual(false)
+
+      expect(mockRequest.redis.client.get).toBeCalledTimes(1)
+      expect(mockRequest.redis.client.get).toBeCalledWith(
+        `${sessionId}.${redisKey}`
+      )
+    })
+
     it('should get a JSON-encoded object from Redis', async () => {
       const mockValue = {
         key1: 'VALUE 1',


### PR DESCRIPTION
IVORY-640: Image upload size warning is appearing when uploading 2 or more images

Due to a recent change, boolean string values (i.e. 'true' and 'false') were no longer being converted into boolean values by the Redis service. This caused a file size errors to occur, because boolean comparisons were no longer working.