### PR TITLE
164895 - Added description of the item in the Section 10 submission r…

### DIFF
--- a/server/routes/service-complete.route.js
+++ b/server/routes/service-complete.route.js
@@ -77,6 +77,11 @@ const _getContext = async (request, itemType, ownedByApplicant) => {
     RedisKeys.APPLICANT_CONTACT_DETAILS
   )
 
+  const itemDescription = await RedisService.get(
+    request,
+    RedisKeys.DESCRIBE_THE_ITEM
+  )
+
   const alreadyCertified = isSection2
     ? await RedisService.get(request, RedisKeys.ALREADY_CERTIFIED)
     : null
@@ -91,6 +96,7 @@ const _getContext = async (request, itemType, ownedByApplicant) => {
     isAlreadyCertified,
     ownerContactDetails,
     applicantContactDetails,
+    itemDescription,
     submissionReference,
     certificateNumber,
     applicantEmail: applicantContactDetails
@@ -288,7 +294,8 @@ const _sendSection10ApplicantEmail = context => {
     submissionReference: context.submissionReference,
     fullName: context.applicantContactDetails.fullName,
     exemptionType: context.itemType,
-    isMuseum: context.itemType === ItemType.MUSEUM
+    isMuseum: context.itemType === ItemType.MUSEUM,
+    whatIsItem: context.itemDescription.whatIsItem
   }
 
   _sendEmail(templateId, recipientEmail, payload)
@@ -302,8 +309,8 @@ const _sendSection10OwnerEmail = context => {
     fullName:
       context.ownerContactDetails.fullName ||
       context.ownerContactDetails.businessName,
-
-    exemptionType: context.itemType
+    exemptionType: context.itemType,
+    whatIsItem: context.itemDescription.whatIsItem
   }
 
   _sendEmail(templateId, recipientEmail, payload)

--- a/test/routes/service-complete.route.test.js
+++ b/test/routes/service-complete.route.test.js
@@ -722,7 +722,8 @@ const _createSection2RedisMock = (
 const _createSection10RedisMock = (
   isOwnedByApplicant,
   hasOwnerEmail = true,
-  itemType = ItemType.MUSICAL
+  itemType = ItemType.MUSICAL,
+  itemDescription = 'sword'
 ) => {
   redisMockDataMap[RedisKeys.WHAT_TYPE_OF_ITEM_IS_IT] = itemType
   redisMockDataMap[RedisKeys.OWNED_BY_APPLICANT] = isOwnedByApplicant
@@ -737,6 +738,8 @@ const _createSection10RedisMock = (
       ? mockOwnerContactDetails
       : null
   }
+
+  redisMockDataMap[RedisKeys.DESCRIBE_THE_ITEM] = itemDescription
 
   RedisService.get = jest.fn((request, redisKey) => {
     return redisMockDataMap[redisKey]

--- a/test/routes/service-complete.route.test.js
+++ b/test/routes/service-complete.route.test.js
@@ -387,6 +387,7 @@ describe('/service-complete route', () => {
                 exemptionType: ItemType.MUSICAL,
                 fullName: mockOwnerContactDetails.fullName,
                 isMuseum: false,
+                whatIsItem: itemDescription.whatIsItem,
                 submissionReference
               }
             )
@@ -411,6 +412,7 @@ describe('/service-complete route', () => {
                 exemptionType: ItemType.MUSEUM,
                 fullName: mockApplicantContactDetails.fullName,
                 isMuseum: true,
+                whatIsItem: itemDescription.whatIsItem,
                 submissionReference
               }
             )
@@ -422,6 +424,7 @@ describe('/service-complete route', () => {
               {
                 exemptionType: ItemType.MUSEUM,
                 fullName: mockOwnerContactDetails.fullName,
+                whatIsItem: itemDescription.whatIsItem,
                 submissionReference
               }
             )
@@ -444,6 +447,7 @@ describe('/service-complete route', () => {
                 exemptionType: ItemType.MUSEUM,
                 fullName: mockApplicantContactDetails.fullName,
                 isMuseum: true,
+                whatIsItem: itemDescription.whatIsItem,
                 submissionReference
               }
             )
@@ -663,6 +667,10 @@ const paymentReference = 'PAYMENT_REFERENCE'
 const submissionReference = '1234ABCD'
 const certificateNumber = 'CERTIFICATE_NUMBER'
 
+const itemDescription = {
+  whatIsItem: 'Sword'
+}
+
 const mockOwnerContactDetails = {
   fullName: 'OWNER_NAME',
   emailAddress: 'OWNER@EMAIL.COM',
@@ -678,7 +686,8 @@ const mockApplicantContactDetails = {
 const redisMockDataMap = {
   [RedisKeys.PAYMENT_ID]: paymentReference,
   [RedisKeys.SUBMISSION_REFERENCE]: submissionReference,
-  [RedisKeys.OWNER_CONTACT_DETAILS]: mockOwnerContactDetails
+  [RedisKeys.OWNER_CONTACT_DETAILS]: mockOwnerContactDetails,
+  [RedisKeys.DESCRIBE_THE_ITEM]: itemDescription
 }
 
 const _createMocks = () => {
@@ -722,8 +731,7 @@ const _createSection2RedisMock = (
 const _createSection10RedisMock = (
   isOwnedByApplicant,
   hasOwnerEmail = true,
-  itemType = ItemType.MUSICAL,
-  itemDescription = 'sword'
+  itemType = ItemType.MUSICAL
 ) => {
   redisMockDataMap[RedisKeys.WHAT_TYPE_OF_ITEM_IS_IT] = itemType
   redisMockDataMap[RedisKeys.OWNED_BY_APPLICANT] = isOwnedByApplicant


### PR DESCRIPTION
- Description of the item is passed in the payload which is used by gov.uk Notify to send section 10 email
- Created 2 new section 10 templates replica of existing templates with extra 'whatisItem' field to support the description of the item - (Need to visit the gov.uk Notify subscription to review that)
- Deployment of the changes ,do need to update the environment variables in octopus/pipeline to use the new email template.