### PR TITLE
Bug fix: Update taken from species page to handle new options added

### DIFF
--- a/server/routes/eligibility-checker/taken-from-species.route.js
+++ b/server/routes/eligibility-checker/taken-from-species.route.js
@@ -13,6 +13,9 @@ const {
 } = require('../../utils/constants')
 const { buildErrorSummary, Validators } = require('../../utils/validation')
 const { getStandardOptions } = require('../../utils/general')
+const {
+  Species
+} = require('../../utils/constants')
 
 const handlers = {
   get: async (request, h) => {
@@ -71,21 +74,32 @@ const handlers = {
 }
 
 const _getContext = async request => {
-  const species = (await RedisHelper.getSpecies(request)).toLowerCase()
+  const speciesValue = (await RedisHelper.getSpecies(request)).toLowerCase()
+  let speciesString = 'species'
+
+  if (Object.values(Species).map(item => item.toLowerCase()).includes(speciesValue)) {
+    speciesString = speciesValue
+  }
 
   return {
-    pageTitle: `Was the replacement ivory taken from the ${species} on or after 1 January 1975?`,
+    pageTitle: `Was the replacement ivory taken from the ${speciesString} on or after 1 January 1975?`,
     items: getStandardOptions(),
-    species
+    species: speciesString
   }
 }
 
 const _validateForm = (payload, context) => {
   const errors = []
   if (Validators.empty(payload.takenFromSpecies)) {
+    let speciesString = 'species'
+
+    if (Object.values(Species).map(item => item.toLowerCase()).includes(context.species)) {
+      speciesString = context.species
+    }
+
     errors.push({
       name: 'takenFromSpecies',
-      text: `You must tell us whether the replacement ivory was taken from the ${context.species} on or after 1 January 1975`
+      text: `You must tell us whether the replacement ivory was taken from the ${speciesString} on or after 1 January 1975`
     })
   }
   return errors

--- a/test/routes/eligibility-checker/taken-from-species.route.test.js
+++ b/test/routes/eligibility-checker/taken-from-species.route.test.js
@@ -51,15 +51,15 @@ describe('/eligibility-checker/taken-from-species route', () => {
       beforeEach(async () => {
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
-  
+
       it('should have the Beta banner', () => {
         TestHelper.checkBetaBanner(document)
       })
-  
+
       it('should have the Back link', () => {
         TestHelper.checkBackLink(document)
       })
-  
+
       it('should have the correct page heading', () => {
         const element = document.querySelector('.govuk-fieldset__legend')
         expect(element).toBeTruthy()
@@ -67,7 +67,7 @@ describe('/eligibility-checker/taken-from-species route', () => {
           `Was the replacement ivory taken from the ${mockSpecies.toLowerCase()} on or after 1 January 1975?`
         )
       })
-  
+
       it('should have the correct radio buttons', () => {
         TestHelper.checkRadioOption(
           document,
@@ -75,14 +75,14 @@ describe('/eligibility-checker/taken-from-species route', () => {
           'Yes',
           'Yes'
         )
-  
+
         TestHelper.checkRadioOption(
           document,
           elementIds.takenFromSpecies2,
           'No',
           'No'
         )
-  
+
         TestHelper.checkRadioOption(
           document,
           elementIds.takenFromSpecies3,
@@ -90,7 +90,7 @@ describe('/eligibility-checker/taken-from-species route', () => {
           'I don’t know'
         )
       })
-  
+
       it('should have the correct Call to Action button', () => {
         const element = document.querySelector(`#${elementIds.continue}`)
         expect(element).toBeTruthy()
@@ -106,12 +106,12 @@ describe('/eligibility-checker/taken-from-species route', () => {
       beforeEach(async () => {
         document = await TestHelper.submitGetRequest(server, getOptions)
       })
-  
+
       it('should have the correct page heading', () => {
         const element = document.querySelector('.govuk-fieldset__legend')
         expect(element).toBeTruthy()
         expect(TestHelper.getTextContent(element)).toEqual(
-          `Was the replacement ivory taken from the species on or after 1 January 1975?`
+          'Was the replacement ivory taken from the species on or after 1 January 1975?'
         )
       })
     })
@@ -205,7 +205,7 @@ describe('/eligibility-checker/taken-from-species route', () => {
             response,
             'takenFromSpecies',
             'takenFromSpecies-error',
-            `You must tell us whether the replacement ivory was taken from the species on or after 1 January 1975`
+            'You must tell us whether the replacement ivory was taken from the species on or after 1 January 1975'
           )
         })
       })

--- a/test/routes/eligibility-checker/taken-from-species.route.test.js
+++ b/test/routes/eligibility-checker/taken-from-species.route.test.js
@@ -33,10 +33,6 @@ describe('/eligibility-checker/taken-from-species route', () => {
     await server.stop()
   })
 
-  beforeEach(() => {
-    _createMocks()
-  })
-
   afterEach(() => {
     jest.clearAllMocks()
   })
@@ -47,53 +43,77 @@ describe('/eligibility-checker/taken-from-species route', () => {
       url
     }
 
-    beforeEach(async () => {
-      document = await TestHelper.submitGetRequest(server, getOptions)
+    describe('When specific species has been selected', () => {
+      beforeEach(() => {
+        _createMocksSpecificSpecies()
+      })
+
+      beforeEach(async () => {
+        document = await TestHelper.submitGetRequest(server, getOptions)
+      })
+  
+      it('should have the Beta banner', () => {
+        TestHelper.checkBetaBanner(document)
+      })
+  
+      it('should have the Back link', () => {
+        TestHelper.checkBackLink(document)
+      })
+  
+      it('should have the correct page heading', () => {
+        const element = document.querySelector('.govuk-fieldset__legend')
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          `Was the replacement ivory taken from the ${mockSpecies.toLowerCase()} on or after 1 January 1975?`
+        )
+      })
+  
+      it('should have the correct radio buttons', () => {
+        TestHelper.checkRadioOption(
+          document,
+          elementIds.takenFromSpecies,
+          'Yes',
+          'Yes'
+        )
+  
+        TestHelper.checkRadioOption(
+          document,
+          elementIds.takenFromSpecies2,
+          'No',
+          'No'
+        )
+  
+        TestHelper.checkRadioOption(
+          document,
+          elementIds.takenFromSpecies3,
+          'I don’t know',
+          'I don’t know'
+        )
+      })
+  
+      it('should have the correct Call to Action button', () => {
+        const element = document.querySelector(`#${elementIds.continue}`)
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual('Continue')
+      })
     })
 
-    it('should have the Beta banner', () => {
-      TestHelper.checkBetaBanner(document)
-    })
+    describe('When two or more species or I\'m not sure selected', () => {
+      beforeEach(() => {
+        _createMocksTwoOrMore()
+      })
 
-    it('should have the Back link', () => {
-      TestHelper.checkBackLink(document)
-    })
-
-    it('should have the correct page heading', () => {
-      const element = document.querySelector('.govuk-fieldset__legend')
-      expect(element).toBeTruthy()
-      expect(TestHelper.getTextContent(element)).toEqual(
-        `Was the replacement ivory taken from the ${mockSpecies.toLowerCase()} on or after 1 January 1975?`
-      )
-    })
-
-    it('should have the correct radio buttons', () => {
-      TestHelper.checkRadioOption(
-        document,
-        elementIds.takenFromSpecies,
-        'Yes',
-        'Yes'
-      )
-
-      TestHelper.checkRadioOption(
-        document,
-        elementIds.takenFromSpecies2,
-        'No',
-        'No'
-      )
-
-      TestHelper.checkRadioOption(
-        document,
-        elementIds.takenFromSpecies3,
-        'I don’t know',
-        'I don’t know'
-      )
-    })
-
-    it('should have the correct Call to Action button', () => {
-      const element = document.querySelector(`#${elementIds.continue}`)
-      expect(element).toBeTruthy()
-      expect(TestHelper.getTextContent(element)).toEqual('Continue')
+      beforeEach(async () => {
+        document = await TestHelper.submitGetRequest(server, getOptions)
+      })
+  
+      it('should have the correct page heading', () => {
+        const element = document.querySelector('.govuk-fieldset__legend')
+        expect(element).toBeTruthy()
+        expect(TestHelper.getTextContent(element)).toEqual(
+          `Was the replacement ivory taken from the species on or after 1 January 1975?`
+        )
+      })
     })
   })
 
@@ -148,19 +168,46 @@ describe('/eligibility-checker/taken-from-species route', () => {
     })
 
     describe('Failure', () => {
-      it('should display a validation error message if the user does not select an item', async () => {
-        postOptions.payload.takenFromSpecies = ''
-        const response = await TestHelper.submitPostRequest(
-          server,
-          postOptions,
-          400
-        )
-        await TestHelper.checkValidationError(
-          response,
-          'takenFromSpecies',
-          'takenFromSpecies-error',
-          `You must tell us whether the replacement ivory was taken from the ${mockSpecies.toLowerCase()} on or after 1 January 1975`
-        )
+      describe('When specific species has been selected', () => {
+        beforeEach(() => {
+          _createMocksSpecificSpecies()
+        })
+
+        it('should display a validation error message if the user does not select an item', async () => {
+          postOptions.payload.takenFromSpecies = ''
+          const response = await TestHelper.submitPostRequest(
+            server,
+            postOptions,
+            400
+          )
+          await TestHelper.checkValidationError(
+            response,
+            'takenFromSpecies',
+            'takenFromSpecies-error',
+            `You must tell us whether the replacement ivory was taken from the ${mockSpecies.toLowerCase()} on or after 1 January 1975`
+          )
+        })
+      })
+
+      describe('When two or more species or I\'m not sure selected', () => {
+        beforeEach(() => {
+          _createMocksTwoOrMore()
+        })
+
+        it('should display a validation error message if the user does not select an item', async () => {
+          postOptions.payload.takenFromSpecies = ''
+          const response = await TestHelper.submitPostRequest(
+            server,
+            postOptions,
+            400
+          )
+          await TestHelper.checkValidationError(
+            response,
+            'takenFromSpecies',
+            'takenFromSpecies-error',
+            `You must tell us whether the replacement ivory was taken from the species on or after 1 January 1975`
+          )
+        })
       })
     })
   })
@@ -168,13 +215,25 @@ describe('/eligibility-checker/taken-from-species route', () => {
 
 const mockSpecies = Species.HIPPOPOTAMUS
 
-const _createMocks = () => {
+const _createMocksSpecificSpecies = () => {
   TestHelper.createMocks()
 
   RedisService.get = jest.fn((request, redisKey) => {
     const mockDataMap = {
       [RedisKeys.WHAT_TYPE_OF_ITEM_IS_IT]: ItemType.HIGH_VALUE,
       [RedisKeys.WHAT_SPECIES]: mockSpecies
+    }
+    return mockDataMap[redisKey]
+  })
+}
+
+const _createMocksTwoOrMore = () => {
+  TestHelper.createMocks()
+
+  RedisService.get = jest.fn((request, redisKey) => {
+    const mockDataMap = {
+      [RedisKeys.WHAT_TYPE_OF_ITEM_IS_IT]: ItemType.HIGH_VALUE,
+      [RedisKeys.WHAT_SPECIES]: 'Two or more of these species'
     }
     return mockDataMap[redisKey]
   })


### PR DESCRIPTION
Originally the species variable in the template would just display: "elephant" or "hippopotamus"...

The two extra options added do not make sense in this context: 

"Two or more of these species"...

<img width="1079" alt="image" src="https://github.com/DEFRA/ivory/assets/141018006/17283655-29f1-404d-9e05-f854f652c21f">

"I'm not sure"...

<img width="1145" alt="image" src="https://github.com/DEFRA/ivory/assets/141018006/d4e896ee-e963-468a-ad5f-98b49bb4e2f8">


### Fix
Only displays the species' name if it's one of those defined in the constants. If not then just the word "species" is displayed instead, which makes a lot more sense. 