### PR TITLE
Stop logging cookie message when home route is accessed

### DIFF
--- a/server/services/cookie.service.js
+++ b/server/services/cookie.service.js
@@ -5,7 +5,7 @@ const { DEFRA_IVORY_SESSION_KEY } = require('../utils/constants')
 module.exports = class CookieService {
   static getSessionCookie (request, displayLogMessage = true) {
     const sessionCookie = request.state[DEFRA_IVORY_SESSION_KEY]
-    if (!sessionCookie) {
+    if (!sessionCookie && displayLogMessage) {
       console.log(`Session cookie not found for page ${request.url.pathname}`)
     }
     return sessionCookie

--- a/test/services/cookie.service.test.js
+++ b/test/services/cookie.service.test.js
@@ -5,6 +5,7 @@ const CookieService = require('../../server/services/cookie.service')
 describe('Cookie service', () => {
   describe('getSessionCookie method', () => {
     let mockRequest
+    let consoleLogSpy
 
     beforeEach(() => {
       mockRequest = {
@@ -15,6 +16,11 @@ describe('Cookie service', () => {
           DefraIvorySession: 'THE_SESSION'
         }
       }
+      consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      consoleLogSpy.mockRestore()
     })
 
     it('should check and return the session cookie if it exists', async () => {
@@ -28,6 +34,27 @@ describe('Cookie service', () => {
       const cookie = CookieService.getSessionCookie(mockRequest)
 
       expect(cookie).toBeNull()
+    })
+
+    it('should log a message if the session cookie does not exist and displayLogMessage is true', async () => {
+      mockRequest.state.DefraIvorySession = null
+      CookieService.getSessionCookie(mockRequest, true)
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(`Session cookie not found for page ${mockRequest.url.pathname}`)
+    })
+
+    it('should log a message if the session cookie does not exist and displayLogMessage is not provided', async () => {
+      mockRequest.state.DefraIvorySession = null
+      CookieService.getSessionCookie(mockRequest)
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(`Session cookie not found for page ${mockRequest.url.pathname}`)
+    })
+
+    it('should not log a message if the session cookie does not exist and displayLogMessage is false', async () => {
+      mockRequest.state.DefraIvorySession = null
+      CookieService.getSessionCookie(mockRequest, false)
+
+      expect(consoleLogSpy).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
Resolves the repeated console logging described in #317 but the issue with the root `/` endpoint being repeatedly hit is probably a health check in the environment, which will need to be investigated and probably should be calling the `/service-status` endpoint instead.