### PR TITLE
Use msal-node instead of adal-node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.3.5",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@azure/identity": "^2.0.4",
+        "@azure/msal-node": "^3.2.1",
         "@azure/storage-blob": "^12.9.0",
         "@defra/hapi-gapi": "^2.0.1",
         "@hapi/basic": "^6.0.0",
@@ -17,7 +17,6 @@
         "@hapi/hapi": "^20.2.1",
         "@hapi/inert": "^6.0.5",
         "@hapi/vision": "^6.1.0",
-        "adal-node": "^0.2.3",
         "applicationinsights": "^2.2.2",
         "bcrypt": "^5.0.1",
         "blipp": "^4.0.2",
@@ -95,23 +94,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/@azure/core-client": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.5.0.tgz",
-      "integrity": "sha512-YNk8i9LT6YcFdFO+RRU0E4Ef+A8Y5lhXo6lz61rwbG8Uo7kSqh0YqK04OexiilM43xd6n3Y9yBhLnb1NFNI9dA==",
-      "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "@azure/core-asynciterator-polyfill": "^1.0.0",
-        "@azure/core-auth": "^1.3.0",
-        "@azure/core-rest-pipeline": "^1.5.0",
-        "@azure/core-tracing": "1.0.0-preview.13",
-        "@azure/logger": "^1.0.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@azure/core-http": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-2.2.4.tgz",
@@ -163,25 +145,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.7.0.tgz",
-      "integrity": "sha512-e2awPzwMKHrmvYgZ0qIKNkqnCM1QoDs7A0rOiS3OSAlOQOz/kL7PPKHXwFMuBeaRvS8i7fgobJn79q2Cji5f+Q==",
-      "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "@azure/core-auth": "^1.3.0",
-        "@azure/core-tracing": "1.0.0-preview.13",
-        "@azure/logger": "^1.0.0",
-        "form-data": "^4.0.0",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "tslib": "^2.2.0",
-        "uuid": "^8.3.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@azure/core-tracing": {
       "version": "1.0.0-preview.13",
       "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
@@ -189,43 +152,6 @@
       "dependencies": {
         "@opentelemetry/api": "^1.0.1",
         "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@azure/core-util": {
-      "version": "1.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.0.0-beta.1.tgz",
-      "integrity": "sha512-pS6cup979/qyuyNP9chIybK2qVkJ3MarbY/bx3JcGKE6An6dRweLnsfJfU2ydqUI/B51Rjnn59ajHIhCUTwWZw==",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@azure/identity": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-2.0.4.tgz",
-      "integrity": "sha512-ZgFubAsmo7dji63NLPaot6O7pmDfceAUPY57uphSCr0hmRj+Cakqb4SUz5SohCHFtscrhcmejRU903Fowz6iXg==",
-      "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "@azure/core-auth": "^1.3.0",
-        "@azure/core-client": "^1.4.0",
-        "@azure/core-rest-pipeline": "^1.1.0",
-        "@azure/core-tracing": "1.0.0-preview.13",
-        "@azure/core-util": "^1.0.0-beta.1",
-        "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^2.16.0",
-        "@azure/msal-common": "^4.5.1",
-        "@azure/msal-node": "^1.3.0",
-        "events": "^3.0.0",
-        "jws": "^4.0.0",
-        "open": "^8.0.0",
-        "stoppable": "^1.1.0",
-        "tslib": "^2.2.0",
-        "uuid": "^8.3.0"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -242,63 +168,49 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/@azure/msal-browser": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.22.1.tgz",
-      "integrity": "sha512-VYvdSHnOen1CDok01OhfQ2qNxsrY10WAKe6c2reIuwqqDDOkWwq1IDkieGHpDRjj4kGdPZ/dle4d7SlvNi9EJQ==",
-      "dependencies": {
-        "@azure/msal-common": "^6.1.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.1.0.tgz",
-      "integrity": "sha512-IGjAHttOgKDPQr0Qxx1NjABR635ZNuN7LHjxI0Y7SEA2thcaRGTccy+oaXTFabM/rZLt4F2VrPKUX4BnR9hW9g==",
-      "dependencies": {
-        "debug": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/@azure/msal-common": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-4.5.1.tgz",
-      "integrity": "sha512-/i5dXM+QAtO+6atYd5oHGBAx48EGSISkXNXViheliOQe+SIFMDo3gSq3lL54W0suOSAsVPws3XnTaIHlla0PIQ==",
-      "dependencies": {
-        "debug": "^4.1.1"
-      },
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.1.1.tgz",
+      "integrity": "sha512-bvLWYq9fleAcTJ6H+hfkG91On6vI/UhGyOB7Z6r0Bsa+KTL3zPtigmGCOJgdxrEklOYD88X9SehexLDH/5NRKQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.7.0.tgz",
-      "integrity": "sha512-qDkW+Z4b0SGkkYrM1x+0s5WJ3z96vgiNZ20iwpmtCUHVfSrDiGFB8s8REKVaz7JZJi2L1s0vQRbUahly8EoGnw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.2.1.tgz",
+      "integrity": "sha512-LuK+4kXltmaajI0BqxcGLNiEldaX2B2cNcBZ42yyBn3YKZuUkrMkZxkPt8KQx/MdCVwkfHmvojBkO1XR6l2+CA==",
+      "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "^6.1.0",
-        "axios": "^0.21.4",
-        "https-proxy-agent": "^5.0.0",
-        "jsonwebtoken": "^8.5.1",
+        "@azure/msal-common": "15.1.1",
+        "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
       "engines": {
-        "node": "10 || 12 || 14 || 16"
+        "node": ">=16"
       }
     },
-    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.1.0.tgz",
-      "integrity": "sha512-IGjAHttOgKDPQr0Qxx1NjABR635ZNuN7LHjxI0Y7SEA2thcaRGTccy+oaXTFabM/rZLt4F2VrPKUX4BnR9hW9g==",
+    "node_modules/@azure/msal-node/node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
       "dependencies": {
-        "debug": "^4.1.1"
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
       },
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=12",
+        "npm": ">=6"
       }
     },
     "node_modules/@azure/storage-blob": {
@@ -2126,6 +2038,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -2312,14 +2225,6 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
-      "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/a-sync-waterfall": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
@@ -2389,52 +2294,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/adal-node": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.3.tgz",
-      "integrity": "sha512-gMKr8RuYEYvsj7jyfCv/4BfKToQThz20SP71N3AtFn3ia3yAR8Qt2T3aVQhuJzunWs2b38ZsQV0qsZPdwZr7VQ==",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.7.0",
-        "async": "^2.6.3",
-        "axios": "^0.21.1",
-        "date-utils": "*",
-        "jws": "3.x.x",
-        "underscore": ">= 1.3.1",
-        "uuid": "^3.1.0",
-        "xpath.js": "~1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.6.15"
-      }
-    },
-    "node_modules/adal-node/node_modules/jwa": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-      "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/adal-node/node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "dependencies": {
-        "jwa": "^1.4.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/adal-node/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/agent-base": {
@@ -2795,14 +2654,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.5.1.tgz",
@@ -3057,7 +2908,8 @@
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -3413,14 +3265,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/date-utils": {
-      "version": "1.2.21",
-      "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
-      "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q=",
-      "engines": {
-        "node": ">0.4.0"
-      }
-    },
     "node_modules/dateformat": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
@@ -3500,14 +3344,6 @@
       "optional": true,
       "dependencies": {
         "clone": "^1.0.2"
-      }
-    },
-    "node_modules/define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/define-properties": {
@@ -3677,6 +3513,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -4827,6 +4664,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
       "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
       "dependencies": {
         "@tootallnate/once": "1",
         "agent-base": "6",
@@ -5087,20 +4925,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5255,17 +5079,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/isarray": {
@@ -6390,25 +6203,6 @@
         "npm": ">=1.4.28"
       }
     },
