### PR TITLE
Improve Docker layer structure & bump sharp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,10 @@ RUN freshclam
 
 WORKDIR /app
 
-COPY . .
-
+COPY package*.json .
 RUN npm install
+
+COPY . .
 RUN npm run build
 
 EXPOSE $PORT

--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ First install the dependencies & build the application using:
 
 `$ npm install`
 
-If installing on a Windows machine you may encounter an error when running `$ npm install` relating to your OS not being able to run the Bash scripts which are part of the installation. Should you have this problem first ensure that you have installed [Git for Windows](https://gitforwindows.org). Then run the command `$ npm config set script-shell %userprofile%\cmder\vendor\git-for-windows\bin\bash` followed by `$ npm install`.
+followed by:
+
+`$ npm run build` - This runs the build tasks, which currently are just building the CSS. This needs to be run on the initial install, if updates are made to the Sass, or if the "govuk-frontend" is updated.
+
+If installing on a Windows machine you may encounter an error when running `$ npm run build` relating to your OS not being able to run the Bash scripts which are part of the installation. Should you have this problem first ensure that you have installed [Git for Windows](https://gitforwindows.org). Then run the command `$ npm config set script-shell %userprofile%\cmder\vendor\git-for-windows\bin\bash` followed by `$ npm run build`.
 
 Now the application is ready to run:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ivory",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ivory",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@airbrake/node": "^2.1.7",
@@ -20,10 +20,10 @@
         "applicationinsights": "^2.2.1",
         "bcrypt": "^5.0.1",
         "blipp": "^4.0.2",
-        "clamscan": "^2.0.1",
+        "clamscan": "^2.0.3",
         "disinfect": "^1.1.0",
         "dotenv": "^15.0.0",
-        "govuk-frontend": "^4.0.0",
+        "govuk-frontend": "^4.0.1",
         "hapi-pino": "8.5.0",
         "hapi-redis2": "^3.0.1",
         "joi": "^17.6.0",
@@ -39,10 +39,10 @@
         "uuid": "^8.3.2"
       },
       "devDependencies": {
-        "jest": "^27.4.7",
+        "jest": "^27.5.1",
         "jest-junit": "^13.0.0",
         "jsdom": "^19.0.0",
-        "nock": "^13.2.2",
+        "nock": "^13.2.4",
         "standard": "^16.0.4"
       },
       "engines": {
@@ -2848,9 +2848,9 @@
       "dev": true
     },
     "node_modules/clamscan": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/clamscan/-/clamscan-2.0.1.tgz",
-      "integrity": "sha512-WQmp+Pn8YhcTV2IaKSUOJQSkh60t4HM2Gps/yJl2RIXZTT0aEz5gA3PB53xxDQ542EgCTVhrI4G4Y2g91rdoVA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/clamscan/-/clamscan-2.0.3.tgz",
+      "integrity": "sha512-JmvU23Lk4pZZTeTXgRN2Tury7FHsjdDQP/hx2JwbKRPdmSTcAbsu4Q6oWiVvCK2M8o8vbdpnX3rqUJIbOxNWKg==",
       "engines": {
         "node": ">=10.12.0"
       }
@@ -12363,9 +12363,9 @@
       "dev": true
     },
     "clamscan": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/clamscan/-/clamscan-2.0.1.tgz",
