### PR TITLE
Use new crown logo and Royal Arms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "clamscan": "^2.1.2",
         "disinfect": "^1.1.0",
         "dotenv": "^16.0.0",
-        "govuk-frontend": "^4.0.1",
+        "govuk-frontend": "^4.9.0",
         "hapi-pino": "9.3.0",
         "hapi-redis2": "^3.0.1",
         "ispinner.css": "^3.1.1",
@@ -4703,9 +4703,10 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.1.tgz",
-      "integrity": "sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.9.0.tgz",
+      "integrity": "sha512-zfX+GBUKpWBeV6JwCIawEuI8VRWlskH8Ok8aNUjKOvzo3zIaNbcrv4IOwgy+oSnMoGh67Eeh+vb7+9GFxN2fNg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -13054,9 +13055,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.1.tgz",
-      "integrity": "sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ=="
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.9.0.tgz",
+      "integrity": "sha512-zfX+GBUKpWBeV6JwCIawEuI8VRWlskH8Ok8aNUjKOvzo3zIaNbcrv4IOwgy+oSnMoGh67Eeh+vb7+9GFxN2fNg=="
     },
     "graceful-fs": {
       "version": "4.2.9",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "clamscan": "^2.1.2",
     "disinfect": "^1.1.0",
     "dotenv": "^16.0.0",
-    "govuk-frontend": "^4.0.1",
+    "govuk-frontend": "^4.9.0",
     "hapi-pino": "9.3.0",
     "hapi-redis2": "^3.0.1",
     "ispinner.css": "^3.1.1",

--- a/server/views/layout.html
+++ b/server/views/layout.html
@@ -26,7 +26,8 @@
     homepageUrl: govUkHome,
     containerClasses: "govuk-width-container",
     serviceName: serviceName,
-    serviceUrl: serviceNameUrl
+    serviceUrl: serviceNameUrl,
+    useTudorCrown: true
   }) }}
 {% endblock %}
 

--- a/test/utils/test-helper.js
+++ b/test/utils/test-helper.js
@@ -265,7 +265,7 @@ module.exports = class TestHelper {
     const document = TestHelper.getDocument(response)
 
     // Error summary heading
-    let element = document.querySelector('#error-summary-title')
+    let element = document.querySelector('.govuk-error-summary__title')
     expect(TestHelper.getTextContent(element)).toEqual(summaryHeading)
 
     // Error summary list item


### PR DESCRIPTION
Resolves #355 but staying on v4 of `govuk-frontend` not yet moved to v5.

v5 removes support for IE11 JavaScript enhancements, so this will need confirming with user research before updating.