-    "node_modules/jsonwebtoken/node_modules/jwa": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-      "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jsonwebtoken/node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "dependencies": {
-        "jwa": "^1.4.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "node_modules/jsonwebtoken/node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -6431,9 +6225,10 @@
       }
     },
     "node_modules/jwa": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -6441,11 +6236,12 @@
       }
     },
     "node_modules/jws": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
       "dependencies": {
-        "jwa": "^2.0.0",
+        "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -7115,22 +6911,6 @@
       },
       "engines": {
         "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/open": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
-      "dependencies": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8137,12 +7917,10 @@
       "integrity": "sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg=="
     },
     "node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -8680,15 +8458,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/stoppable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
-      "engines": {
-        "node": ">=4",
-        "npm": ">=6"
       }
     },
     "node_modules/stream-shift": {
@@ -9480,14 +9249,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
-    "node_modules/xpath.js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
-      "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -9562,20 +9323,6 @@
         "tslib": "^2.2.0"
       }
     },
-    "@azure/core-client": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.5.0.tgz",
-      "integrity": "sha512-YNk8i9LT6YcFdFO+RRU0E4Ef+A8Y5lhXo6lz61rwbG8Uo7kSqh0YqK04OexiilM43xd6n3Y9yBhLnb1NFNI9dA==",
-      "requires": {
-        "@azure/abort-controller": "^1.0.0",
-        "@azure/core-asynciterator-polyfill": "^1.0.0",
-        "@azure/core-auth": "^1.3.0",
-        "@azure/core-rest-pipeline": "^1.5.0",
-        "@azure/core-tracing": "1.0.0-preview.13",
-        "@azure/logger": "^1.0.0",
-        "tslib": "^2.2.0"
-      }
-    },
     "@azure/core-http": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-2.2.4.tgz",
