### PR TITLE
Cannot-trade page not working due to missing species

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivory",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "Digital service to support the Ivory Act",
   "main": "index.js",
   "scripts": {

--- a/server/routes/eligibility-checker/contain-elephant-ivory.route.js
+++ b/server/routes/eligibility-checker/contain-elephant-ivory.route.js
@@ -8,6 +8,7 @@ const {
   Options,
   Paths,
   RedisKeys,
+  Species,
   Urls,
   Views
 } = require('../../utils/constants')
@@ -52,6 +53,8 @@ const handlers = {
       payload.containElephantIvory
     )
 
+    await RedisService.set(request, RedisKeys.USED_CHECKER, true)
+
     if (payload.containElephantIvory === Options.NO) {
       await RedisService.set(request, RedisKeys.ARE_YOU_A_MUSEUM, false)
     }
@@ -71,8 +74,6 @@ const handlers = {
       )
     }
 
-    await RedisService.set(request, RedisKeys.USED_CHECKER, true)
-
     AnalyticsService.sendEvent(request, {
       category: Analytics.Category.ELIGIBILITY_CHECKER,
       action: `${Analytics.Action.SELECTED} ${payload.containElephantIvory}`,
@@ -81,6 +82,11 @@ const handlers = {
 
     switch (payload.containElephantIvory) {
       case Options.YES:
+        await RedisService.set(
+          request,
+          RedisKeys.WHAT_SPECIES,
+          Species.ELEPHANT
+        )
         return h.redirect(Paths.SELLING_TO_MUSEUM)
       case Options.NO:
         return h.redirect(Paths.WHAT_SPECIES)

--- a/test/routes/eligibility-checker/contain-elephant-ivory.route.test.js
+++ b/test/routes/eligibility-checker/contain-elephant-ivory.route.test.js
@@ -7,7 +7,11 @@ jest.mock('../../../server/services/redis.service')
 const RedisService = require('../../../server/services/redis.service')
 
 const TestHelper = require('../../utils/test-helper')
-const { Options, RedisKeys } = require('../../../server/utils/constants')
+const {
+  Options,
+  RedisKeys,
+  Species
+} = require('../../../server/utils/constants')
 
 describe('/eligibility-checker/contain-elephant-ivory route', () => {
   let server
@@ -252,23 +256,16 @@ const _checkSelectedRadioAction = async (
 
   const response = await TestHelper.submitPostRequest(server, postOptions)
 
-  expect(RedisService.set).toBeCalledTimes(
-    selectedOption === Options.NO ? 4 : 3
-  )
-
-  expect(RedisService.set).toBeCalledWith(
-    expect.any(Object),
-    RedisKeys.CONTAIN_ELEPHANT_IVORY,
-    selectedOption
-  )
-
-  if (selectedOption === Options.NO) {
-    expect(RedisService.set).toBeCalledWith(
-      expect.any(Object),
-      RedisKeys.ARE_YOU_A_MUSEUM,
-      false
-    )
+  let expectedNumberOfCalls
+  if (selectedOption === Options.YES) {
+    expectedNumberOfCalls = 4
+  } else if (selectedOption === Options.NO) {
+    expectedNumberOfCalls = 4
+  } else {
+    expectedNumberOfCalls = 3
   }
+
+  expect(RedisService.set).toBeCalledTimes(expectedNumberOfCalls)
 
   expect(RedisService.set).toBeCalledWith(
     expect.any(Object),
@@ -281,6 +278,26 @@ const _checkSelectedRadioAction = async (
     RedisKeys.USED_CHECKER,
     true
   )
+
+  expect(RedisService.set).toBeCalledWith(
+    expect.any(Object),
+    RedisKeys.CONTAIN_ELEPHANT_IVORY,
+    selectedOption
+  )
+
+  if (selectedOption === Options.YES) {
+    expect(RedisService.set).toBeCalledWith(
+      expect.any(Object),
+      RedisKeys.WHAT_SPECIES,
+      Species.ELEPHANT
+    )
+  } else if (selectedOption === Options.NO) {
+    expect(RedisService.set).toBeCalledWith(
+      expect.any(Object),
+      RedisKeys.ARE_YOU_A_MUSEUM,
+      false
+    )
+  }
 
   expect(response.headers.location).toEqual(nextUrl)
 }


### PR DESCRIPTION
IVORY-675: Cannot-trade page not working due to missing species

In the EtS flow, if the user selects "Yes" to "Is it an elephant" we were not saving the species. This broke the cannot-trade page if they eventually got there.