-      "integrity": "sha512-WQmp+Pn8YhcTV2IaKSUOJQSkh60t4HM2Gps/yJl2RIXZTT0aEz5gA3PB53xxDQ542EgCTVhrI4G4Y2g91rdoVA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/clamscan/-/clamscan-2.0.3.tgz",
+      "integrity": "sha512-JmvU23Lk4pZZTeTXgRN2Tury7FHsjdDQP/hx2JwbKRPdmSTcAbsu4Q6oWiVvCK2M8o8vbdpnX3rqUJIbOxNWKg=="
     },
     "clean-stack": {
       "version": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
   "name": "ivory",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ivory",
-      "version": "1.0.12",
-      "hasInstallScript": true,
+      "version": "1.1.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@airbrake/node": "^2.1.7",
@@ -36,7 +35,7 @@
         "pdf-lib": "^1.17.1",
         "postcode-validator": "^3.5.3",
         "randomstring": "^1.2.2",
-        "sharp": "^0.29.3",
+        "sharp": "^0.30.1",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
@@ -8576,17 +8575,17 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "node_modules/sharp": {
-      "version": "0.29.3",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.29.3.tgz",
-      "integrity": "sha512-fKWUuOw77E4nhpyzCCJR1ayrttHoFHBT2U/kR/qEMRhvPEcluG4BKj324+SCO1e84+knXHwhJ1HHJGnUt4ElGA==",
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.30.1.tgz",
+      "integrity": "sha512-ycpz81q8AeVjz1pGvvirQBeJcYE2sXAjcLXR/69LWOe/oxavBLOrenZcTzvTXn83jqAGqY+OuwF+2kFXzbKtDA==",
       "hasInstallScript": true,
       "dependencies": {
-        "color": "^4.0.1",
-        "detect-libc": "^1.0.3",
-        "node-addon-api": "^4.2.0",
-        "prebuild-install": "^7.0.0",
+        "color": "^4.2.0",
+        "detect-libc": "^2.0.0",
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.0.1",
         "semver": "^7.3.5",
-        "simple-get": "^4.0.0",
+        "simple-get": "^4.0.1",
         "tar-fs": "^2.1.1",
         "tunnel-agent": "^0.6.0"
       },
@@ -8595,6 +8594,14 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/sharp/node_modules/detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/sharp/node_modules/node-addon-api": {
@@ -16698,20 +16705,25 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "sharp": {
-      "version": "0.29.3",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.29.3.tgz",
-      "integrity": "sha512-fKWUuOw77E4nhpyzCCJR1ayrttHoFHBT2U/kR/qEMRhvPEcluG4BKj324+SCO1e84+knXHwhJ1HHJGnUt4ElGA==",
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.30.1.tgz",
+      "integrity": "sha512-ycpz81q8AeVjz1pGvvirQBeJcYE2sXAjcLXR/69LWOe/oxavBLOrenZcTzvTXn83jqAGqY+OuwF+2kFXzbKtDA==",
       "requires": {
-        "color": "^4.0.1",
-        "detect-libc": "^1.0.3",
-        "node-addon-api": "^4.2.0",
-        "prebuild-install": "^7.0.0",
+        "color": "^4.2.0",
+        "detect-libc": "^2.0.0",
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.0.1",
         "semver": "^7.3.5",
-        "simple-get": "^4.0.0",
+        "simple-get": "^4.0.1",
         "tar-fs": "^2.1.1",
         "tunnel-agent": "^0.6.0"
       },
       "dependencies": {
+        "detect-libc": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+          "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w=="
+        },
         "node-addon-api": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "debug": "nodemon --inspect index.js",
     "lint": "standard",
     "unit-test": "npx jest --detectOpenHandles --forceExit --verbose",
-    "test": "npm run lint && npm run unit-test",
-    "postinstall": "npm run build"
+    "test": "npm run lint && npm run unit-test"
   },
   "author": "Department for Environment, Food & Rural Affairs",
   "license": "SEE LICENSE IN LICENSE",
@@ -53,7 +52,7 @@
     "pdf-lib": "^1.17.1",
     "postcode-validator": "^3.5.3",
     "randomstring": "^1.2.2",
-    "sharp": "^0.29.3",
+    "sharp": "^0.30.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
     "applicationinsights": "^2.2.1",
     "bcrypt": "^5.0.1",
     "blipp": "^4.0.2",
-    "clamscan": "^2.0.1",
+    "clamscan": "^2.0.3",
     "disinfect": "^1.1.0",
     "dotenv": "^15.0.0",
-    "govuk-frontend": "^4.0.0",
+    "govuk-frontend": "^4.0.1",
     "hapi-pino": "8.5.0",
     "hapi-redis2": "^3.0.1",
     "joi": "^17.6.0",
@@ -56,10 +56,10 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "jest": "^27.4.7",
+    "jest": "^27.5.1",
     "jest-junit": "^13.0.0",
     "jsdom": "^19.0.0",
-    "nock": "^13.2.2",
+    "nock": "^13.2.4",
     "standard": "^16.0.4"
   },
   "standard": {


### PR DESCRIPTION
You may or may not want this in :)
Dockerfile: split copying of package.json & lock from main app code to create a new cachable layer and speed up the rebuilds.
package.json+lock: as you'd got a postinstall there you were running npm run build twice, once after npm install and then again in dockerfile explictly. Sharp on 0.29.3 was failing to install on my M1, bumping to 0.30.1 fixes and all tests still pass.