@@ -9618,22 +9365,6 @@
         "tslib": "^2.2.0"
       }
     },
-    "@azure/core-rest-pipeline": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.7.0.tgz",
-      "integrity": "sha512-e2awPzwMKHrmvYgZ0qIKNkqnCM1QoDs7A0rOiS3OSAlOQOz/kL7PPKHXwFMuBeaRvS8i7fgobJn79q2Cji5f+Q==",
-      "requires": {
-        "@azure/abort-controller": "^1.0.0",
-        "@azure/core-auth": "^1.3.0",
-        "@azure/core-tracing": "1.0.0-preview.13",
-        "@azure/logger": "^1.0.0",
-        "form-data": "^4.0.0",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "tslib": "^2.2.0",
-        "uuid": "^8.3.0"
-      }
-    },
     "@azure/core-tracing": {
       "version": "1.0.0-preview.13",
       "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
@@ -9641,37 +9372,6 @@
       "requires": {
         "@opentelemetry/api": "^1.0.1",
         "tslib": "^2.2.0"
-      }
-    },
-    "@azure/core-util": {
-      "version": "1.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.0.0-beta.1.tgz",
-      "integrity": "sha512-pS6cup979/qyuyNP9chIybK2qVkJ3MarbY/bx3JcGKE6An6dRweLnsfJfU2ydqUI/B51Rjnn59ajHIhCUTwWZw==",
-      "requires": {
-        "tslib": "^2.0.0"
-      }
-    },
-    "@azure/identity": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-2.0.4.tgz",
-      "integrity": "sha512-ZgFubAsmo7dji63NLPaot6O7pmDfceAUPY57uphSCr0hmRj+Cakqb4SUz5SohCHFtscrhcmejRU903Fowz6iXg==",
-      "requires": {
-        "@azure/abort-controller": "^1.0.0",
-        "@azure/core-auth": "^1.3.0",
-        "@azure/core-client": "^1.4.0",
-        "@azure/core-rest-pipeline": "^1.1.0",
-        "@azure/core-tracing": "1.0.0-preview.13",
-        "@azure/core-util": "^1.0.0-beta.1",
-        "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^2.16.0",
-        "@azure/msal-common": "^4.5.1",
-        "@azure/msal-node": "^1.3.0",
-        "events": "^3.0.0",
-        "jws": "^4.0.0",
-        "open": "^8.0.0",
-        "stoppable": "^1.1.0",
-        "tslib": "^2.2.0",
-        "uuid": "^8.3.0"
       }
     },
     "@azure/logger": {
@@ -9682,50 +9382,36 @@
         "tslib": "^2.2.0"
       }
     },
-    "@azure/msal-browser": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.22.1.tgz",
-      "integrity": "sha512-VYvdSHnOen1CDok01OhfQ2qNxsrY10WAKe6c2reIuwqqDDOkWwq1IDkieGHpDRjj4kGdPZ/dle4d7SlvNi9EJQ==",
-      "requires": {
-        "@azure/msal-common": "^6.1.0"
-      },
-      "dependencies": {
-        "@azure/msal-common": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.1.0.tgz",
-          "integrity": "sha512-IGjAHttOgKDPQr0Qxx1NjABR635ZNuN7LHjxI0Y7SEA2thcaRGTccy+oaXTFabM/rZLt4F2VrPKUX4BnR9hW9g==",
-          "requires": {
-            "debug": "^4.1.1"
-          }
-        }
-      }
-    },
     "@azure/msal-common": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-4.5.1.tgz",
-      "integrity": "sha512-/i5dXM+QAtO+6atYd5oHGBAx48EGSISkXNXViheliOQe+SIFMDo3gSq3lL54W0suOSAsVPws3XnTaIHlla0PIQ==",
-      "requires": {
-        "debug": "^4.1.1"
-      }
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.1.1.tgz",
+      "integrity": "sha512-bvLWYq9fleAcTJ6H+hfkG91On6vI/UhGyOB7Z6r0Bsa+KTL3zPtigmGCOJgdxrEklOYD88X9SehexLDH/5NRKQ=="
     },
     "@azure/msal-node": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.7.0.tgz",
-      "integrity": "sha512-qDkW+Z4b0SGkkYrM1x+0s5WJ3z96vgiNZ20iwpmtCUHVfSrDiGFB8s8REKVaz7JZJi2L1s0vQRbUahly8EoGnw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.2.1.tgz",
+      "integrity": "sha512-LuK+4kXltmaajI0BqxcGLNiEldaX2B2cNcBZ42yyBn3YKZuUkrMkZxkPt8KQx/MdCVwkfHmvojBkO1XR6l2+CA==",
       "requires": {
-        "@azure/msal-common": "^6.1.0",
-        "axios": "^0.21.4",
-        "https-proxy-agent": "^5.0.0",
-        "jsonwebtoken": "^8.5.1",
+        "@azure/msal-common": "15.1.1",
+        "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
       "dependencies": {
-        "@azure/msal-common": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.1.0.tgz",
-          "integrity": "sha512-IGjAHttOgKDPQr0Qxx1NjABR635ZNuN7LHjxI0Y7SEA2thcaRGTccy+oaXTFabM/rZLt4F2VrPKUX4BnR9hW9g==",
+        "jsonwebtoken": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+          "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
           "requires": {
-            "debug": "^4.1.1"
+            "jws": "^3.2.2",
+            "lodash.includes": "^4.3.0",
+            "lodash.isboolean": "^3.0.3",
+            "lodash.isinteger": "^4.0.4",
+            "lodash.isnumber": "^3.0.3",
+            "lodash.isplainobject": "^4.0.6",
+            "lodash.isstring": "^4.0.1",
+            "lodash.once": "^4.0.0",
+            "ms": "^2.1.1",
+            "semver": "^7.5.4"
           }
         }
       }
@@ -11106,7 +10792,8 @@
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.19",
@@ -11289,11 +10976,6 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
-    "@xmldom/xmldom": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
-      "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A=="
-    },
     "a-sync-waterfall": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
@@ -11349,47 +11031,6 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
-    },
-    "adal-node": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.3.tgz",
-      "integrity": "sha512-gMKr8RuYEYvsj7jyfCv/4BfKToQThz20SP71N3AtFn3ia3yAR8Qt2T3aVQhuJzunWs2b38ZsQV0qsZPdwZr7VQ==",
-      "requires": {
-        "@xmldom/xmldom": "^0.7.0",
-        "async": "^2.6.3",
-        "axios": "^0.21.1",
-        "date-utils": "*",
-        "jws": "3.x.x",
-        "underscore": ">= 1.3.1",
-        "uuid": "^3.1.0",
-        "xpath.js": "~1.1.0"
-      },
-      "dependencies": {
-        "jwa": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-          "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-          "requires": {
-            "buffer-equal-constant-time": "1.0.1",
-            "ecdsa-sig-formatter": "1.0.11",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "jws": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-          "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-          "requires": {
-            "jwa": "^1.4.1",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        }
-      }
     },
     "agent-base": {
       "version": "6.0.2",
@@ -11650,14 +11291,6 @@
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
     },
-    "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "requires": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
     "babel-jest": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.5.1.tgz",
@@ -11834,7 +11467,7 @@
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "buffer-from": {
       "version": "1.1.2",
@@ -12109,11 +11742,6 @@
         "whatwg-url": "^10.0.0"
       }
     },
-    "date-utils": {
-      "version": "1.2.21",
-      "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
-      "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q="
-    },
     "dateformat": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
@@ -12171,11 +11799,6 @@
       "requires": {
         "clone": "^1.0.2"
       }
-    },
-    "define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -13147,6 +12770,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
       "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
       "requires": {
         "@tootallnate/once": "1",
         "agent-base": "6",
@@ -13323,11 +12947,6 @@
         "has-tostringtag": "^1.0.0"
       }
     },
-    "is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
-    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -13425,14 +13044,6 @@
       "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
       "requires": {
         "call-bind": "^1.0.2"
-      }
-    },
-    "is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "requires": {
-        "is-docker": "^2.0.0"
       }
     },
     "isarray": {
@@ -14313,25 +13924,6 @@
         "semver": "^5.6.0"
       },
       "dependencies": {
-        "jwa": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-          "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-          "requires": {
-            "buffer-equal-constant-time": "1.0.1",
-            "ecdsa-sig-formatter": "1.0.11",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "jws": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-          "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-          "requires": {
-            "jwa": "^1.4.1",
-            "safe-buffer": "^5.0.1"
-          }
-        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -14350,9 +13942,9 @@
       }
     },
     "jwa": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -14360,11 +13952,11 @@
       }
     },
     "jws": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
       "requires": {
-        "jwa": "^2.0.0",
+        "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -14882,16 +14474,6 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
-      }
-    },
-    "open": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
-      "requires": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
       }
     },
     "optionator": {
@@ -15669,12 +15251,9 @@
       "integrity": "sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg=="
     },
     "semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -16057,11 +15636,6 @@
           "dev": true
         }
       }
-    },
-    "stoppable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="
     },
     "stream-shift": {
       "version": "1.0.1",
@@ -16676,11 +16250,6 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
-    },
-    "xpath.js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
-      "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": "22.x"
   },
   "dependencies": {
-    "@azure/identity": "^2.0.4",
+    "@azure/msal-node": "^3.2.1",
     "@azure/storage-blob": "^12.9.0",
     "@defra/hapi-gapi": "^2.0.1",
     "@hapi/basic": "^6.0.0",
@@ -34,7 +34,6 @@
     "@hapi/hapi": "^20.2.1",
     "@hapi/inert": "^6.0.5",
     "@hapi/vision": "^6.1.0",
-    "adal-node": "^0.2.3",
     "applicationinsights": "^2.2.2",
     "bcrypt": "^5.0.1",
     "blipp": "^4.0.2",

--- a/test/services/active-directory-auth.service.test.js
+++ b/test/services/active-directory-auth.service.test.js
@@ -1,19 +1,19 @@
-const AdalNode = require('adal-node')
+const msal = require('@azure/msal-node')
 const ActiveDirectoryAuthService = require('../../server/services/active-directory-auth.service')
 const config = require('../../server/utils/config')
 
 const MISSING_TOKEN_ERROR = 'Error obtaining Active Directory auth token'
 const CALL_ERROR = 'Call error'
 
-jest.mock('adal-node')
+jest.mock('@azure/msal-node')
 
 describe('ActiveDirectoryAuthService', () => {
-  const mockAcquireTokenWithClientCredentials = jest.fn()
+  const mockAcquireTokenByClientCredential = jest.fn()
 
   beforeAll(() => {
-    AdalNode.AuthenticationContext.mockImplementation(() => {
+    msal.ConfidentialClientApplication.mockImplementation(() => {
       return {
-        acquireTokenWithClientCredentials: mockAcquireTokenWithClientCredentials
+        acquireTokenByClientCredential: mockAcquireTokenByClientCredential
       }
     })
   })
@@ -25,32 +25,23 @@ describe('ActiveDirectoryAuthService', () => {
   describe('getTokenForDataverse', () => {
     it('should return a token for Dataverse', async () => {
       const mockToken = 'mockDataverseToken'
-      mockAcquireTokenWithClientCredentials.mockImplementation((_resource, _clientId, _clientSecret, callback) => {
-        callback(null, { accessToken: mockToken })
-      })
+      mockAcquireTokenByClientCredential.mockResolvedValue({ accessToken: mockToken })
 
       const token = await ActiveDirectoryAuthService.getTokenForDataverse()
       expect(token).toBe(mockToken)
-      expect(mockAcquireTokenWithClientCredentials).toHaveBeenCalledWith(
-        config.dataverseResource,
-        config.dataverseClientId,
-        config.dataverseClientSecret,
-        expect.any(Function)
-      )
+      expect(mockAcquireTokenByClientCredential).toHaveBeenCalledWith({
+        scopes: [config.dataverseResource + '/.default']
+      })
     })
 
     it('should throw an error if token is not obtained', async () => {
-      mockAcquireTokenWithClientCredentials.mockImplementation((_resource, _clientId, _clientSecret, callback) => {
-        callback(null, {})
-      })
+      mockAcquireTokenByClientCredential.mockResolvedValue({})
 
       await expect(ActiveDirectoryAuthService.getTokenForDataverse()).rejects.toThrow(MISSING_TOKEN_ERROR)
     })
 
     it('should throw an error if the call to Entra ID errors', async () => {
-      mockAcquireTokenWithClientCredentials.mockImplementation((_resource, _clientId, _clientSecret, callback) => {
-        callback(new Error(CALL_ERROR), null)
-      })
+      mockAcquireTokenByClientCredential.mockRejectedValue(new Error(CALL_ERROR))
 
       await expect(ActiveDirectoryAuthService.getTokenForDataverse()).rejects.toThrow(CALL_ERROR)
     })
@@ -59,34 +50,25 @@ describe('ActiveDirectoryAuthService', () => {
   describe('getTokenForAddressLookup', () => {
     it('should return a token for Address Lookup', async () => {
       const mockToken = 'mockAddressLookupToken'
-      mockAcquireTokenWithClientCredentials.mockImplementation((_resource, _clientId, _clientSecret, callback) => {
-        callback(null, { accessToken: mockToken })
-      })
+      mockAcquireTokenByClientCredential.mockResolvedValue({ accessToken: mockToken })
 
       const token = await ActiveDirectoryAuthService.getTokenForAddressLookup()
       expect(token).toBe(mockToken)
-      expect(mockAcquireTokenWithClientCredentials).toHaveBeenCalledWith(
-        config.addressLookupResource,
-        config.dataverseClientId,
-        config.dataverseClientSecret,
-        expect.any(Function)
-      )
+      expect(mockAcquireTokenByClientCredential).toHaveBeenCalledWith({
+        scopes: [config.addressLookupResource + '/.default']
+      })
     })
 
     it('should throw an error if token is not obtained', async () => {
-      mockAcquireTokenWithClientCredentials.mockImplementation((_resource, _clientId, _clientSecret, callback) => {
-        callback(null, {})
-      })
+      mockAcquireTokenByClientCredential.mockResolvedValue({})
 
       await expect(ActiveDirectoryAuthService.getTokenForAddressLookup()).rejects.toThrow(MISSING_TOKEN_ERROR)
     })
 
     it('should throw an error if the call to Entra ID errors', async () => {
-      mockAcquireTokenWithClientCredentials.mockImplementation((_resource, _clientId, _clientSecret, callback) => {
-        callback(new Error(CALL_ERROR), null)
-      })
+      mockAcquireTokenByClientCredential.mockRejectedValue(new Error(CALL_ERROR))
 
-      await expect(ActiveDirectoryAuthService.getTokenForDataverse()).rejects.toThrow(CALL_ERROR)
+      await expect(ActiveDirectoryAuthService.getTokenForAddressLookup()).rejects.toThrow(CALL_ERROR)
     })
   })
 


### PR DESCRIPTION
Upgrade to use the `msal-node` library as `adal-node` was deprecated some years ago.

Resolves #351 